### PR TITLE
Data Table actions-cell

### DIFF
--- a/src/semantic-ui/DataTable.css
+++ b/src/semantic-ui/DataTable.css
@@ -1,6 +1,6 @@
 .data-table .ui.table .actions-cell {
   white-space: nowrap;
-  max-width: 1px;
+  width: 1px;
 }
 
 .data-table .empty-button {


### PR DESCRIPTION
This pull request adjusts the DataTable component style to use "width" instead of "max-width" for the actions-cell.

**Before**
![Screen Shot 2020-06-01 at 4 52 43 PM](https://user-images.githubusercontent.com/20641961/83453471-8ed21080-a428-11ea-8caf-acc2674c067b.png)

**After**
![Screen Shot 2020-06-01 at 4 52 56 PM](https://user-images.githubusercontent.com/20641961/83453472-8f6aa700-a428-11ea-968c-10cc8f668133.png)