### PR TITLE
RC #145 - ListTable render

### DIFF
--- a/packages/semantic-ui/src/components/DataTable.js
+++ b/packages/semantic-ui/src/components/DataTable.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Browser } from '@performant-software/shared-components';
+import { Browser, Object as ObjectUtils } from '@performant-software/shared-components';
 import React, { Component, createRef, type Element } from 'react';
 import {
   Checkbox,
@@ -119,6 +119,17 @@ class DataTable extends Component<Props, State> {
     if (Browser.isBrowser()) {
       document.addEventListener('mousemove', this.onMouseMove);
       document.addEventListener('mouseup', this.onMouseUp);
+    }
+  }
+
+  /**
+   * Reinitialize the column refs if the columns change.
+   *
+   * @param prevProps
+   */
+  componentDidUpdate(prevProps: Props) {
+    if (!ObjectUtils.isEqual(prevProps.columns, this.props.columns)) {
+      this.initializeColumnRefs();
     }
   }
 

--- a/packages/semantic-ui/src/components/DataTableColumnSelector.js
+++ b/packages/semantic-ui/src/components/DataTableColumnSelector.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { Object as ObjectUtils } from '@performant-software/shared-components';
 import React, { Component, type ComponentType, type Element } from 'react';
 import { Checkbox, Dropdown, Icon } from 'semantic-ui-react';
 import _ from 'underscore';
@@ -49,7 +50,7 @@ const useColumnSelector = (WrappedComponent: ComponentType<any>) => (
      * @param prevProps
      */
     componentDidUpdate(prevProps: Props): * {
-      if (prevProps.columns !== this.props.columns) {
+      if (!ObjectUtils.isEqual(prevProps.columns, this.props.columns)) {
         this.setState({ columns: this.props.columns });
       }
     }

--- a/packages/semantic-ui/src/components/ListTable.js
+++ b/packages/semantic-ui/src/components/ListTable.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { Hooks, Object as ObjectUtils } from '@performant-software/shared-components';
 import React, { useEffect } from 'react';
 import _ from 'underscore';
 import DataTable from './DataTable';
@@ -20,6 +21,8 @@ type Props = {
 };
 
 const ListTable = (props: Props) => {
+  const prevColumns = Hooks.usePrevious(props.columns);
+
   /**
    * Sorts the list by the selected column, and/or reverse the direction.
    *
@@ -51,18 +54,24 @@ const ListTable = (props: Props) => {
    * sortable column.
    */
   useEffect(() => {
-    const { page, defaultSort, defaultSortDirection = SORT_ASCENDING } = props;
+    if (!ObjectUtils.isEqual(props.columns, prevColumns)) {
+      const {
+        page,
+        defaultSort,
+        defaultSortDirection = SORT_ASCENDING
+      } = props;
 
-    if (defaultSort) {
-      props.onSort(defaultSort, defaultSortDirection, page);
-    } else {
-      const sortableColumn = _.findWhere(props.columns, { sortable: true });
-
-      if (sortableColumn) {
-        onColumnClick(sortableColumn);
+      if (defaultSort) {
+        props.onSort(defaultSort, defaultSortDirection, page);
       } else {
-        // If no columns are sortable, load the data as is
-        props.onInit();
+        const sortableColumn = _.findWhere(props.columns, { sortable: true });
+
+        if (sortableColumn) {
+          onColumnClick(sortableColumn);
+        } else {
+          // If no columns are sortable, load the data as is
+          props.onInit();
+        }
       }
     }
   }, [props.columns]);

--- a/packages/shared/src/utils/Hooks.js
+++ b/packages/shared/src/utils/Hooks.js
@@ -1,0 +1,24 @@
+// @flow
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Stores the previous value of the passed parameter.
+ *
+ * @param value
+ *
+ * @returns {*}
+ */
+const usePrevious = (value) => {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+};
+
+export default {
+  usePrevious
+};

--- a/packages/storybook/src/semantic-ui/ListTable.stories.js
+++ b/packages/storybook/src/semantic-ui/ListTable.stories.js
@@ -860,3 +860,52 @@ export const WithPerPageNoDefault = useDragDrop(() => (
     searchable={boolean('Searchable', true)}
   />
 ));
+
+export const WithCount = useDragDrop(() => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <>
+      <Button
+        content={`Clicks: ${count}`}
+        primary
+        onClick={() => setCount((prevCount) => prevCount + 1)}
+      />
+      <ListTable
+        actions={actions}
+        collectionName='items'
+        columns={[{
+          name: 'make',
+          label: 'Make',
+          sortable: true
+        }, {
+          name: 'model',
+          label: 'Model',
+          sortable: true
+        }, {
+          name: 'vin',
+          label: 'Vin',
+          sortable: true
+        }, {
+          name: 'address',
+          label: 'Address',
+          sortable: true
+        }, {
+          name: 'city',
+          label: 'City',
+          sortable: true
+        }, {
+          name: 'state',
+          label: 'State',
+          sortable: true
+        }]}
+        onCopy={action('copy')}
+        onLoad={(params) => Api.onLoad(_.extend(params, { items }))}
+        onDelete={action('delete')}
+        onSave={action('save')}
+        perPageOptions={[10, 25, 50, 100]}
+        searchable={boolean('Searchable', true)}
+      />
+    </>
+  );
+});


### PR DESCRIPTION
This pull request fixes an issue with the ListTable component that was causing it to re-render and fetch data unnecessarily. 

The issue occurs when the `columns` prop receives a hard-coded array of values. Since Javascript passes objects by value (as opposed to reference), when the parent component triggered a re-render, the hard-coded list of columns also triggered the ListTable component to re-render.

The solution was to use the `ObjectUtils.isEqual` function instead of the `!==` to compare the previous columns to the current columns to determine if the columns have changed and the component should re-render.