### PR TITLE
Archnet #187 - List filters

### DIFF
--- a/src/common/EditContainer.js
+++ b/src/common/EditContainer.js
@@ -10,7 +10,6 @@ type Props = {
   item?: any,
   onClose: () => void,
   onInitialize?: (id: number) => Promise<any>,
-  onReset?: () => void,
   onSave: (item: any) => Promise<any>,
   required?: Array<string>,
   resolveValidationError?: (error: string, item: any, status: number) => Array<string>,
@@ -242,11 +241,7 @@ const useEditContainer = (WrappedComponent: ComponentType<any>) => (
      * Resets the item on the state to the default item and calls the onReset prop.
      */
     onReset() {
-      this.setState({ item: this.getDefaultItem(this.props) }, () => {
-        if (this.props.onReset) {
-          this.props.onReset();
-        }
-      });
+      this.setState({ item: this.getDefaultItem(this.props) });
     }
 
     /**

--- a/src/semantic-ui/DataList.js
+++ b/src/semantic-ui/DataList.js
@@ -221,13 +221,6 @@ const useDataList = (WrappedComponent: ComponentType<any>) => (
     }
 
     /**
-     * Resets the filters on the state to the default values.
-     */
-    onResetFilters() {
-      this.setState({ filters: (this.props.filters && this.props.filters.props) || {} });
-    }
-
-    /**
      * Calls the onSave prop and reloads the data.
      *
      * @param item
@@ -285,7 +278,6 @@ const useDataList = (WrappedComponent: ComponentType<any>) => (
               component: this.props.filters && this.props.filters.component,
               onChange: this.onFilterChange.bind(this),
               props: {
-                onReset: this.onResetFilters.bind(this),
                 item: this.state.filters
               }
             }}


### PR DESCRIPTION
This pull request updates the EditContainer component to include a `onReset` prop to the wrapped component. This will allow the container to be "reset" to its original state. The use case for this is when using the EditContainer to select list filters, the user may want to reset the filters.