### PR TITLE
RC #180 - Rich Text Area

### DIFF
--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.8-beta.0",
+  "version": "1.0.8-beta.1",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.8-beta.0",
-    "@performant-software/shared-components": "^1.0.8-beta.0",
+    "@performant-software/semantic-components": "^1.0.8-beta.1",
+    "@performant-software/shared-components": "^1.0.8-beta.1",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.8-beta.2",
+  "version": "1.0.8",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.8-beta.2",
-    "@performant-software/shared-components": "^1.0.8-beta.2",
+    "@performant-software/semantic-components": "^1.0.8",
+    "@performant-software/shared-components": "^1.0.8",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.7",
+  "version": "1.0.8-beta.0",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.7",
-    "@performant-software/shared-components": "^1.0.7",
+    "@performant-software/semantic-components": "^1.0.8-beta.0",
+    "@performant-software/shared-components": "^1.0.8-beta.0",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.8-beta.1",
+  "version": "1.0.8-beta.2",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.8-beta.1",
-    "@performant-software/shared-components": "^1.0.8-beta.1",
+    "@performant-software/semantic-components": "^1.0.8-beta.2",
+    "@performant-software/shared-components": "^1.0.8-beta.2",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.7",
+  "version": "1.0.8-beta.0",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.7",
+    "@performant-software/shared-components": "^1.0.8-beta.0",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.8-beta.0",
+  "version": "1.0.8-beta.1",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.8-beta.0",
+    "@performant-software/shared-components": "^1.0.8-beta.1",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.8-beta.1",
+  "version": "1.0.8-beta.2",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.8-beta.1",
+    "@performant-software/shared-components": "^1.0.8-beta.2",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.8-beta.2",
+  "version": "1.0.8",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.8-beta.2",
+    "@performant-software/shared-components": "^1.0.8",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.8-beta.1",
+  "version": "1.0.8-beta.2",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.7",
+  "version": "1.0.8-beta.0",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.8-beta.0",
+  "version": "1.0.8-beta.1",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.8-beta.2",
+  "version": "1.0.8",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/src/components/IIIFViewer.js
+++ b/packages/shared/src/components/IIIFViewer.js
@@ -3,14 +3,12 @@
 import React, { lazy } from 'react';
 import withSuspense from '../hooks/Suspense';
 
-const IIIFViewer = withSuspense((props) => {
-  const CloverIIIF = lazy(() => import('@samvera/clover-iiif'));
+const CloverIIIF = lazy(() => import('@samvera/clover-iiif'));
 
-  return (
-    <CloverIIIF
-      {...props}
-    />
-  );
-});
+const IIIFViewer = withSuspense((props) => (
+  <CloverIIIF
+    {...props}
+  />
+));
 
 export default IIIFViewer;

--- a/packages/shared/src/components/RichTextArea.css
+++ b/packages/shared/src/components/RichTextArea.css
@@ -1,3 +1,5 @@
+@import 'react-quill/dist/quill.snow.css';
+
 .rich-text-area.quill {
   width: 100%;
 }

--- a/packages/shared/src/components/RichTextArea.js
+++ b/packages/shared/src/components/RichTextArea.js
@@ -13,32 +13,30 @@ type Props = {
   value: ?string
 };
 
+const ReactQuill = lazy(() => import('react-quill'));
+
 const SEARCH_EMPTY = '<p><br></p>';
 const REPLACE_EMPTY = '';
 
