### PR TITLE
BASIRA #31 - Search and filter

### DIFF
--- a/src/semantic-ui/ListFilters.js
+++ b/src/semantic-ui/ListFilters.js
@@ -277,6 +277,11 @@ const ListFilters = (props: Props) => {
   useEffect(() => {
     _.each(props.item.filters, (filter) => {
       const defaults = _.findWhere(props.filters, { key: filter.key });
+
+      if (filter.type === FilterTypes.boolean) {
+        defaults.value = false;
+      }
+
       props.onSaveChildAssociation('filters', _.defaults(filter, defaults));
     });
   }, []);


### PR DESCRIPTION
This pull request makes the following changes to the ListFilters component to support filtering for BASIRA:

- Adds support to Integer field filters
- Fixes a bug where boolean filters were defaulting to `NULL` instead of `false` (this was brought up in Archnet as well)