### PR TITLE
CC #170 - Genre aggregate totals

### DIFF
--- a/src/semantic-ui/ListTable.js
+++ b/src/semantic-ui/ListTable.js
@@ -45,8 +45,10 @@ type Props = {
   polling?: number,
   renderDeleteModal?: ({ selectedItem: any, onCancel: () => void, onConfirm: () => void }) => Component<{}>,
   renderEmptyRow?: () => void,
+  renderItem?: (item: any) => Component<{}>,
   saved?: boolean,
-  searchable?: boolean
+  searchable?: boolean,
+  tableProps: any
 };
 
 type State = {
@@ -329,10 +331,7 @@ class ListTable extends Component<Props, State> {
           renderSearch={this.renderSearch.bind(this)}
           sortColumn={this.state.sortColumn}
           sortDirection={this.state.sortDirection}
-          tableProps={{
-            celled: true,
-            sortable: true
-          }}
+          tableProps={this.props.tableProps}
         />
         { this.state.saved && (
           <Toaster
@@ -386,7 +385,11 @@ ListTable.defaultProps = {
   onCopy: undefined,
   renderDeleteModal: undefined,
   renderEmptyRow: undefined,
-  searchable: true
+  searchable: true,
+  tableProps: {
+    celled: true,
+    sortable: true
+  }
 };
 
 export default ListTable;


### PR DESCRIPTION
This pull request makes a few changes to the ListTable component in support of [#170](https://github.com/performant-software/courts-canons/issues/170):

- Allows `tableProps` property to be supplied to ListTable
- Updates `componentDidMount` to select the first _sortable_ column; Previously if the first column was not sortable, the list would not load