### PR TITLE
BASIRA #116 - Allow multiple types in NestedAccordion

### DIFF
--- a/src/semantic-ui/NestedAccordion.js
+++ b/src/semantic-ui/NestedAccordion.js
@@ -54,9 +54,9 @@ class NestedAccordion extends Component<Props, State> {
       && this.props.defaultActive
       && this.props.defaultActive.length) {
         if (this.props.multipleItemTypes 
-          && !this.props.defaultActive.some(active => {
+          && !this.props.defaultActive.some(active =>
             typeof active !== 'object' || !_.has(active, 'id') || !_.has(active, 'type')
-          })
+          )
         ) {
           this.setState({ activeItems: this.props.defaultActive });
         } else {

--- a/src/semantic-ui/NestedAccordion.js
+++ b/src/semantic-ui/NestedAccordion.js
@@ -254,7 +254,7 @@ class NestedAccordion extends Component<Props, State> {
       activeItems: this.isActive(item)
         ? _.filter(state.activeItems, (i) => {
             if (this.props.multipleItemTypes && _.has(item, 'type') && _.has(i, 'type')) {
-              return i.id !== item.id && i.type !== item.type;
+              return i.id !== item.id || i.type !== item.type;
             }
             return i.id !== item.id;
           })


### PR DESCRIPTION
It was discovered in https://github.com/performant-software/basira/issues/116 that when a `NestedAccordion` contains multiple types of objects, ID collisions may cause unexpected behaviors, such as with toggling.

To resolve this without breaking other implementations of `NestedAccordion`, this PR accepts a new boolean prop for that component called `multipleItemTypes`. When this prop is set `true`:

- `defaultActive` will expect an array of objects instead of an array of numbers. Each object in `defaultActive` is expected to have keys `id` and `type`. If any of this is not true, it will fall back to default behavior (i.e. as if `multipleItemTypes` were `false`)
- In `componentDidUpdate`, these objects will directly populate `activeItems` on the `NestedAccordion`'s state instead of using a map function on an array of numbers.
- Then during `toggleItem`, `item.type` is checked in addition to `item.id`.
- `type` is also used in `isActive` and `renderPanel` when present.