### PR TITLE
UDF #23 - Field order

### DIFF
--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.3-beta.1",
+  "version": "1.0.3",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.3-beta.1",
-    "@performant-software/shared-components": "^1.0.3-beta.1",
+    "@performant-software/semantic-components": "^1.0.3",
+    "@performant-software/shared-components": "^1.0.3",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.3-beta.0",
+  "version": "1.0.3-beta.1",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.3-beta.0",
-    "@performant-software/shared-components": "^1.0.3-beta.0",
+    "@performant-software/semantic-components": "^1.0.3-beta.1",
+    "@performant-software/shared-components": "^1.0.3-beta.1",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.2",
+  "version": "1.0.3-beta.0",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.2",
-    "@performant-software/shared-components": "^1.0.2",
+    "@performant-software/semantic-components": "^1.0.3-beta.0",
+    "@performant-software/shared-components": "^1.0.3-beta.0",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.3-beta.0",
+  "version": "1.0.3-beta.1",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.3-beta.0",
+    "@performant-software/shared-components": "^1.0.3-beta.1",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.2",
+  "version": "1.0.3-beta.0",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.2",
+    "@performant-software/shared-components": "^1.0.3-beta.0",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.3-beta.1",
+  "version": "1.0.3",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.3-beta.1",
+    "@performant-software/shared-components": "^1.0.3",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.2",
+  "version": "1.0.3-beta.0",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.3-beta.1",
+  "version": "1.0.3",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.3-beta.0",
+  "version": "1.0.3-beta.1",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/storybook/.storybook/routes/UserDefinedFields.js
+++ b/packages/storybook/.storybook/routes/UserDefinedFields.js
@@ -35,29 +35,35 @@ const addRoutes = (router) => {
       table_name: 'People',
       column_name: 'First name',
       data_type: 'String',
-      required: true
+      required: true,
+      order: 10
     }, {
       table_name: 'People',
       column_name: 'Last name',
       data_type: 'String',
-      required: true
+      required: true,
+      order: 20
     }, {
       table_name: 'People',
       column_name: 'Date of birth',
-      data_type: 'Date'
+      data_type: 'Date',
+      order: 30
     }, {
       table_name: 'People',
       column_name: 'Biography',
-      data_type: 'RichText'
+      data_type: 'RichText',
+      order: 40
     }, {
       table_name: 'People',
       column_name: 'Favorite color',
       data_type: 'Select',
+      order: 50,
       options: ['Red', 'Blue', 'Green', 'Orange', 'Yellow']
     }, {
       table_name: 'People',
       column_name: 'Year of service',
-      data_type: 'Number'
+      data_type: 'Number',
+      order: 60
     }];
 
     response.send({

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.2",
+  "version": "1.0.3-beta.0",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.2",
-    "@performant-software/shared-components": "^1.0.2",
+    "@performant-software/semantic-components": "^1.0.3-beta.0",
+    "@performant-software/shared-components": "^1.0.3-beta.0",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.3-beta.1",
+  "version": "1.0.3",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.3-beta.1",
-    "@performant-software/shared-components": "^1.0.3-beta.1",
+    "@performant-software/semantic-components": "^1.0.3",
+    "@performant-software/shared-components": "^1.0.3",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.3-beta.0",
+  "version": "1.0.3-beta.1",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.3-beta.0",
-    "@performant-software/shared-components": "^1.0.3-beta.0",
+    "@performant-software/semantic-components": "^1.0.3-beta.1",
+    "@performant-software/shared-components": "^1.0.3-beta.1",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/src/components/UserDefinedFieldModal.js
+++ b/packages/user-defined-fields/src/components/UserDefinedFieldModal.js
@@ -83,6 +83,14 @@ const UserDefinedFieldModal: ComponentType<any> = (props) => {
           selectOnBlur={false}
           value={props.item.data_type || ''}
         />
+        <Form.Input
+          error={props.isError('order')}
+          label={i18n.t('UserDefinedFieldModal.labels.order')}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('oder')}
+          value={props.item.order || 0}
+          type='number'
+        />
         <Form.Group>
           <Form.Checkbox
             error={props.isError('required')}

--- a/packages/user-defined-fields/src/components/UserDefinedFieldsEmbeddedList.js
+++ b/packages/user-defined-fields/src/components/UserDefinedFieldsEmbeddedList.js
@@ -31,6 +31,9 @@ const UserDefinedFieldsEmbeddedList = (props: Props) => (
       name: 'required',
       label: i18n.t('UserDefinedFieldsEmbeddedList.columns.required'),
       render: (udf) => <BooleanIcon value={udf.required} />
+    }, {
+      name: 'order',
+      label: i18n.t('UserDefinedFieldsEmbeddedList.columns.order')
     }]}
     items={props.items}
     modal={{

--- a/packages/user-defined-fields/src/components/UserDefinedFieldsForm.js
+++ b/packages/user-defined-fields/src/components/UserDefinedFieldsForm.js
@@ -178,8 +178,9 @@ const UserDefinedFieldsForm: ComponentType<any> = (props: Props) => {
     const params = {
       defineable_id: props.defineableId,
       defineable_type: props.defineableType,
-      table_name: props.tableName,
-      sort_by: 'order'
+      per_page: 0,
+      sort_by: 'order',
+      table_name: props.tableName
     };
 
     UserDefinedFieldsService

--- a/packages/user-defined-fields/src/components/UserDefinedFieldsForm.js
+++ b/packages/user-defined-fields/src/components/UserDefinedFieldsForm.js
@@ -178,7 +178,8 @@ const UserDefinedFieldsForm: ComponentType<any> = (props: Props) => {
     const params = {
       defineable_id: props.defineableId,
       defineable_type: props.defineableType,
-      table_name: props.tableName
+      table_name: props.tableName,
+      sort_by: 'order'
     };
 
     UserDefinedFieldsService

--- a/packages/user-defined-fields/src/components/UserDefinedFieldsList.js
+++ b/packages/user-defined-fields/src/components/UserDefinedFieldsList.js
@@ -26,6 +26,9 @@ const UserDefinedFieldsList: ComponentType<any> = () => (
       name: 'required',
       label: i18n.t('UserDefinedFieldsList.columns.required'),
       render: (udf) => <BooleanIcon value={udf.required} />
+    }, {
+      name: 'order',
+      label: i18n.t('UserDefinedFieldsList.columns.order')
     }]}
     collectionName='user_defined_fields'
     modal={{

--- a/packages/user-defined-fields/src/i18n/en.json
+++ b/packages/user-defined-fields/src/i18n/en.json
@@ -4,6 +4,7 @@
       "allowMultiple": "Allow multiple",
       "dataType": "Data type",
       "name": "Name",
+      "order": "Order",
       "required": "Required",
       "searchable": "Searchable",
       "table": "Table"
@@ -17,6 +18,7 @@
     "columns": {
       "dataType": "Data type",
       "name": "Name",
+      "order": "Order",
       "required": "Required",
       "table": "Table"
     }
@@ -25,6 +27,7 @@
     "columns": {
       "dataType": "Data type",
       "name": "Name",
+      "order": "Order",
       "required": "Required",
       "table": "Table"
     }

--- a/packages/user-defined-fields/src/transforms/UserDefinedField.js
+++ b/packages/user-defined-fields/src/transforms/UserDefinedField.js
@@ -19,7 +19,8 @@ class UserDefinedField extends BaseTransform {
       'required',
       'searchable',
       'allow_multiple',
-      'options'
+      'options',
+      'order'
     ];
   }
 

--- a/packages/user-defined-fields/src/transforms/UserDefinedFields.js
+++ b/packages/user-defined-fields/src/transforms/UserDefinedFields.js
@@ -21,6 +21,7 @@ class UserDefinedFields extends NestedAttributesTransform {
       'searchable',
       'allow_multiple',
       'options',
+      'order',
       '_destroy'
     ];
   }

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.2",
+  "version": "1.0.3-beta.0",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.3-beta.0",
+  "version": "1.0.3-beta.1",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.3-beta.1",
+  "version": "1.0.3",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.3-beta.1"
+  "version": "1.0.3"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.3-beta.0"
+  "version": "1.0.3-beta.1"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.2"
+  "version": "1.0.3-beta.0"
 }


### PR DESCRIPTION
This pull request adds the `order` property to the user defined fields components. When fetching the user defined fields in the UserDefinedFieldsForm, results will be sorted by the `order`.

This pull request also fixes a bug where the fetch request in the UserDefinedFieldsForm was paginating the results.

## Modal
The `order` input element has been added to the modal
![Screen Shot 2022-10-26 at 7 46 21 AM](https://user-images.githubusercontent.com/20641961/198018443-ca66d155-12d3-4a20-9ec5-d4f95002b2fd.png)

## List
The list has been updated to display the `order` for each field
![Screen Shot 2022-10-26 at 7 46 28 AM](https://user-images.githubusercontent.com/20641961/198018447-23b2f9b6-3cae-4908-9ce1-913269765ac2.png)

## Form
The form will display inputs sorted by the `order`
![Screen Shot 2022-10-26 at 7 46 35 AM](https://user-images.githubusercontent.com/20641961/198018449-3b432d4c-2a7d-4988-b306-6f3d1c400024.png)
