### PR TITLE
EVQ #185 - Annotation filters

### DIFF
--- a/src/semantic-ui/DataList.js
+++ b/src/semantic-ui/DataList.js
@@ -286,12 +286,12 @@ const useDataList = (WrappedComponent: ComponentType<any>) => (
      */
     onFilterChange(filters: any) {
       return new Promise<void>((resolve) => {
-        // TODO: Comment me
+        // Call the custom onChange prop
         if (this.props.filters && this.props.filters.onChange) {
           this.props.filters.onChange(filters);
         }
 
-        // TODO: Comment me
+        // Set the filters and re-fetch the data
         this.setState({ filters, page: 1 }, () => {
           this.fetchData();
           resolve();

--- a/src/semantic-ui/DataList.js
+++ b/src/semantic-ui/DataList.js
@@ -286,6 +286,12 @@ const useDataList = (WrappedComponent: ComponentType<any>) => (
      */
     onFilterChange(filters: any) {
       return new Promise<void>((resolve) => {
+        // TODO: Comment me
+        if (this.props.filters.onChange) {
+          this.props.filters.onChange(filters);
+        }
+
+        // TODO: Comment me
         this.setState({ filters, page: 1 }, () => {
           this.fetchData();
           resolve();

--- a/src/semantic-ui/DataList.js
+++ b/src/semantic-ui/DataList.js
@@ -287,7 +287,7 @@ const useDataList = (WrappedComponent: ComponentType<any>) => (
     onFilterChange(filters: any) {
       return new Promise<void>((resolve) => {
         // TODO: Comment me
-        if (this.props.filters.onChange) {
+        if (this.props.filters && this.props.filters.onChange) {
           this.props.filters.onChange(filters);
         }
 

--- a/src/semantic-ui/TagsList.js
+++ b/src/semantic-ui/TagsList.js
@@ -1,31 +1,40 @@
+// @flow
+
 import React from 'react';
-import { Label } from 'semantic-ui-react';
+import { Icon, Label } from 'semantic-ui-react';
 import _ from 'underscore';
 import './TagsList.css';
 
 type Props = {
-  config: {
+  config?: {
     [key: string]: {
       background: string,
       color: string
     }
   },
+  onDelete: (tag: string) => void,
   tags: Array<string>
 };
 
-const TagsList = ({ config, tags = [] }: Props) => (
+const TagsList = (props: Props) => (
   <div
     className='tags-list'
   >
-    { _.map(tags || [], (tag) => (
+    { _.map(props.tags || [], (tag) => (
       <Label
         style={{
-          backgroundColor: config[tag] && config[tag].background,
-          color: config[tag] && config[tag].color,
+          backgroundColor: props.config && props.config[tag] && props.config[tag].background,
+          color: props.config && props.config[tag] && props.config[tag].color,
           marginRight: '10px'
         }}
       >
         { tag }
+        { props.onDelete && (
+          <Icon
+            name='delete'
+            onClick={props.onDelete.bind(this, tag)}
+          />
+        )}
       </Label>
     ))}
   </div>

--- a/stories/components/semantic-ui/TagsList.stories.js
+++ b/stories/components/semantic-ui/TagsList.stories.js
@@ -27,7 +27,7 @@ export const Default = () => {
       background: '#DFCC74',
       color: 'white'
     }
-  }
+  };
 
   return (
     <TagsList
@@ -36,3 +36,10 @@ export const Default = () => {
     />
   );
 };
+
+export const WithDelete = () => (
+  <TagsList
+    onDelete={() => {}}
+    tags={['Apple', 'Orange', 'Banana']}
+  />
+);


### PR DESCRIPTION
This pull request updates the DataList component to call a custom `onChange` prop nested in the `filters` prop in order to allow filters stored in the DataList to be used elsewhere. This is useful for EVQ in the public view where we have a list of annotations that are filterable (via DataList), but the filters also carry over to the reader interface.