### PR TITLE
EVQ #404 - Associated Dropdown

### DIFF
--- a/packages/semantic-ui/src/components/AssociatedDropdown.js
+++ b/packages/semantic-ui/src/components/AssociatedDropdown.js
@@ -63,6 +63,7 @@ class AssociatedDropdown extends Component<Props, State> {
       items: [],
       loading: false,
       modalAdd: false,
+      modalEdit: false,
       options: [],
       saved: false,
       searchQuery: props.searchQuery || '',
@@ -208,7 +209,7 @@ class AssociatedDropdown extends Component<Props, State> {
           { this.renderAddButton() }
           { this.renderClearButton() }
         </Button.Group>
-        { this.renderAddModal() }
+        { this.renderModal() }
         { this.state.saved && (
           <Toaster
             onDismiss={() => this.setState({ saved: false })}
@@ -248,56 +249,6 @@ class AssociatedDropdown extends Component<Props, State> {
   }
 
   /**
-   * Renders the edit button (if applicable).
-   *
-   * @returns {null|*}
-   */
-  renderEditButton() {
-    if (!this.props.modal || !this.props.modal.props || !this.props.modal.props.onInitialize || !this.state.value) {
-      return null;
-    }
-
-    return (
-      <Button
-        basic
-        content={i18n.t('Common.buttons.edit')}
-        icon='pencil'
-        onClick={() => this.setState({ modalAdd: true })}
-        type='button'
-      />
-    );
-  }
-
-  /**
-   * Renders the add association button.
-   *
-   * @returns {null|*}
-   */
-  renderAddModal() {
-    if (!(this.state.modalAdd && this.props.modal)) {
-      return null;
-    }
-
-    const {
-      component, props, onSave
-    } = this.props.modal;
-
-    return (
-      <EditModal
-        component={component}
-        item={{ id: this.state.value }}
-        onClose={() => this.setState({ modalAdd: false })}
-        onSave={(item) => onSave(item)
-          .then((record) => {
-            this.props.onSelection(record);
-            this.setState({ modalAdd: false, saved: true });
-          })}
-        {...props}
-      />
-    );
-  }
-
-  /**
    * Renders the clear button.
    *
    * @returns {*}
@@ -314,6 +265,63 @@ class AssociatedDropdown extends Component<Props, State> {
         icon='times'
         onClick={this.onClear.bind(this)}
         type='button'
+      />
+    );
+  }
+
+  /**
+   * Renders the edit button (if applicable).
+   *
+   * @returns {null|*}
+   */
+  renderEditButton() {
+    if (!this.props.modal || !this.props.modal.props || !this.props.modal.props.onInitialize || !this.state.value) {
+      return null;
+    }
+
+    return (
+      <Button
+        basic
+        content={i18n.t('Common.buttons.edit')}
+        icon='pencil'
+        onClick={() => this.setState({ modalEdit: true })}
+        type='button'
+      />
+    );
+  }
+
+  /**
+   * Renders the add association button.
+   *
+   * @returns {null|*}
+   */
+  renderModal() {
+    if (!((this.state.modalAdd || this.state.modalEdit) && this.props.modal)) {
+      return null;
+    }
+
+    const { component, props, onSave } = this.props.modal;
+
+    // If we're editing the existing record, pass the ID to the modal in order to retrieve the full record.
+    let item;
+
+    if (this.state.modalEdit) {
+      item = {
+        id: this.state.value
+      };
+    }
+
+    return (
+      <EditModal
+        component={component}
+        item={item}
+        onClose={() => this.setState({ modalAdd: false, modalEdit: false })}
+        onSave={(data) => onSave(data)
+          .then((record) => {
+            this.props.onSelection(record);
+            this.setState({ modalAdd: false, modalEdit: false, saved: true });
+          })}
+        {...props}
       />
     );
   }

--- a/packages/storybook/src/semantic-ui/AssociatedDropdown.stories.js
+++ b/packages/storybook/src/semantic-ui/AssociatedDropdown.stories.js
@@ -4,10 +4,11 @@ import React from 'react';
 import { withA11y } from '@storybook/addon-a11y';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs';
-import { Form } from 'semantic-ui-react';
+import { Form, Modal } from 'semantic-ui-react';
 import AddModal from '../components/AddModal';
 import Api from '../services/Api';
 import AssociatedDropdown from '../../../semantic-ui/src/components/AssociatedDropdown';
+import { type EditContainerProps } from '../../../shared/src/components/EditContainer';
 
 export default {
   title: 'Components/Semantic UI/AssociatedDropdown',
@@ -339,18 +340,48 @@ export const Default = () => (
   />
 );
 
+const TestModal = (props: EditContainerProps) => (
+  <Modal
+    as={Form}
+    centered={false}
+    open
+  >
+    <Modal.Header
+      content={props.item.id ? 'Edit' : 'Add'}
+    />
+    <Modal.Content>
+      <Form.Input
+        label='Company'
+        onChange={props.onTextInputChange.bind(this, 'company')}
+        value={props.item.company}
+      />
+      <Form.Input
+        label='Email'
+        onChange={props.onTextInputChange.bind(this, 'email')}
+        value={props.item.email}
+      />
+      <Form.Input
+        label='Card'
+        onChange={props.onTextInputChange.bind(this, 'card')}
+        value={props.item.card}
+      />
+    </Modal.Content>
+    { props.children }
+  </Modal>
+);
+
 export const WithEditButton = () => (
   <AssociatedDropdown
     collectionName='items'
     modal={{
-      component: AddModal,
+      component: TestModal,
       onSave: () => {
         action('save')();
         return Promise.resolve({});
       },
       props: {
         onInitialize: (id) => {
-          action('edit')();
+          action('initialize')();
           return Promise.resolve({ ...items.find((i) => i.id === id) });
         }
       }


### PR DESCRIPTION
This pull request fixes a bug with using the "Add" button in the AssociatedDropdown component. When the ability to edit records via the AssociatedDropdown was added, it introduced a bug which made the "Add" button actually edit existing records if a value was selected.

The solution was to modify the logic to not provide an `id` value to the modal if the "Add" button was clicked.