-const RichTextArea = withSuspense((props: Props) => {
-  const ReactQuill = lazy(() => import('react-quill'));
+const RichTextArea = withSuspense((props: Props) => (
+  <ReactQuill
+    className='rich-text-area'
+    formats={props.formats}
+    modules={props.modules}
+    onChange={(value) => {
+      let newValue = value;
 
-  return (
-    <ReactQuill
-      className='rich-text-area'
-      formats={props.formats}
-      modules={props.modules}
-      onChange={(value) => {
-        let newValue = value;
+      if (value === SEARCH_EMPTY) {
+        newValue = REPLACE_EMPTY;
+      }
 
-        if (value === SEARCH_EMPTY) {
-          newValue = REPLACE_EMPTY;
-        }
-
-        props.onChange(newValue);
-      }}
-      placeholder={props.placeholder}
-      theme='snow'
-      value={props.value}
-    />
-  );
-});
+      props.onChange(newValue);
+    }}
+    placeholder={props.placeholder}
+    theme='snow'
+    value={props.value}
+  />
+));
 
 RichTextArea.defaultProps = {
   formats: [

--- a/packages/shared/src/components/RichTextArea.js
+++ b/packages/shared/src/components/RichTextArea.js
@@ -2,7 +2,6 @@
 
 import React, { lazy } from 'react';
 import withSuspense from '../hooks/Suspense';
-import 'react-quill/dist/quill.snow.css';
 import './RichTextArea.css';
 
 type Props = {

--- a/packages/shared/src/components/RichTextArea.js
+++ b/packages/shared/src/components/RichTextArea.js
@@ -2,6 +2,7 @@
 
 import React, { lazy } from 'react';
 import withSuspense from '../hooks/Suspense';
+import 'react-quill/dist/quill.snow.css';
 import './RichTextArea.css';
 
 type Props = {
@@ -17,7 +18,6 @@ const REPLACE_EMPTY = '';
 
 const RichTextArea = withSuspense((props: Props) => {
   const ReactQuill = lazy(() => import('react-quill'));
-  lazy(() => import('react-quill/dist/quill.snow.css'));
 
   return (
     <ReactQuill

--- a/packages/shared/webpack.config.js
+++ b/packages/shared/webpack.config.js
@@ -1,3 +1,13 @@
 const { configure } = require('@performant-software/webpack-config');
+const path = require('path');
 
-module.exports = configure(__dirname);
+module.exports = configure(__dirname, {
+  resolve: {
+    alias: {
+      './react-quill/dist/quill.snow.css$': path.resolve(
+        __dirname,
+        '../../node_modules/react-quill/dist/quill.snow.css'
+      )
+    }
+  }
+});

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.8-beta.0",
+  "version": "1.0.8-beta.1",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.8-beta.0",
-    "@performant-software/shared-components": "^1.0.8-beta.0",
+    "@performant-software/semantic-components": "^1.0.8-beta.1",
+    "@performant-software/shared-components": "^1.0.8-beta.1",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.8-beta.1",
+  "version": "1.0.8-beta.2",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.8-beta.1",
-    "@performant-software/shared-components": "^1.0.8-beta.1",
+    "@performant-software/semantic-components": "^1.0.8-beta.2",
+    "@performant-software/shared-components": "^1.0.8-beta.2",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.8-beta.2",
+  "version": "1.0.8",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.8-beta.2",
-    "@performant-software/shared-components": "^1.0.8-beta.2",
+    "@performant-software/semantic-components": "^1.0.8",
+    "@performant-software/shared-components": "^1.0.8",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.7",
+  "version": "1.0.8-beta.0",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.7",
-    "@performant-software/shared-components": "^1.0.7",
+    "@performant-software/semantic-components": "^1.0.8-beta.0",
+    "@performant-software/shared-components": "^1.0.8-beta.0",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.7",
+  "version": "1.0.8-beta.0",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.8-beta.0",
+  "version": "1.0.8-beta.1",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.8-beta.1",
+  "version": "1.0.8-beta.2",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.8-beta.2",
+  "version": "1.0.8",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.8-beta.0"
+  "version": "1.0.8-beta.1"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.8-beta.2"
+  "version": "1.0.8"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.7"
+  "version": "1.0.8-beta.0"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.8-beta.1"
+  "version": "1.0.8-beta.2"
 }


### PR DESCRIPTION
This pull request fixes an issue with the RichTextArea component not rendering. The issue happened when we updated the package to be SSR-friendly by lazy loading components that have dependencies that use browser objects (`window`, `document`, etc). We also updated the CSS to be imported by React's `lazy` function, which is intended to be used only for components.

The solution was to move the lazy function import out of the function, and move the CSS into the component CSS file loaded via webpack as normal.

This fix can be tested using `v1.0.8-beta.2`.