### PR TITLE
RC #140 - BaseService

### DIFF
--- a/packages/shared/src/services/BaseService.js
+++ b/packages/shared/src/services/BaseService.js
@@ -1,6 +1,6 @@
 // @flow
 
-import axios, { type AxiosResponse } from 'axios';
+import axios, { type AxiosResponse, type AxiosStatic } from 'axios';
 
 /**
  * Base class for making API calls. This class uses Axios under the hood and a customizable transform class for
@@ -101,6 +101,15 @@ class BaseService {
   }
 
   // protected
+
+  /**
+   * Returns the axios instance.
+   *
+   * @returns {AxiosStatic}
+   */
+  getAxios(): AxiosStatic {
+    return axios;
+  }
 
   /**
    * Returns the API base URL string.


### PR DESCRIPTION
This pull request adds the `getAxios` method to the `BaseService` class to allow subclass to access the axios instance for implementing additional API end points.

```javascript
class MyService extends BaseService {
   doSomethingElse() {
    return this.getAxios().get('/api/some_route');
  }
}
```