### PR TITLE
IIIF #20 - File upload

### DIFF
--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.5",
+  "version": "1.0.4-beta.6",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.5",
-    "@performant-software/shared-components": "^1.0.4-beta.5",
+    "@performant-software/semantic-components": "^1.0.4-beta.6",
+    "@performant-software/shared-components": "^1.0.4-beta.6",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.9",
+  "version": "1.0.4",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.9",
-    "@performant-software/shared-components": "^1.0.4-beta.9",
+    "@performant-software/semantic-components": "^1.0.4",
+    "@performant-software/shared-components": "^1.0.4",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.3",
+  "version": "1.0.4-beta.0",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.3",
-    "@performant-software/shared-components": "^1.0.3",
+    "@performant-software/semantic-components": "^1.0.4-beta.0",
+    "@performant-software/shared-components": "^1.0.4-beta.0",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.7",
+  "version": "1.0.4-beta.8",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.7",
-    "@performant-software/shared-components": "^1.0.4-beta.7",
+    "@performant-software/semantic-components": "^1.0.4-beta.8",
+    "@performant-software/shared-components": "^1.0.4-beta.8",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.8",
+  "version": "1.0.4-beta.9",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.8",
-    "@performant-software/shared-components": "^1.0.4-beta.8",
+    "@performant-software/semantic-components": "^1.0.4-beta.9",
+    "@performant-software/shared-components": "^1.0.4-beta.9",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.6",
+  "version": "1.0.4-beta.7",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.6",
-    "@performant-software/shared-components": "^1.0.4-beta.6",
+    "@performant-software/semantic-components": "^1.0.4-beta.7",
+    "@performant-software/shared-components": "^1.0.4-beta.7",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.4",
+  "version": "1.0.4-beta.5",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.4",
-    "@performant-software/shared-components": "^1.0.4-beta.4",
+    "@performant-software/semantic-components": "^1.0.4-beta.5",
+    "@performant-software/shared-components": "^1.0.4-beta.5",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.3",
+  "version": "1.0.4-beta.4",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.3",
-    "@performant-software/shared-components": "^1.0.4-beta.3",
+    "@performant-software/semantic-components": "^1.0.4-beta.4",
+    "@performant-software/shared-components": "^1.0.4-beta.4",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.0",
+  "version": "1.0.4-beta.1",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.0",
-    "@performant-software/shared-components": "^1.0.4-beta.0",
+    "@performant-software/semantic-components": "^1.0.4-beta.1",
+    "@performant-software/shared-components": "^1.0.4-beta.1",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.2",
+  "version": "1.0.4-beta.3",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.2",
-    "@performant-software/shared-components": "^1.0.4-beta.2",
+    "@performant-software/semantic-components": "^1.0.4-beta.3",
+    "@performant-software/shared-components": "^1.0.4-beta.3",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.4-beta.1",
+  "version": "1.0.4-beta.2",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.1",
-    "@performant-software/shared-components": "^1.0.4-beta.1",
+    "@performant-software/semantic-components": "^1.0.4-beta.2",
+    "@performant-software/shared-components": "^1.0.4-beta.2",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.9",
+  "version": "1.0.4",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.9",
+    "@performant-software/shared-components": "^1.0.4",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.3",
+  "version": "1.0.4-beta.0",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.3",
+    "@performant-software/shared-components": "^1.0.4-beta.0",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.5",
+  "version": "1.0.4-beta.6",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.5",
+    "@performant-software/shared-components": "^1.0.4-beta.6",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.7",
+  "version": "1.0.4-beta.8",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.7",
+    "@performant-software/shared-components": "^1.0.4-beta.8",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.0",
+  "version": "1.0.4-beta.1",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.0",
+    "@performant-software/shared-components": "^1.0.4-beta.1",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.6",
+  "version": "1.0.4-beta.7",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.6",
+    "@performant-software/shared-components": "^1.0.4-beta.7",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.3",
+  "version": "1.0.4-beta.4",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.3",
+    "@performant-software/shared-components": "^1.0.4-beta.4",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.8",
+  "version": "1.0.4-beta.9",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.8",
+    "@performant-software/shared-components": "^1.0.4-beta.9",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.1",
+  "version": "1.0.4-beta.2",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.1",
+    "@performant-software/shared-components": "^1.0.4-beta.2",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.2",
+  "version": "1.0.4-beta.3",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.2",
+    "@performant-software/shared-components": "^1.0.4-beta.3",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.4-beta.4",
+  "version": "1.0.4-beta.5",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.4-beta.4",
+    "@performant-software/shared-components": "^1.0.4-beta.5",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -175,7 +175,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
       const item = items[i];
 
       // Update the status for the item
-      setStatus(i, Status.processing);
+      setStatus(item, Status.processing);
 
       let error;
 
@@ -189,9 +189,9 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
 
       // Update the status for the item
       if (error) {
-        setStatus(i, Status.error, error.message);
+        setStatus(item, Status.error, error.message);
       } else {
-        setStatus(i, Status.complete);
+        setStatus(item, Status.complete);
       }
 
       // Update the upload count

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -85,12 +85,18 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
   const [items, setItems] = useState([]);
   const [uploadCount, setUploadCount] = useState(0);
   const [uploading, setUploading] = useState(false);
-  // const [statuses, setStatuses] = useState({});
+  const [statuses, setStatuses] = useState({});
 
   /**
    * Sets the <code>hasErrors</code> value to <code>true</code> if at least one item on the state contains errors.
    */
   const hasErrors = useMemo(() => !!_.find(items, (item) => !_.isEmpty(item.errors)), [items]);
+
+  /**
+   * Sets the <code>hasUploadErrors</code> value to <code>true</code> if at least one file uploaded with
+   * an error status.
+   */
+  const hasUploaderErrors = useMemo(() => _.find(_.values(statuses), (status) => status === Status.error), [statuses]);
 
   /**
    * Calls the <code>onAddFile</code> prop for each item in the passed collection of files and adds them
@@ -157,13 +163,9 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
    *
    * @type {function(*, *): void}
    */
