### PR TITLE
Optionally hide root add button on AccordionList

### DIFF
--- a/src/semantic-ui/AccordionList.js
+++ b/src/semantic-ui/AccordionList.js
@@ -30,6 +30,7 @@ type Props = {
   collectionName: string,
   getChildItems: (items: Array<any>, item: any) => Array<any>,
   getRootItems: (items: Array<any>) => Array<any>,
+  hideAddRootButton: boolean,
   lazyLoad: boolean,
   modal?: {
     component: Component<{}>,
@@ -429,7 +430,7 @@ class AccordionList extends Component<Props, State> {
    * @returns {null|*}
    */
   renderHeaderAddButton() {
-    if (!this.props.modal) {
+    if (!this.props.modal || this.props.hideAddRootButton) {
       return null;
     }
 


### PR DESCRIPTION
This pr adds the `hideAddRootButton` prop to `AccordionList.js`. When true, the Add button at the top of the list will not be rendered.

<img width="1121" alt="Screen Shot 2021-06-23 at 3 26 04 PM" src="https://user-images.githubusercontent.com/13070019/123156603-7bc91e80-d437-11eb-83dc-8d612f54e657.png">
