### PR TITLE
CC #121 - Action button popups

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -18,6 +18,20 @@
     }
   },
   "DataTable": {
+    "actions": {
+      "copy": {
+        "content": "Creates an editable copy to be saved as a new record",
+        "title": "Copy"
+      },
+      "delete": {
+        "content": "Removes the record, permanently",
+        "title": "Remove"
+      },
+      "edit": {
+        "content": "Opens the modal to edit the record",
+        "title": "Edit"
+      }
+    },
     "buttons": {
       "add": "Add",
       "deleteAll": "Delete All"

--- a/src/semantic-ui/DataTable.js
+++ b/src/semantic-ui/DataTable.js
@@ -12,6 +12,7 @@ import {
   Icon,
   Menu,
   Pagination,
+  Popup,
   Table
 } from 'semantic-ui-react';
 import _ from 'underscore';
@@ -26,6 +27,10 @@ type Action = {
   icon?: string,
   name: string,
   onClick?: (item: any) => void,
+  popup: {
+    content: string,
+    title: string
+  },
   render?: (item: any, index: number) => Element<any>,
   title?: string
 };
@@ -361,11 +366,12 @@ class DataTable extends Component<Props, State> {
    * @returns {*}
    */
   renderActionButton(item: any, index: number, action: Action) {
+    // If the action specified its own render function, return the result of the function call
     if (action.render) {
       return action.render(item, index);
     }
 
-    return (
+    const actionButton = (
       <Button
         basic
         compact
@@ -373,9 +379,28 @@ class DataTable extends Component<Props, State> {
         icon={action.icon}
         key={`${action.name}-${index}`}
         onClick={action.onClick && action.onClick.bind(this, item)}
-        title={action.title || action.name}
+        title={action.title}
       />
     );
+
+    // Wrap the button in a popup if the action specifies a popup attribute
+    if (action.popup) {
+      const { content, title } = action.popup;
+
+      return (
+        <Popup
+          content={content}
+          header={title}
+          hideOnScroll
+          mouseEnterDelay={500}
+          position='top right'
+          trigger={actionButton}
+        />
+      );
+    }
+
+    // Otherwise, simply return the button
+    return actionButton;
   }
 
   /**
@@ -397,11 +422,32 @@ class DataTable extends Component<Props, State> {
         let defaults = {};
 
         if (action.name === 'edit') {
-          defaults = { onClick: this.onEditButton.bind(this), icon: 'edit outline' };
+          defaults = {
+            icon: 'edit outline',
+            onClick: this.onEditButton.bind(this),
+            popup: {
+              title: i18n.t('DataTable.actions.edit.title'),
+              content: i18n.t('DataTable.actions.edit.content')
+            }
+          };
         } else if (action.name === 'copy') {
-          defaults = { onClick: this.onCopyButton.bind(this), icon: 'copy outline' };
+          defaults = {
+            icon: 'copy outline',
+            onClick: this.onCopyButton.bind(this),
+            popup: {
+              title: i18n.t('DataTable.actions.copy.title'),
+              content: i18n.t('DataTable.actions.copy.content')
+            }
+          };
         } else if (action.name === 'delete') {
-          defaults = { onClick: this.onDeleteButton.bind(this), icon: 'times circle outline' };
+          defaults = {
+            icon: 'times circle outline',
+            onClick: this.onDeleteButton.bind(this),
+            popup: {
+              title: i18n.t('DataTable.actions.delete.title'),
+              content: i18n.t('DataTable.actions.delete.content')
+            }
+          };
         }
 
         return _.defaults(action, defaults);


### PR DESCRIPTION
This pull request adds generic popup components to the default edit, copy, and delete action buttons on the DataTable component.

![Screen Shot 2020-11-02 at 12 06 31 PM](https://user-images.githubusercontent.com/20641961/97897233-315a2c80-1d04-11eb-8d2e-09f2ed44f008.png)
![Screen Shot 2020-11-02 at 12 06 35 PM](https://user-images.githubusercontent.com/20641961/97897236-31f2c300-1d04-11eb-9cf8-da62c5549542.png)
![Screen Shot 2020-11-02 at 12 06 39 PM](https://user-images.githubusercontent.com/20641961/97897238-31f2c300-1d04-11eb-83d6-843f52f8106e.png)

This pull request closes [#121](https://github.com/performant-software/courts-canons/issues/121) in the courts-canons repo.