### PR TITLE
EVQ #282 - Google Analytics

### DIFF
--- a/src/common/GoogleAnalytics.js
+++ b/src/common/GoogleAnalytics.js
@@ -97,7 +97,7 @@ const withGoogleAnalytics = (BannerComponent: ComponentType<any>) => (props: Pro
    * Initializes GoogleAnalytics when the status is set to accepted.
    */
   useEffect(() => {
-    if (status === Status.accepted) {
+    if (status === Status.accepted && props.id) {
       GoogleAnalytics.initialize(props.id);
     }
   }, [status]);


### PR DESCRIPTION
This pull request updates the GoogleAnalytics HOC to only initialize analytics if an `id` prop is provided.