### PR TITLE
CC #311 - Holdings

### DIFF
--- a/src/semantic-ui/DataList.js
+++ b/src/semantic-ui/DataList.js
@@ -305,8 +305,7 @@ const useDataList = (WrappedComponent: ComponentType<any>) => (
      * @returns {Q.Promise<any> | Promise<R> | Promise<any> | void | *}
      */
     onSave(item: any) {
-      return this.props
-        .onSave(item)
+      return Promise.resolve(this.props.onSave(item))
         .then(() => this.setState({ saved: true }, this.fetchData.bind(this)));
     }
 

--- a/stories/components/semantic-ui/ListTable.stories.js
+++ b/stories/components/semantic-ui/ListTable.stories.js
@@ -629,10 +629,7 @@ export const AddButton = useDragDrop(() => (
       perPage: number('Per page', 10)
     }))}
     onDelete={action('delete')}
-    onSave={() => {
-      action('save')();
-      return Promise.resolve();
-    }}
+    onSave={action('save')}
     searchable={boolean('Searchable', true)}
   />
 ));


### PR DESCRIPTION
This pull request fixes a bug with the Selectize component introduced by the refactor to update the component to use the DataList HOC. The issue was that the DataList was expecting the `onSave` prop to return a Promise. However, the previous implementation on the Selectize component was not.

In order to prevent refactoring of all implementations of the Selectize component, I've updated the DataList to wrap the `onSave` prop in the `Promise.resolve` so that the provided function may or may not return a Promise, and still execute successfully.