### PR TITLE
Stacklife #19 - Export results

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -19,11 +19,14 @@
   },
   "DataTable": {
     "buttons": {
-      "add": "Add"
+      "add": "Add",
+      "deleteAll": "Delete All"
     },
     "columns": {
       "actions": "Actions"
     },
+    "deleteAllContent": "Are you sure you want to remove all records? This action cannot be undone.",
+    "deleteAllHeader": "Confirm Remove All",
     "deleteContent": "Are you sure you want to remove this record?",
     "deleteHeader": "Confirm Remove",
     "emptyList": "No matching records found.",

--- a/src/semantic-ui/ListTable.js
+++ b/src/semantic-ui/ListTable.js
@@ -31,16 +31,17 @@ type Props = {
     props: any
   },
   modal: {
-    component: Component,
+    component: Component<{}>,
     props: any,
     state: any
   },
   onCopy?: (item: any) => any,
-  onDelete: (item: any) => void,
-  onLoad: (page: number) => void,
-  onSave: (item: any) => void,
+  onDelete: (item: any) => Promise<any>,
+  onDeleteAll: () => Promise<any>,
+  onLoad: (page: number) => Promise<any>,
+  onSave: (item: any) => Promise<any>,
   polling?: number,
-  renderDeleteModal?: ({ selectedItem: any, onCancel: () => void, onConfirm: () => void }) => Component,
+  renderDeleteModal?: ({ selectedItem: any, onCancel: () => void, onConfirm: () => void }) => Component<{}>,
   renderEmptyRow?: () => void,
   searchable?: boolean
 };
@@ -71,7 +72,7 @@ class ListTable extends Component<Props, State> {
    *
    * @param props
    */
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
 
     this.state = {
@@ -116,6 +117,13 @@ class ListTable extends Component<Props, State> {
     }
 
     return this.fetchData();
+  }
+
+  /**
+   * Resets the state and reloads the data.
+   */
+  afterDeleteAll() {
+    this.setState({ page: 1 }, this.fetchData.bind(this));
   }
 
   /**
@@ -211,6 +219,17 @@ class ListTable extends Component<Props, State> {
   }
 
   /**
+   * Deletes all the records and resets the state.
+   *
+   * @returns {Q.Promise<any> | Promise<R> | Promise<any> | void | *}
+   */
+  onDeleteAll() {
+    return this.props
+      .onDeleteAll()
+      .then(this.afterDeleteAll.bind(this));
+  }
+
+  /**
    * Sets the filters on the state and returns a promise.
    *
    * @param filters
@@ -278,6 +297,7 @@ class ListTable extends Component<Props, State> {
         className={this.props.className}
         columns={this.props.columns}
         configurable={this.props.configurable}
+        deleteButton={this.props.deleteButton}
         filters={{
           active: this.isFilterActive(),
           component: this.props.filters && this.props.filters.component,
@@ -292,6 +312,7 @@ class ListTable extends Component<Props, State> {
         onColumnClick={this.onColumnClick.bind(this)}
         onCopy={this.props.onCopy}
         onDelete={this.onDelete.bind(this)}
+        onDeleteAll={this.onDeleteAll.bind(this)}
         onPageChange={this.onPageChange.bind(this)}
         onSave={this.onSave.bind(this)}
         renderDeleteModal={this.props.renderDeleteModal}

--- a/stories/components/semantic-ui/ListTable.stories.js
+++ b/stories/components/semantic-ui/ListTable.stories.js
@@ -639,3 +639,27 @@ export const WithExtraButtons = () => (
     searchable={boolean('Searchable', true)}
   />
 );
+
+export const WithDeleteAllButton = () => (
+  <ListTable
+    actions={actions}
+    collectionName='items'
+    columns={columns}
+    deleteButton={{
+      color: 'red',
+      location: 'top'
+    }}
+    modal={{
+      component: AddModal
+    }}
+    onCopy={action('copy')}
+    onLoad={(params) => Api.onLoad(_.extend(params, {
+      items,
+      perPage: number('Per page', 10)
+    }))}
+    onDelete={action('delete')}
+    onDeleteAll={action('delete all')}
+    onSave={() => Promise.resolve()}
+    searchable={boolean('Searchable', true)}
+  />
+);


### PR DESCRIPTION
This pull request makes changes to the ListTable and DataTable components to support the Stacklife [export results](https://github.com/performant-software/stacklife/issues/19) feature.

1. The ListTable/DataTable component will now include an optional `onDeleteAll` property. The value should be a function that calls an API to delete all records of a specific class or classes. When provided a button will display at the top of the list. This property should be used with caution as most situations probably wont require it.

![Screen Shot 2020-10-06 at 11 50 37 AM](https://user-images.githubusercontent.com/20641961/95225805-2f1ab600-07ca-11eb-8653-eb103fe1fab7.png)

2. The ListTable component will now support an optional `polling` property. When provided, the `onLoad` function will be called when the component is mounted and every x seconds (where `polling={x}`).

3. The DataTable component was refactored slightly to determine which buttons should be displayed at the top/bottom of the list.