### PR TITLE
Fix broken click action on DataTable action columns

### DIFF
--- a/src/semantic-ui/DataTable.js
+++ b/src/semantic-ui/DataTable.js
@@ -529,7 +529,7 @@ class DataTable extends Component<Props, State> {
       <>
         <Table.Row
           key={index}
-          onClick={this.props.expandableRows ? handleCellClick : {}}
+          onClick={this.props.expandableRows ? handleCellClick : () => return }
           className={this.props.expandableRows ? 'expandable' : ''}
         >
           { children }


### PR DESCRIPTION
Return rather than passing empty object to click action on non expanding row