### PR TITLE
RC #153 - EmbeddedList default sort

### DIFF
--- a/packages/semantic-ui/src/components/DataTable.js
+++ b/packages/semantic-ui/src/components/DataTable.js
@@ -437,7 +437,7 @@ class DataTable extends Component<Props, State> {
         <Table.HeaderCell
           key={column.name}
           sorted={this.props.sortColumn === column.name ? this.props.sortDirection : null}
-          onClick={this.props.onColumnClick.bind(this, column)}
+          onClick={() => this.props.onColumnClick(column)}
         >
           { column.label }
           <ColumnResize

--- a/packages/semantic-ui/src/components/EmbeddedList.js
+++ b/packages/semantic-ui/src/components/EmbeddedList.js
@@ -25,6 +25,8 @@ type Props = {
   className?: string,
   columns: Array<Column>,
   configurable: boolean,
+  defaultSort?: string,
+  defaultSortDirection?: string,
   items: Array<any>,
   modal?: {
     component: ComponentType<any>,
@@ -77,10 +79,16 @@ class EmbeddedList extends Component<Props, State> {
    * Sorts the table by the first column.
    */
   componentDidMount() {
-    const column = _.find(this.props.columns, (c) => c.sortable !== false);
+    let column;
+
+    if (this.props.defaultSort) {
+      column = _.findWhere(this.props.columns, { name: this.props.defaultSort });
+    } else {
+      column = _.find(this.props.columns, (c) => c.sortable !== false);
+    }
 
     if (column) {
-      this.onColumnClick(column);
+      this.onColumnClick(column, this.props.defaultSortDirection);
     }
   }
 
@@ -101,7 +109,7 @@ class EmbeddedList extends Component<Props, State> {
    *
    * @param column
    */
-  onColumnClick(column: Column) {
+  onColumnClick(column: Column, direction: string = SORT_ASCENDING) {
     /*
      * We'll disable the column sorting if the table rows are draggable. Making the table rows draggable implies
      * that the sorting will be done manually. Allowing column click sorting could make things confusing.
@@ -119,7 +127,7 @@ class EmbeddedList extends Component<Props, State> {
     }
 
     const sortColumn = column.name;
-    let sortDirection = SORT_ASCENDING;
+    let sortDirection = direction || SORT_ASCENDING;
 
     if (column.name === this.state.sortColumn) {
       sortDirection = this.state.sortDirection === SORT_ASCENDING ? SORT_DESCENDING : SORT_ASCENDING;
@@ -276,3 +284,8 @@ EmbeddedList.defaultProps = {
 };
 
 export default EmbeddedList;
+
+export {
+  SORT_ASCENDING,
+  SORT_DESCENDING
+};

--- a/packages/storybook/src/semantic-ui/EmbeddedList.stories.js
+++ b/packages/storybook/src/semantic-ui/EmbeddedList.stories.js
@@ -9,7 +9,7 @@ import _ from 'underscore';
 import AddModal from '../components/AddModal';
 import { SemanticColors } from '../services/Colors';
 import EditModal from '../../../semantic-ui/src/components/EditModal';
-import EmbeddedList from '../../../semantic-ui/src/components/EmbeddedList';
+import EmbeddedList, { SORT_DESCENDING } from '../../../semantic-ui/src/components/EmbeddedList';
 import TabbedModal from '../../../semantic-ui/src/components/TabbedModal';
 import useDragDrop from '../../../shared/src/utils/DragDrop';
 
@@ -286,6 +286,17 @@ export const NoSortableColumns = useDragDrop(() => (
     actions={actions}
     onDelete={action('delete')}
     columns={_.map(columns, (c) => ({ ...c, sortable: false }))}
+    items={items}
+  />
+));
+
+export const DefaultSort = useDragDrop(() => (
+  <EmbeddedList
+    actions={actions}
+    columns={columns}
+    defaultSort='country'
+    defaultSortDirection={SORT_DESCENDING}
+    onDelete={action('delete')}
     items={items}
   />
 ));


### PR DESCRIPTION
This pull request updates the EmbeddedList component to accept `defaultSort` and `defaultSortDirection` props in order to define how the list should be initially sorted:

```javascript
<EmbeddedList
  columns={...}
  defaultSort='created_at'
  defaultSortDirection='descending'
/>
```