-  // const setStatus = useCallback((index, status, message = null) => (
-  //   setStatuses((prevStatuses) => ({ ...prevStatuses, [index]: { status, message } }))
-  // ));
-
-  const setStatus = useCallback((item, status, message = null) => (
-    setItems(_.map(items, (i) => (i !== item ? i : { ...i, status, errors: [message] })))
-  ), [items]);
+  const setStatus = useCallback((index, status) => (
+    setStatuses((prevStatuses) => ({ ...prevStatuses, [index]: status }))
+  ));
 
   /**
    * Iterates of the list of items and sequentially calls the <code>onSave</code> prop for each.
@@ -189,7 +191,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
 
       // Update the status for the item
       if (error) {
-        setStatus(item, Status.error, error.message);
+        setStatus(item, Status.error);
       } else {
         setStatus(item, Status.complete);
       }
@@ -372,6 +374,13 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
                   { _.map(items, renderMessageItem) }
                 </Message.List>
               </Message>
+            )}
+            { hasUploaderErrors && (
+              <Message
+                content={i18n.t('FileUploadModal.errors.upload.content')}
+                header={i18n.t('FileUploadModal.errors.upload.header')}
+                error
+              />
             )}
             <FileUpload
               onFilesAdded={onAddFiles}

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -253,7 +253,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
    *
    * @type {function(): Promise<void>}
    */
-  const onValidate = useCallback(() => {
+  const onValidate = useCallback(() => new Promise((resolve, reject) => {
     let error = false;
 
     setItems((prevItems) => _.map(prevItems, (item) => {
@@ -266,8 +266,12 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
       return valid;
     }));
 
-    return error ? Promise.reject() : Promise.resolve();
-  }, [validateItem]);
+    if (error) {
+      reject();
+    } else {
+      resolve();
+    }
+  }), []);
 
   /**
    * Updates the passed item with the passed props.

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -96,7 +96,9 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
    * Sets the <code>hasUploadErrors</code> value to <code>true</code> if at least one file uploaded with
    * an error status.
    */
-  const hasUploaderErrors = useMemo(() => _.find(_.values(statuses), (status) => status === Status.error), [statuses]);
+  const hasUploadErrors = useMemo(() => (
+    !!_.find(_.values(statuses), (status) => status === Status.error)
+  ), [statuses]);
 
   /**
    * Calls the <code>onAddFile</code> prop for each item in the passed collection of files and adds them
@@ -375,7 +377,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
                 </Message.List>
               </Message>
             )}
-            { hasUploaderErrors && (
+            { hasUploadErrors && (
               <Message
                 content={i18n.t('FileUploadModal.errors.upload.content')}
                 header={i18n.t('FileUploadModal.errors.upload.header')}
@@ -404,7 +406,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
                 >
                   { props.strategy === Strategy.single && (
                     <FileUploadStatus
-                      status={item.status}
+                      status={statuses[index]}
                     />
                   )}
                 </UploadItem>

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -179,7 +179,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
       const item = items[i];
 
       // Update the status for the item
-      setStatus(item, Status.processing);
+      setStatus(i, Status.processing);
 
       let error;
 
@@ -193,9 +193,9 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
 
       // Update the status for the item
       if (error) {
-        setStatus(item, Status.error);
+        setStatus(i, Status.error);
       } else {
-        setStatus(item, Status.complete);
+        setStatus(i, Status.complete);
       }
 
       // Update the upload count

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -1,367 +1,275 @@
 // @flow
 
-import React, { Component, type ComponentType } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+  type ComponentType
+} from 'react';
 import {
   Button,
   Dimmer,
   Form,
   Item,
-  Loader,
-  Message,
+  Loader, Message,
   Modal
 } from 'semantic-ui-react';
 import _ from 'underscore';
-import i18n from '../i18n/i18n';
 import FileUpload from './FileUpload';
+import FileUploadStatus from './FileUploadStatus';
+import FileUploadProgress from './FileUploadProgress';
+import i18n from '../i18n/i18n';
 import ModalContext from '../context/ModalContext';
-import Toaster from './Toaster';
 
 type Props = {
   /**
-   * Content to display on the button used to open the modal
+   * If <code>true</code>, the modal will close once the upload has completed.
    */
-  button: string,
+  closeOnComplete?: boolean,
 
   /**
-   * Determines if the component should render a button as a trigger for the modal
-   */
-  includeButton?: boolean,
-
-  /**
-   * Component to render within the modal
+   * Component to render within the modal.
    */
   itemComponent: ComponentType<any>,
 
   /**
-   * Callback fired when a file is added
+   * Callback fired when a file is added.
    */
-  onAddFile: (file: File) => void,
+  onAddFile: (file: File) => any,
 
   /**
-   * Callback fired when the close button is clicked
+   * Callback fired when the close button is clicked.
    */
-  onClose?: () => void,
+  onClose: () => void,
 
   /**
-   * Callback fired when the save button is clicked
+   * Callback fired when the save button is clicked. See <code>strategy</code> prop.
    */
   onSave: (items: Array<any>) => Promise<any>,
 
   /**
-   * An object with keys containing the names of properties that are required
+   * An object with keys containing the names of properties that are required.
    */
-  required: { [string]: string },
+  required?: { [key: string]: string },
 
   /**
-   * Title value to display in the modal header
+   * If <code>true</code>, a full page loader will display while uploading is in progress.
    */
-  title?: string
+  showPageLoader?: boolean,
+
+  /**
+   * The upload strategy to use. If <code>batch</code>, we'll execute one <code>onSave</code> request with each item
+   * as an array in the body. If <code>single</code>, we'll execute an <code>onSave</code> request for each item.
+   */
+  strategy?: string
 };
 
