### PR TITLE
BASIRA #113 - Use Message "visible" prop and add onSuccess callback in FileUpload

### DIFF
--- a/src/semantic-ui/FileUpload.js
+++ b/src/semantic-ui/FileUpload.js
@@ -76,6 +76,7 @@ class FileUpload extends Component<Props, State> {
           error
           header={i18n.t('Common.errors.title')}
           hidden={!(this.state.errors && this.state.errors.length)}
+          visible={this.state.errors && this.state.errors.length}
           onDismiss={() => this.setState({ errors: null })}
           list={this.state.errors}
         />

--- a/src/semantic-ui/FileUpload.js
+++ b/src/semantic-ui/FileUpload.js
@@ -11,7 +11,6 @@ type Props = {
   fileTypes?: Array<string>,
   maxSize?: number,
   onFilesAdded: (files: Array<File>) => void,
-  onSuccess?: () => void,
 };
 
 type State = {
@@ -52,7 +51,11 @@ class FileUpload extends Component<Props, State> {
    */
   onDropFiles(e) {
     e.preventDefault();
-    this.props.onFilesAdded(this.validate(this.toArray(e.dataTransfer.files)));
+    const files = this.toArray(e.dataTransfer.files);
+    const validFiles = this.validate(files);
+    if (validFiles.length === files.length) {
+      this.props.onFilesAdded(files);
+    }
   }
 
   /**
@@ -62,7 +65,11 @@ class FileUpload extends Component<Props, State> {
    */
   onFilesAdded(e) {
     e.preventDefault();
-    this.props.onFilesAdded(this.validate(this.toArray(e.target.files)));
+    const files = this.toArray(e.target.files);
+    const validFiles = this.validate(files);
+    if (validFiles.length === files.length) {
+      this.props.onFilesAdded(files);
+    }
   }
 
   /**
@@ -166,9 +173,6 @@ class FileUpload extends Component<Props, State> {
       }
     });
 
-    if (!(errors && errors.length) && this.props.onSuccess) {
-      this.props.onSuccess();
-    }
     this.setState({ errors });
 
     return validFiles;

--- a/src/semantic-ui/FileUpload.js
+++ b/src/semantic-ui/FileUpload.js
@@ -10,7 +10,8 @@ import './FileUpload.css';
 type Props = {
   fileTypes?: Array<string>,
   maxSize?: number,
-  onFilesAdded: (files: Array<File>) => void
+  onFilesAdded: (files: Array<File>) => void,
+  onSuccess?: () => void,
 };
 
 type State = {
@@ -165,6 +166,9 @@ class FileUpload extends Component<Props, State> {
       }
     });
 
+    if (!(errors && errors.length) && this.props.onSuccess) {
+      this.props.onSuccess();
+    }
     this.setState({ errors });
 
     return validFiles;


### PR DESCRIPTION
For work in https://github.com/performant-software/basira/issues/113:
- `visible` prop: For some reason, without this, any error message will be clobbered when just using this component outside the context of a `FileUploadModal`. I guess some Semantic UI decision to prevent accidentally displaying messages in forms.
- `onSuccess` callback: This allows us to, for example, unmount this component when the validation was successful. If the validation threw errors, we can leave the component mounted and show the error messages.