### PR TITLE
FCA #24 - Stripe API

### DIFF
--- a/src/common/EditContainer.js
+++ b/src/common/EditContainer.js
@@ -13,7 +13,7 @@ type Props = {
   onInitialize?: (id: number) => Promise<any>,
   onSave: (item: any) => Promise<any>,
   required?: Array<string>,
-  resolveValidationError?: (error: string, item: any, status: number) => Array<string>,
+  resolveValidationError?: ({ error: string, item: any, status: number, key: string }) => Array<string>,
   validate?: (item: any) => Array<string>
 };
 
@@ -170,7 +170,12 @@ const useEditContainer = (WrappedComponent: ComponentType<any>) => (
           } else if (error === ERROR_EMPTY) {
             _.extend(validationErrors, { [key]: i18n.t('EditContainer.errors.required', { key }) });
           } else if (this.props.resolveValidationError) {
-            _.extend(validationErrors, this.props.resolveValidationError(error, this.state.item, status));
+            _.extend(validationErrors, this.props.resolveValidationError({
+              key,
+              error,
+              status,
+              item: this.state.item
+            }));
           }
         });
       });


### PR DESCRIPTION
This pull request updates the `resolveValidationError` prop in EditContainer to allow for a hash parameter, rather than individual arguments. This was done to add the `key` parameter, and no enforce any ordering of arguments.

This is a breaking change 💥 and will require documentation in the next release.