-type State = {
-  items: Array<any>,
-  modal: boolean,
-  saving: boolean
+const Strategy = {
+  batch: 'batch',
+  single: 'single'
 };
 
-const LIST_DELIMITER = ', ';
+const Status = {
+  pending: 'pending',
+  processing: 'processing',
+  complete: 'complete',
+  error: 'error'
+};
 
 /**
  * The <code>FileUploadModal</code> is a convenience wrapper for the <code>FileUpload</code> component, allowing
  * it to render in a modal.
  */
-class FileUploadModal extends Component<Props, State> {
-  /**
-   * Constructs a new FileUploadModal component.
-   *
-   * @param props
-   */
-  constructor(props: Props) {
-    super(props);
-
-    this.state = this.getInitialState();
-  }
+const FileUploadModal: ComponentType<any> = (props: Props) => {
+  const [items, setItems] = useState([]);
+  const [uploadCount, setUploadCount] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [statuses, setStatuses] = useState({});
 
   /**
-   * Returns the initial component state.
-   *
-   * @returns {{saving: boolean, items: [], modal: boolean}}
+   * Sets the <code>hasErrors</code> value to <code>true</code> if at least one item on the state contains errors.
    */
-  getInitialState() {
-    return {
-      items: [],
-      modal: !this.props.includeButton,
-      saving: false
-    };
-  }
+  const hasErrors = useMemo(() => !!_.find(items, (item) => !_.isEmpty(item.errors)), [items]);
 
   /**
-   * Returns true if any of the items contain errors.
+   * Calls the <code>onAddFile</code> prop for each item in the passed collection of files and adds them
+   * to the items on the state.
    *
-   * @returns {boolean}
+   * @type {function(*): void}
    */
-  hasErrors() {
-    return !!_.find(this.state.items, (item) => !_.isEmpty(item.errors));
-  }
-
-  /**
-   * Adds the passed collection of files to the state. Typically files will be added as a property of another model.
-   * This component calls the onAddFiles prop to transform the items stored in the state.
-   *
-   * @param files
-   */
-  onAddFiles(files: Array<File>) {
-    this.setState((state) => ({
-      items: [
-        ...state.items,
-        ..._.map(files, this.props.onAddFile.bind(this))
-      ]
-    }));
-  }
+  const onAddFiles = useCallback((files) => (
+    setItems((prevItems) => [
+      ...prevItems,
+      ..._.map(files, props.onAddFile)
+    ])
+  ), []);
 
   /**
    * Updates the passed association for the passed item.
    *
-   * @param item
-   * @param idAttribute
-   * @param attribute
-   * @param value
+   * @type {function(*, string, string, *): void}
    */
-  onAssociationInputChange(item: any, idAttribute: string, attribute: string, value: any) {
-    this.setState((state) => ({
-      items: _.map(state.items, (i) => (i !== item ? i : ({
-        ...i,
-        [idAttribute]: value.id,
-        [attribute]: value,
-        errors: _.without(item.errors, idAttribute)
-      })))
-    }));
-  }
+  const onAssociationInputChange = useCallback((item: any, idAttribute: string, attribute: string, value: any) => (
+    setItems((prevItems) => _.map(prevItems, (i) => (i !== item ? i : {
+      ...i,
+      [idAttribute]: value.id,
+      [attribute]: value,
+      errors: _.without(item.errors, idAttribute)
+    })))
+  ), []);
 
   /**
-   * Resets the state or calls the onClose prop.
+   * Calls the <code>onSave</code> prop with the current list of items.
+   *
+   * @type {function(): *}
    */
-  onClose() {
-    if (this.props.onClose) {
-      this.props.onClose();
-    } else {
-      this.setState(this.getInitialState());
+  const onBatchUpload = useCallback(() => (
+    props
+      .onSave(items)
+      .then(() => setUploadCount(1))
+  ), [items]);
+
+  /**
+   * Sets the uploading state <code>false</code> and calls the <code>onClose</code> prop if necessary.
+   *
+   * @type {(function(): void)|*}
+   */
+  const onComplete = useCallback(() => {
+    setUploading(false);
+
+    if (props.closeOnComplete) {
+      props.onClose();
     }
-  }
+  }, [props.closeOnComplete, props.onClose]);
 
   /**
    * Deletes the passed item from the state.
    *
-   * @param item
+   * @type {function(*): void}
    */
-  onDelete(item: any) {
-    this.setState((state) => ({
-      items: _.filter(state.items, (i) => i !== item)
-    }));
-  }
+  const onDelete = useCallback((item) => (
+    setItems((prevItems) => _.filter(prevItems, (i) => i !== item))
+  ), []);
 
   /**
-   * Clears the errors for all items in the state.
+   * Sets the status for the item at the passed index.
+   *
+   * @type {function(*, *): void}
    */
-  onDismissErrors() {
-    this.setState((state) => ({
-      items: _.map(state.items, (item) => _.omit(item, 'errors'))
-    }));
-  }
+  const setStatus = useCallback((index, status) => (
+    setStatuses((prevStatuses) => ({ ...prevStatuses, [index]: status }))
+  ));
 
   /**
-   * Validates the items and saves.
+   * Iterates of the list of items and sequentially calls the <code>onSave</code> prop for each.
+   *
+   * @type {function(): Promise<unknown>}
    */
-  onSave() {
-    this.setState((state) => ({
-      items: _.map(state.items, this.validateItem.bind(this))
-    }), this.save.bind(this));
-  }
+  const onSingleUpload = useCallback(async () => {
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i];
+
+      // Update the status for the item
+      setStatus(i, Status.processing);
+
+      let error = false;
+
+      // Do the upload
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await props.onSave(item);
+      } catch (e) {
+        error = true;
+      }
+
+      // Update the status for the item
+      if (error) {
+        setStatus(i, Status.error);
+      } else {
+        setStatus(i, Status.complete);
+      }
+
+      // Update the upload count
+      setUploadCount((prevCount) => prevCount + 1);
+    }
+
+    return Promise.resolve();
+  }, [items, props.onSave]);
 
   /**
    * Updates the text value for the passed item.
    *
-   * @param item
-   * @param attribute
-   * @param e
-   * @param value
+   * @type {function(*, string, Event, {value: *}): void}
    */
-  onTextInputChange(item: any, attribute: string, e: Event, { value }: { value: any }) {
-    this.setState((state) => ({
-      items: _.map(state.items, (i) => (i !== item ? i : ({
-        ...i,
-        [attribute]: value,
-        errors: _.without(item.errors, attribute)
-      })))
-    }));
-  }
+  const onTextInputChange = useCallback((item: any, attribute: string, e: Event, { value }: { value: any }) => (
+    setItems((prevItems) => _.map(prevItems, (i) => (i !== item ? i : {
+      ...i,
+      [attribute]: value,
+      errors: _.without(item.errors, attribute)
+    })))
+  ), []);
+
+  /**
+   * Updates the passed item with the passed object of attributes.
+   *
+   * @type {function(*, *): void}
+   */
+  const onUpdate = useCallback((item, attributes) => (
+    setItems((prevItems) => _.map(prevItems, (i) => (i !== item ? i : { ...i, ...attributes })))
+  ), []);
 
   /**
    * Updates the passed item with the passed props.
    *
-   * @param item
-   * @param props
+   * @type {(function(): void)|*}
    */
-  onUpdate(item: any, props: any) {
-    this.setState((state) => ({
-      items: _.map(state.items, (i) => (i !== item ? i : ({
-        ...i,
-        ...props,
-        errors: _.without(item.errors, _.keys(props))
-      })))
+  const onUpload = useCallback(() => {
+    // Set the uploading indicator
+    setUploading(true);
+
+    // Upload the files
+    onValidate()
+      .then(() => (
+        props.strategy === Strategy.batch
+          ? onBatchUpload()
+          : onSingleUpload()
+      ))
+      .finally(onComplete);
+  }, [onBatchUpload, onComplete, onSingleUpload, props.strategy]);
+
+  /**
+   * Validates the items on the state.
+   *
+   * @type {function(): Promise<void>}
+   */
+  const onValidate = useCallback(() => {
+    let error = false;
+
+    setItems((prevItems) => _.map(prevItems, (item) => {
+      const valid = validateItem(item);
+
+      if (!_.isEmpty(item.errors)) {
+        error = true;
+      }
+
+      return valid;
     }));
-  }
+
+    return error ? Promise.reject() : Promise.resolve();
+  }, [items]);
 
   /**
-   * Renders the FileUploadModal component.
+   * Renders the error message for the passed item.
    *
-   * @returns {*}
+   * @type {(function(*, *): (null|*))|*}
    */
-  render() {
-    return (
-      <>
-        { this.props.includeButton && (
-          <Button
-            content={this.props.button}
-            icon='cloud upload'
-            onClick={() => this.setState({ modal: true })}
-            primary
-          />
-        )}
-        { this.state.modal && (
-          <ModalContext.Consumer>
-            { (mountNode) => (
-              <Modal
-                centered={false}
-                className='file-upload-modal'
-                mountNode={mountNode}
-                open
-              >
-                <Dimmer
-                  active={this.state.saving}
-                  inverted
-                >
-                  <Loader
-                    content={i18n.t('FileUploadModal.loader')}
-                  />
-                </Dimmer>
-                { this.renderErrors() }
-                <Modal.Header
-                  content={this.props.title || i18n.t('FileUploadModal.title')}
-                />
-                <Modal.Content>
-                  <FileUpload
-                    onFilesAdded={this.onAddFiles.bind(this)}
-                  />
-                  { this.renderItems() }
-                </Modal.Content>
-                <Modal.Actions>
-                  <Button
-                    content={i18n.t('Common.buttons.save')}
-                    disabled={!(this.state.items && this.state.items.length)}
-                    primary
-                    onClick={this.onSave.bind(this)}
-                  />
-                  <Button
-                    basic
-                    content={i18n.t('Common.buttons.cancel')}
-                    onClick={this.onClose.bind(this)}
-                  />
-                </Modal.Actions>
-              </Modal>
-            )}
-          </ModalContext.Consumer>
-        )}
-      </>
-    );
-  }
-
-  /**
-   * Renders the error modal.
-   *
-   * @returns {null|*}
-   */
-  renderErrors() {
-    if (!this.hasErrors()) {
-      return null;
-    }
-
-    return (
-      <Toaster
-        onDismiss={this.onDismissErrors.bind(this)}
-        timeout={0}
-        type={Toaster.MessageTypes.negative}
-      >
-        <Message.Header
-          content={i18n.t('Common.messages.error.header')}
-        />
-        <Message.List>
-          { _.map(this.state.items, this.renderMessageItem.bind(this)) }
-        </Message.List>
-      </Toaster>
-    );
-  }
-
-  /**
-   * Renders the passed item.
-   *
-   * @param item
-   *
-   * @returns {*}
-   */
-  renderItem(item: any) {
-    const FileItem = this.props.itemComponent;
-
-    return (
-      <FileItem
-        isError={(key) => _.contains(item.errors, key)}
-        isRequired={(key) => !!this.props.required[key]}
-        item={item}
-        onAssociationInputChange={this.onAssociationInputChange.bind(this, item)}
-        onDelete={this.onDelete.bind(this, item)}
-        onTextInputChange={this.onTextInputChange.bind(this, item)}
-        onUpdate={this.onUpdate.bind(this, item)}
-      />
-    );
-  }
-
-  /**
-   * Renders the list of items.
-   *
-   * @returns {null|*}
-   */
-  renderItems() {
-    if (!(this.state.items && this.state.items.length)) {
-      return null;
-    }
-
-    return (
-      <Item.Group
-        as={Form}
-        divided
-        noValidate
-        relaxed='very'
-      >
-        { _.map(this.state.items, this.renderItem.bind(this)) }
-      </Item.Group>
-    );
-  }
-
-  /**
-   * Renders the errors message for the passed item.
-   *
-   * @param item
-   * @param index
-   *
-   * @returns {null|*}
-   */
-  renderMessageItem(item: any, index: number) {
+  const renderMessageItem = useCallback((item, index) => {
     if (_.isEmpty(item.errors)) {
       return null;
     }
 
     const filename = !_.isEmpty(item.name) ? item.name : `File ${index}`;
-    const fields = _.map(item.errors, (e) => this.props.required[e]).join(LIST_DELIMITER);
+    const fields = _.map(item.errors, (e) => props.required[e]).join(', ');
 
     return (
       <Message.Item
@@ -369,48 +277,17 @@ class FileUploadModal extends Component<Props, State> {
         key={index}
       />
     );
-  }
-
-  /**
-   * Saves the uploaded items.
-   */
-  save() {
-    if (this.hasErrors()) {
-      return;
-    }
-
-    this.setState({ saving: true }, () => {
-      this.props
-        .onSave(this.state.items)
-        .then(this.onClose.bind(this));
-    });
-  }
-
-  /**
-   * Validates the list of items.
-   */
-  validate() {
-    this.setState((state) => {
-      const items = _.map(state.items, this.validateItem.bind(this));
-
-      return {
-        items,
-        saving: !_.find(items, (item) => !_.isEmpty(item.errors))
-      };
-    }, this.save.bind(this));
-  }
+  }, []);
 
   /**
    * Validates the passed item.
    *
-   * @param item
-   *
-   * @returns {{errors: []}}
+   * @type {function(*): *&{errors: []}}
    */
-  validateItem(item: any) {
+  const validateItem = useCallback((item) => {
     const errors = [];
 
-    _.each(_.keys(this.props.required), (key) => {
+    _.each(_.keys(props.required), (key) => {
       const value = item[key];
       let invalid;
 
@@ -425,22 +302,119 @@ class FileUploadModal extends Component<Props, State> {
       }
     });
 
-    return { ...item, errors };
-  }
-}
+    return {
+      ...item,
+      errors
+    };
+  }, [props.required]);
 
-FileUploadModal.defaultProps = {
-  includeButton: true
+  /**
+   * Memoization and case correction for the <code>itemComponent</code> prop.
+   *
+   * @type {React$AbstractComponent<*, *>}
+   */
+  const UploadItem = useMemo(() => props.itemComponent, [props.itemComponent]);
+
+  return (
+    <ModalContext.Consumer>
+      { (mountNode) => (
+        <Modal
+          centered={false}
+          className='serial-upload-modal'
+          mountNode={mountNode}
+          open
+        >
+          { props.showPageLoader && (
+            <Dimmer
+              active={uploading}
+              inverted
+            >
+              <Loader
+                content={i18n.t('FileUploadModal.loader')}
+              />
+            </Dimmer>
+          )}
+          <Modal.Header>
+            { props.strategy === Strategy.batch && i18n.t('FileUploadModal.title') }
+            { props.strategy === Strategy.single && (
+              <FileUploadProgress
+                completed={uploadCount}
+                total={items.length}
+                uploading={uploading}
+              />
+            )}
+          </Modal.Header>
+          <Modal.Content
+            scrolling
+          >
+            { hasErrors && (
+              <Message
+                error
+              >
+                <Message.Header
+                  content={'An error occurred'}
+                />
+                <Message.List>
+                  { _.map(items, renderMessageItem) }
+                </Message.List>
+              </Message>
+            )}
+            <FileUpload
+              onFilesAdded={onAddFiles}
+            />
+            <Item.Group
+              as={Form}
+              divided
+              noValidate
+              relaxed='very'
+            >
+              { _.map(items, (item, index) => (
+                <UploadItem
+                  isError={(key) => _.contains(item.errors, key)}
+                  isRequired={(key) => !!(props.required && props.required[key])}
+                  item={item}
+                  key={index}
+                  onAssociationInputChange={onAssociationInputChange.bind(this, item)}
+                  onDelete={onDelete.bind(this, item)}
+                  onTextInputChange={onTextInputChange.bind(this, item)}
+                  onUpdate={onUpdate.bind(this, item)}
+                >
+                  { props.strategy === Strategy.single && (
+                    <FileUploadStatus
+                      status={statuses[index]}
+                    />
+                  )}
+                </UploadItem>
+              ))}
+            </Item.Group>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button
+              content={i18n.t('Common.buttons.upload')}
+              disabled={uploading || uploadCount > 0}
+              icon='cloud upload'
+              loading={uploading && !props.showPageLoader}
+              onClick={onUpload}
+              primary
+            />
+            <Button
+              content={uploadCount > 0
+                ? i18n.t('Common.buttons.close')
+                : i18n.t('Common.buttons.cancel')}
+              disabled={uploading}
+              onClick={props.onClose}
+            />
+          </Modal.Actions>
+        </Modal>
+      )}
+    </ModalContext.Consumer>
+  );
 };
 
-export type FileUploadProps = {
-  isError: (key: string) => boolean,
-  isRequired: (key: string) => boolean,
-  item: any,
-  onAssociationInputChange: (idKey: string, valueKey: string, item: any) => void,
-  onDelete: (item: any) => void,
-  onTextInputChange: (item: any, value: any) => void,
-  onUpdate: (item: any, props: any) => void
+FileUploadModal.defaultProps = {
+  closeOnComplete: true,
+  strategy: Strategy.batch,
+  showPageLoader: true
 };
 
 export default FileUploadModal;

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -256,22 +256,27 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
   const onValidate = useCallback(() => new Promise((resolve, reject) => {
     let error = false;
 
-    setItems((prevItems) => _.map(prevItems, (item) => {
-      const valid = validateItem(item);
+    // Validate each item
+    const newItems = _.map(items, (item) => {
+      const newItem = validateItem(item);
 
-      if (!_.isEmpty(item.errors)) {
+      if (!_.isEmpty(newItem.errors)) {
         error = true;
       }
 
-      return valid;
-    }));
+      return newItem;
+    });
 
+    // Set the new items on the state
+    setItems(newItems);
+
+    // Reject or resolve the promise
     if (error) {
       reject();
     } else {
       resolve();
     }
-  }), []);
+  }), [items]);
 
   /**
    * Updates the passed item with the passed props.

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -327,6 +327,23 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
   }, []);
 
   /**
+   * Renders the status component for the passed index.
+   *
+   * @type {(function(*): (null|*))|*}
+   */
+  const renderStatus = useCallback((index) => {
+    if (props.strategy !== Strategy.single) {
+      return null;
+    }
+
+    return (
+      <FileUploadStatus
+        status={statuses[index]}
+      />
+    );
+  }, [statuses, props.strategy]);
+
+  /**
    * Memoization and case correction for the <code>itemComponent</code> prop.
    *
    * @type {React$AbstractComponent<*, *>}
@@ -403,13 +420,8 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
                   onDelete={onDelete.bind(this, item)}
                   onTextInputChange={onTextInputChange.bind(this, item)}
                   onUpdate={onUpdate.bind(this, item)}
-                >
-                  { props.strategy === Strategy.single && (
-                    <FileUploadStatus
-                      status={statuses[index]}
-                    />
-                  )}
-                </UploadItem>
+                  renderStatus={renderStatus.bind(this, index)}
+                />
               ))}
             </Item.Group>
           </Modal.Content>

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -85,7 +85,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
   const [items, setItems] = useState([]);
   const [uploadCount, setUploadCount] = useState(0);
   const [uploading, setUploading] = useState(false);
-  const [statuses, setStatuses] = useState({});
+  // const [statuses, setStatuses] = useState({});
 
   /**
    * Sets the <code>hasErrors</code> value to <code>true</code> if at least one item on the state contains errors.
@@ -157,9 +157,13 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
    *
    * @type {function(*, *): void}
    */
-  const setStatus = useCallback((index, status) => (
-    setStatuses((prevStatuses) => ({ ...prevStatuses, [index]: status }))
-  ));
+  // const setStatus = useCallback((index, status, message = null) => (
+  //   setStatuses((prevStatuses) => ({ ...prevStatuses, [index]: { status, message } }))
+  // ));
+
+  const setStatus = useCallback((item, status, message = null) => (
+    setItems(_.map(items, (i) => (i !== item ? i : { ...i, status, errors: [message] })))
+  ), [items]);
 
   /**
    * Iterates of the list of items and sequentially calls the <code>onSave</code> prop for each.
@@ -173,19 +177,19 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
       // Update the status for the item
       setStatus(i, Status.processing);
 
-      let error = false;
+      let error;
 
       // Do the upload
       try {
         // eslint-disable-next-line no-await-in-loop
         await props.onSave(item);
       } catch (e) {
-        error = true;
+        error = e;
       }
 
       // Update the status for the item
       if (error) {
-        setStatus(i, Status.error);
+        setStatus(i, Status.error, error.message);
       } else {
         setStatus(i, Status.complete);
       }
@@ -391,7 +395,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
                 >
                   { props.strategy === Strategy.single && (
                     <FileUploadStatus
-                      status={statuses[index]}
+                      status={item.status}
                     />
                   )}
                 </UploadItem>

--- a/packages/semantic-ui/src/components/FileUploadProgress.css
+++ b/packages/semantic-ui/src/components/FileUploadProgress.css
@@ -1,0 +1,24 @@
+.file-upload-progress {
+  display: flex;
+  align-items: center;
+}
+
+.file-upload-progress > .progress-container {
+  display: flex;
+  flex-direction: column;
+  margin-left: 20px;
+  width: 100%;
+}
+
+.file-upload-progress > .progress-container > .ui.header {
+  display: flex;
+  align-items: flex-end;
+}
+
+.file-upload-progress > .progress-container > .ui.header > .content {
+  margin-right: 40px;
+}
+
+.file-upload-progress > .progress-container > .progress {
+  margin-bottom: 0;
+}

--- a/packages/semantic-ui/src/components/FileUploadProgress.js
+++ b/packages/semantic-ui/src/components/FileUploadProgress.js
@@ -1,0 +1,75 @@
+// @flow
+
+import React, { useMemo, type ComponentType } from 'react';
+import { Header, Icon, Progress } from 'semantic-ui-react';
+import './FileUploadProgress.css';
+
+type Props = {
+  completed: number,
+  total: number,
+  uploading?: boolean
+};
+
+const FileUploadProgress: ComponentType<any> = (props: Props) => {
+  /**
+   * Sets the "complete" variable to "true" if the number of completed items is equal to the total and
+   * greater than zero.
+   *
+   * @type {unknown}
+   */
+  const complete = useMemo(() => (
+    props.completed > 0 && props.completed === props.total
+  ), [props.completed, props.total]);
+
+  /**
+   * Sets the percent of completed items.
+   *
+   * @type {number|number}
+   */
+  const percent = useMemo(() => (
+    props.total > 0 ? (props.completed / props.total) : 0
+  ), [props.completed, props.total]);
+
+  /**
+   * Sets the formatted percent view.
+   */
+  const percentView = useMemo(() => (
+    Number(percent)
+      .toLocaleString(undefined, {
+        style: 'percent',
+        minimumFractionDigits: 0
+      })
+  ), [percent]);
+
+  return (
+    <div
+      className='file-upload-progress'
+    >
+      <Icon
+        color='blue'
+        name='cloud upload'
+        size='big'
+      />
+      <div
+        className='progress-container'
+      >
+        <Header>
+          <Header.Content
+            content={percentView}
+          />
+          <Header.Subheader>
+            { !(props.uploading || complete) && 'Getting Started' }
+            { props.uploading && 'Uploading...' }
+            { complete && 'Completed' }
+          </Header.Subheader>
+        </Header>
+        <Progress
+          color='blue'
+          percent={percent * 100}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default FileUploadProgress;

--- a/packages/semantic-ui/src/components/FileUploadStatus.css
+++ b/packages/semantic-ui/src/components/FileUploadStatus.css
@@ -1,0 +1,3 @@
+.file-upload-status.ui.label > .loader {
+  margin-right: 1em;
+}

--- a/packages/semantic-ui/src/components/FileUploadStatus.js
+++ b/packages/semantic-ui/src/components/FileUploadStatus.js
@@ -1,0 +1,65 @@
+// @flow
+
+import React, { useMemo, type ComponentType } from 'react';
+import { Icon, Label, Loader } from 'semantic-ui-react';
+import './FileUploadStatus.css';
+
+type Props = {
+  status: string
+};
+
+const Status = {
+  pending: 'pending',
+  processing: 'processing',
+  complete: 'complete',
+  error: 'error'
+};
+
+const ColorsByStatus = {
+  [Status.processing]: 'black',
+  [Status.complete]: 'green',
+  [Status.error]: 'red'
+};
+
+const IconsByStatus = {
+  [Status.pending]: 'clock outline',
+  [Status.complete]: 'checkmark',
+  [Status.error]: 'warning circle'
+};
+
+const TextByStatus = {
+  [Status.pending]: 'Pending',
+  [Status.processing]: 'Processing',
+  [Status.complete]: 'Complete',
+  [Status.error]: 'Error'
+};
+
+const FileUploadStatus: ComponentType<any> = ({ status = Status.pending }: Props) => {
+  const color = useMemo(() => ColorsByStatus[status], [status]);
+  const icon = useMemo(() => IconsByStatus[status], [status]);
+  const text = useMemo(() => TextByStatus[status], [status]);
+
+  return (
+    <Label
+      className='file-upload-status'
+      color={color}
+    >
+      { status === Status.processing && (
+        <Loader
+          active
+          inline
+          inverted
+          size='mini'
+        />
+      )}
+      { icon && (
+        <Icon
+          name={icon}
+        />
+      )}
+      { text }
+    </Label>
+  );
+};
+
+export default FileUploadStatus;

--- a/packages/semantic-ui/src/i18n/en.json
+++ b/packages/semantic-ui/src/i18n/en.json
@@ -128,7 +128,8 @@
   },
   "FileUploadModal": {
     "errors": {
-      "required": "{{filename}} - The following fields are required: {{fields}}"
+      "header": "There was an error processing your files",
+      "required": "File {{filename}} - The following fields are required: {{fields}}"
     },
     "loader": "Uploading files...",
     "title": "Upload Files"

--- a/packages/semantic-ui/src/i18n/en.json
+++ b/packages/semantic-ui/src/i18n/en.json
@@ -129,7 +129,11 @@
   "FileUploadModal": {
     "errors": {
       "header": "There was an error processing your files",
-      "required": "File {{filename}} - The following fields are required: {{fields}}"
+      "required": "File {{filename}} - The following fields are required: {{fields}}",
+      "upload": {
+        "content": "Check the status on each file to see which were unsuccessful.",
+        "header": "Some of the files did not upload"
+      }
     },
     "loader": "Uploading files...",
     "title": "Upload Files"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.5",
+  "version": "1.0.4-beta.6",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.3",
+  "version": "1.0.4-beta.4",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.3",
+  "version": "1.0.4-beta.0",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.1",
+  "version": "1.0.4-beta.2",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.8",
+  "version": "1.0.4-beta.9",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.4",
+  "version": "1.0.4-beta.5",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.2",
+  "version": "1.0.4-beta.3",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.9",
+  "version": "1.0.4",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.0",
+  "version": "1.0.4-beta.1",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.7",
+  "version": "1.0.4-beta.8",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.4-beta.6",
+  "version": "1.0.4-beta.7",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/storybook/src/semantic-ui/FileUploadModal.modules.js
+++ b/packages/storybook/src/semantic-ui/FileUploadModal.modules.js
@@ -33,7 +33,11 @@ export const Default = withWrapper((props) => (
         value={item.name || ''}
       />
     )}
-    onAddFile={(file) => file}
+    onAddFile={(file) => ({
+      name: file.name,
+      content: file,
+      type: file.type
+    })}
     onClose={props.onClose}
     onSave={() => {
       action('save')();
@@ -94,7 +98,7 @@ export const Images = withWrapper((props) => (
     itemComponent={({ item, onTextInputChange }) => (
       <Item>
         <Item.Image
-          src={URL.createObjectURL(item)}
+          src={URL.createObjectURL(item.content)}
         />
         <Item.Content>
           <Form.Input
@@ -105,7 +109,11 @@ export const Images = withWrapper((props) => (
         </Item.Content>
       </Item>
     )}
-    onAddFile={(file) => file}
+    onAddFile={(file) => ({
+      name: file.name,
+      content: file,
+      type: file.type
+    })}
     onClose={props.onClose}
     onSave={() => {
       action('save')();
@@ -120,7 +128,7 @@ export const SingleUpload = withWrapper((props) => (
     itemComponent={({ item, onTextInputChange }) => (
       <Item>
         <Item.Image
-          src={URL.createObjectURL(item)}
+          src={URL.createObjectURL(item.content)}
         />
         <Item.Content>
           <Form.Input
@@ -131,7 +139,11 @@ export const SingleUpload = withWrapper((props) => (
         </Item.Content>
       </Item>
     )}
-    onAddFile={(file) => file}
+    onAddFile={(file) => ({
+      name: file.name,
+      content: file,
+      type: file.type
+    })}
     onClose={props.onClose}
     onSave={() => {
       action('save')();

--- a/packages/storybook/src/semantic-ui/FileUploadModal.modules.js
+++ b/packages/storybook/src/semantic-ui/FileUploadModal.modules.js
@@ -125,7 +125,12 @@ export const Images = withWrapper((props) => (
 export const SingleUpload = withWrapper((props) => (
   <FileUploadModal
     closeOnComplete={false}
-    itemComponent={({ item, onTextInputChange }) => (
+    itemComponent={({
+      item,
+      onDelete,
+      onTextInputChange,
+      renderStatus
+    }) => (
       <Item>
         <Item.Image
           src={URL.createObjectURL(item.content)}
@@ -136,6 +141,13 @@ export const SingleUpload = withWrapper((props) => (
             onChange={onTextInputChange.bind(this, 'name')}
             value={item.name}
           />
+          <Button
+            basic
+            color='red'
+            icon='trash'
+            onClick={onDelete}
+          />
+          { renderStatus() }
         </Item.Content>
       </Item>
     )}

--- a/packages/storybook/src/semantic-ui/FileUploadModal.modules.js
+++ b/packages/storybook/src/semantic-ui/FileUploadModal.modules.js
@@ -1,0 +1,143 @@
+// @flow
+
+import { action } from '@storybook/addon-actions';
+import React, { useState } from 'react';
+import { Button, Form, Item } from 'semantic-ui-react';
+import FileUploadModal from '../../../semantic-ui/src/components/FileUploadModal';
+
+const withWrapper = (WrappedComponent) => (props) => {
+  const [modal, setModal] = useState(false);
+
+  return (
+    <>
+      <Button
+        content='Open'
+        primary
+        onClick={() => setModal(true)}
+      />
+      { modal && (
+        <WrappedComponent
+          {...props}
+          onClose={() => setModal(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export const Default = withWrapper((props) => (
+  <FileUploadModal
+    itemComponent={({ item }) => (
+      <Form.Input
+        label='Name'
+        value={item.name || ''}
+      />
+    )}
+    onAddFile={(file) => file}
+    onClose={props.onClose}
+    onSave={() => {
+      action('save')();
+      return Promise.resolve();
+    }}
+  />
+));
+
+export const Errors = withWrapper((props) => (
+  <FileUploadModal
+    closeOnComplete={false}
+    itemComponent={({
+      item,
+      isError,
+      isRequired,
+      onDelete,
+      onTextInputChange
+    }) => (
+      <Item>
+        <Item.Image
+          src={URL.createObjectURL(item.content)}
+        />
+        <Item.Content>
+          <Form.Input
+            error={isError('name')}
+            label='Name'
+            onChange={onTextInputChange.bind(this, 'name')}
+            required={isRequired('name')}
+            value={item.name || ''}
+          />
+          <Button
+            basic
+            color='red'
+            icon='trash'
+            onClick={onDelete}
+          />
+        </Item.Content>
+      </Item>
+    )}
+    onAddFile={(file) => ({
+      name: file.name,
+      content: file,
+      content_type: file.type
+    })}
+    onClose={props.onClose}
+    onSave={() => {
+      action('save')();
+      return Promise.resolve();
+    }}
+    required={{
+      name: 'Name'
+    }}
+  />
+));
+
+export const Images = withWrapper((props) => (
+  <FileUploadModal
+    itemComponent={({ item, onTextInputChange }) => (
+      <Item>
+        <Item.Image
+          src={URL.createObjectURL(item)}
+        />
+        <Item.Content>
+          <Form.Input
+            label='Name'
+            onChange={onTextInputChange.bind(this, 'name')}
+            value={item.name}
+          />
+        </Item.Content>
+      </Item>
+    )}
+    onAddFile={(file) => file}
+    onClose={props.onClose}
+    onSave={() => {
+      action('save')();
+      return Promise.resolve();
+    }}
+  />
+));
+
+export const SingleUpload = withWrapper((props) => (
+  <FileUploadModal
+    closeOnComplete={false}
+    itemComponent={({ item, onTextInputChange }) => (
+      <Item>
+        <Item.Image
+          src={URL.createObjectURL(item)}
+        />
+        <Item.Content>
+          <Form.Input
+            label='Name'
+            onChange={onTextInputChange.bind(this, 'name')}
+            value={item.name}
+          />
+        </Item.Content>
+      </Item>
+    )}
+    onAddFile={(file) => file}
+    onClose={props.onClose}
+    onSave={() => {
+      action('save')();
+      return Promise.resolve();
+    }}
+    showPageLoader={false}
+    strategy='single'
+  />
+));

--- a/packages/storybook/src/semantic-ui/FileUploadModal.stories.mdx
+++ b/packages/storybook/src/semantic-ui/FileUploadModal.stories.mdx
@@ -1,9 +1,13 @@
-import { action } from '@storybook/addon-actions';
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
-import { Form } from 'semantic-ui-react';
 import DocHeader from '../components/DocHeader';
 import FileUploadModal from '../../../semantic-ui/src/components/FileUploadModal';
 import PropsTable from '../components/PropsTable';
+import {
+  Default,
+  Errors,
+  Images,
+  SingleUpload
+} from './FileUploadModal.modules';
 
 <Meta
   title='Components/Semantic UI/FileUploadModal'
@@ -18,23 +22,39 @@ import PropsTable from '../components/PropsTable';
   <Story
     name='Default'
   >
-    <FileUploadModal
-      button='Upload files'
-      itemComponent={({ item }) => (
-        <Form.Input
-          label='Name'
-          value={item.name || ''}
-        />
-      )}
-      onAddFile={(file) => file}
-      onSave={() => {
-        action('save')();
-        return Promise.resolve();
-      }}
-    />
+    <Default />
   </Story>
 </Canvas>
 
 <PropsTable
   item={FileUploadModal}
 />
+
+## Errors
+The `FileUploadModal` can be configured to display error messages for required fields that are not provided.
+
+<Story
+  name='Errors'
+>
+  <Errors />
+</Story>
+
+## Images
+The component that renders each item can be customized to display images and more.
+
+<Story
+  name='Images'
+>
+  <Images />
+</Story>
+
+## Single Upload
+The `FileUploadModal` component to be configured to use one of two upload strategies:
+- **Batch**: The component will call the `onSave` prop passing all of the uploaded items, assuming the end point will process them in batch
+- **Single**: The component will call the `onSave` prop once per uploaded item, assuming the end point will process a single item
+
+<Story
+  name='Single Upload'
+>
+  <SingleUpload />
+</Story>

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.7",
+  "version": "1.0.4-beta.8",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.7",
-    "@performant-software/shared-components": "^1.0.4-beta.7",
+    "@performant-software/semantic-components": "^1.0.4-beta.8",
+    "@performant-software/shared-components": "^1.0.4-beta.8",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.2",
+  "version": "1.0.4-beta.3",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.2",
-    "@performant-software/shared-components": "^1.0.4-beta.2",
+    "@performant-software/semantic-components": "^1.0.4-beta.3",
+    "@performant-software/shared-components": "^1.0.4-beta.3",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.6",
+  "version": "1.0.4-beta.7",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.6",
-    "@performant-software/shared-components": "^1.0.4-beta.6",
+    "@performant-software/semantic-components": "^1.0.4-beta.7",
+    "@performant-software/shared-components": "^1.0.4-beta.7",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.9",
+  "version": "1.0.4",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.9",
-    "@performant-software/shared-components": "^1.0.4-beta.9",
+    "@performant-software/semantic-components": "^1.0.4",
+    "@performant-software/shared-components": "^1.0.4",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.5",
+  "version": "1.0.4-beta.6",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.5",
-    "@performant-software/shared-components": "^1.0.4-beta.5",
+    "@performant-software/semantic-components": "^1.0.4-beta.6",
+    "@performant-software/shared-components": "^1.0.4-beta.6",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.4",
+  "version": "1.0.4-beta.5",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.4",
-    "@performant-software/shared-components": "^1.0.4-beta.4",
+    "@performant-software/semantic-components": "^1.0.4-beta.5",
+    "@performant-software/shared-components": "^1.0.4-beta.5",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.3",
+  "version": "1.0.4-beta.4",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.3",
-    "@performant-software/shared-components": "^1.0.4-beta.3",
+    "@performant-software/semantic-components": "^1.0.4-beta.4",
+    "@performant-software/shared-components": "^1.0.4-beta.4",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.3",
+  "version": "1.0.4-beta.0",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.3",
-    "@performant-software/shared-components": "^1.0.3",
+    "@performant-software/semantic-components": "^1.0.4-beta.0",
+    "@performant-software/shared-components": "^1.0.4-beta.0",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.0",
+  "version": "1.0.4-beta.1",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.0",
-    "@performant-software/shared-components": "^1.0.4-beta.0",
+    "@performant-software/semantic-components": "^1.0.4-beta.1",
+    "@performant-software/shared-components": "^1.0.4-beta.1",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.1",
+  "version": "1.0.4-beta.2",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.1",
-    "@performant-software/shared-components": "^1.0.4-beta.1",
+    "@performant-software/semantic-components": "^1.0.4-beta.2",
+    "@performant-software/shared-components": "^1.0.4-beta.2",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.4-beta.8",
+  "version": "1.0.4-beta.9",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.4-beta.8",
-    "@performant-software/shared-components": "^1.0.4-beta.8",
+    "@performant-software/semantic-components": "^1.0.4-beta.9",
+    "@performant-software/shared-components": "^1.0.4-beta.9",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.8",
+  "version": "1.0.4-beta.9",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.9",
+  "version": "1.0.4",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.3",
+  "version": "1.0.4-beta.0",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.6",
+  "version": "1.0.4-beta.7",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.2",
+  "version": "1.0.4-beta.3",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.4",
+  "version": "1.0.4-beta.5",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.5",
+  "version": "1.0.4-beta.6",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.1",
+  "version": "1.0.4-beta.2",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.3",
+  "version": "1.0.4-beta.4",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.0",
+  "version": "1.0.4-beta.1",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.4-beta.7",
+  "version": "1.0.4-beta.8",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.9"
+  "version": "1.0.4"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.8"
+  "version": "1.0.4-beta.9"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.0"
+  "version": "1.0.4-beta.1"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.2"
+  "version": "1.0.4-beta.3"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.5"
+  "version": "1.0.4-beta.6"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.3"
+  "version": "1.0.4-beta.0"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.6"
+  "version": "1.0.4-beta.7"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.4"
+  "version": "1.0.4-beta.5"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.7"
+  "version": "1.0.4-beta.8"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.3"
+  "version": "1.0.4-beta.4"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.4-beta.1"
+  "version": "1.0.4-beta.2"
 }


### PR DESCRIPTION
This pull request updates the `FileUploadModal` component to implement another strategy for uploading files. Previously, the component used a bulk upload strategy, which would send all files in a single request. Now, a `strategy` prop can be proved as `batch` (which will use the normal functionality) or `single`. The `single` strategy will create one request per file, and upload using the `onSave` prop. This will resolve issues where large numbers of files are being uploaded and connections are timing out after a certain amount of time.

## Single Strategy
Single strategy mode will display a progress bar

![Screen Shot 2022-10-27 at 3 30 15 PM](https://user-images.githubusercontent.com/20641961/198381436-0f55c844-b0b7-49e8-81f3-b306b655295c.png)

## File Status
In single strategy mode, each file will display a status

![Screen Shot 2022-10-27 at 11 45 22 AM](https://user-images.githubusercontent.com/20641961/198381434-beb1e4a3-c4f3-4f37-973e-fa7f711d1429.png)