### PR TITLE
DataTable actions cell

### DIFF
--- a/src/semantic-ui/DataTable.css
+++ b/src/semantic-ui/DataTable.css
@@ -1,6 +1,6 @@
 .data-table .ui.table .actions-cell {
-  padding-right: 20px;
-  text-align: right;
+  white-space: nowrap;
+  max-width: 1px;
 }
 
 .data-table .empty-button {


### PR DESCRIPTION
Adjusting the style of the actions cells on DataTable. The width of the cell will take up only as much space as the buttons.