### PR TITLE
BASIRA #230 - Expand/collapse facets

### DIFF
--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.18-beta.9",
+  "version": "1.0.18-beta.10",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.18-beta.9",
-    "@performant-software/shared-components": "^1.0.18-beta.9",
+    "@performant-software/semantic-components": "^1.0.18-beta.10",
+    "@performant-software/shared-components": "^1.0.18-beta.10",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.18-beta.9",
+  "version": "1.0.18-beta.10",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.18-beta.9",
+    "@performant-software/shared-components": "^1.0.18-beta.10",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "i18next": "^19.4.4",

--- a/packages/semantic-ui/src/components/Facet.js
+++ b/packages/semantic-ui/src/components/Facet.js
@@ -1,6 +1,11 @@
 // @flow
 
-import React, { useState, type Node, useMemo } from 'react';
+import React, {
+  useImperativeHandle,
+  useMemo,
+  useState,
+  type Node
+} from 'react';
 import {
   Accordion,
   Divider,
@@ -29,6 +34,13 @@ type Props = {
    * If `true`, a divider will be rendered between each facet in the list.
    */
   divided?: boolean,
+
+  /**
+   * React ref element to apply to the expand/collapse functions.
+   */
+  innerRef?: {
+    current: ?HTMLElement
+  },
 
   /**
    * Facet title to display at the top.
@@ -65,6 +77,14 @@ const Facet = (props: Props) => {
 
     return classNames.join(' ');
   }, [props.className, props.visible]);
+
+  /**
+   * Expose collapse/expand functions on the ref object to allow parent components to imperatively open/close.
+   */
+  useImperativeHandle(props.innerRef, () => ({
+    collapse: () => setActive(false),
+    expand: () => setActive(true)
+  }));
 
   return (
     <>

--- a/packages/semantic-ui/src/components/FacetList.js
+++ b/packages/semantic-ui/src/components/FacetList.js
@@ -2,8 +2,10 @@
 
 import { Timer } from '@performant-software/shared-components';
 import React, {
+  forwardRef,
   useCallback,
-  useEffect, useMemo,
+  useEffect,
+  useMemo,
   useRef,
   useState
 } from 'react';
@@ -50,7 +52,7 @@ const OPERATOR_AND = 'and';
  * This component is used with the `useRefinementList` hook from Instant Search Hooks. If the `searchable` prop
  * is "true", the component will also render a search box used to filter the list of facet values.
  */
-const FacetList = ({ useRefinementList, ...props }: Props) => {
+const FacetList = forwardRef(({ useRefinementList, ...props }: Props, ref: HTMLElement) => {
   const [operator, setOperator] = useState(props.defaultOperator || OPERATOR_OR);
 
   const {
@@ -63,7 +65,7 @@ const FacetList = ({ useRefinementList, ...props }: Props) => {
     toggleShowMore,
   } = useRefinementList({ ...props, operator });
 
-  const ref = useRef();
+  const searchRef = useRef();
   const [query, setQuery] = useState('');
 
   /**
@@ -79,7 +81,7 @@ const FacetList = ({ useRefinementList, ...props }: Props) => {
     searchForItems();
 
     // Refocus the input element
-    const { current: instance } = ref;
+    const { current: instance } = searchRef;
     if (instance) {
       instance.focus();
     }
@@ -129,6 +131,7 @@ const FacetList = ({ useRefinementList, ...props }: Props) => {
       className='facet-list'
       defaultActive={props.defaultActive}
       divided={props.divided}
+      innerRef={ref}
       title={props.title}
       visible={visible}
     >
@@ -146,7 +149,7 @@ const FacetList = ({ useRefinementList, ...props }: Props) => {
           onKeyDown={() => Timer.clearSearchTimer()}
           onKeyUp={() => Timer.setSearchTimer(onSearch)}
           placeholder={i18n.t('FacetList.labels.search')}
-          ref={ref}
+          ref={searchRef}
           value={query}
         />
       )}
@@ -202,7 +205,7 @@ const FacetList = ({ useRefinementList, ...props }: Props) => {
       )}
     </Facet>
   );
-};
+});
 
 FacetList.defaultProps = {
   ...Facet.defaultProps,

--- a/packages/semantic-ui/src/components/FacetSlider.js
+++ b/packages/semantic-ui/src/components/FacetSlider.js
@@ -1,7 +1,12 @@
 // @flow
 
 import Slider from 'rc-slider';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, {
+  forwardRef,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import { Grid } from 'semantic-ui-react';
 import Facet, { type Props as FacetProps } from './Facet';
 import { type RangeSliderProps } from '../types/InstantSearch';
@@ -13,7 +18,7 @@ type Props = FacetProps & RangeSliderProps;
 /**
  * This component can be used with the `useRange` hook from Instant Search Hooks.
  */
-const FacetSlider = ({ useRangeSlider, ...props }: Props) => {
+const FacetSlider = forwardRef(({ useRangeSlider, ...props }: Props, ref: HTMLElement) => {
   const {
     start,
     range,
@@ -42,6 +47,7 @@ const FacetSlider = ({ useRangeSlider, ...props }: Props) => {
     <Facet
       defaultActive={props.defaultActive}
       divided={props.divided}
+      innerRef={ref}
       title={props.title}
       visible={visible}
     >
@@ -77,7 +83,7 @@ const FacetSlider = ({ useRangeSlider, ...props }: Props) => {
       </div>
     </Facet>
   );
-};
+});
 
 FacetSlider.defaultProps = Facet.defaultProps;
 

--- a/packages/semantic-ui/src/components/FacetToggle.js
+++ b/packages/semantic-ui/src/components/FacetToggle.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useMemo } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import { Checkbox, Label } from 'semantic-ui-react';
 import Facet, { type Props as FacetProps } from './Facet';
 import { type ToggleRefinementProps } from '../types/InstantSearch';
@@ -10,7 +10,7 @@ type Props = FacetProps & ToggleRefinementProps;
 /**
  * This component is used with the `useToggleRefinement` hook from Instant Search Hooks.
  */
-const FacetToggle = ({ useToggleRefinement, ...props }: Props) => {
+const FacetToggle = forwardRef(({ useToggleRefinement, ...props }: Props, ref: HTMLElement) => {
   const {
     value: {
       isRefined,
@@ -30,6 +30,7 @@ const FacetToggle = ({ useToggleRefinement, ...props }: Props) => {
     <Facet
       defaultActive={props.defaultActive}
       divided={props.divided}
+      innerRef={ref}
       title={props.title}
       visible={visible}
     >
@@ -49,7 +50,7 @@ const FacetToggle = ({ useToggleRefinement, ...props }: Props) => {
       />
     </Facet>
   );
-};
+});
 
 FacetToggle.defaultProps = Facet.defaultProps;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.18-beta.9",
+  "version": "1.0.18-beta.10",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/storybook/src/semantic-ui/Facet.stories.js
+++ b/packages/storybook/src/semantic-ui/Facet.stories.js
@@ -1,8 +1,8 @@
 // @flow
 
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
-import { Checkbox, Form } from 'semantic-ui-react';
+import React, { useCallback, useRef } from 'react';
+import { Button, Checkbox, Form } from 'semantic-ui-react';
 import Facet from '../../../semantic-ui/src/components/Facet';
 
 export default {
@@ -137,3 +137,73 @@ export const Divided = () => (
     </Facet>
   </>
 );
+
+export const ExpandCollapse = () => {
+  const ref = useRef();
+
+  /**
+   * Collapses the facet via the imperative function.
+   *
+   * @type {(function(): void)|*}
+   */
+  const onCollapse = useCallback(() => {
+    const { current: instance } = ref;
+
+    if (instance) {
+      instance.collapse();
+    }
+  }, [ref.current]);
+
+  /**
+   * Expands the facet via the imperative function.
+   *
+   * @type {(function(): void)|*}
+   */
+  const onExpand = useCallback(() => {
+    const { current: instance } = ref;
+
+    if (instance) {
+      instance.expand();
+    }
+  }, [ref.current]);
+
+  return (
+    <>
+      <Facet
+        innerRef={ref}
+        title='Department'
+      >
+        <Form>
+          <Form.Field>
+            <Checkbox
+              label='Appliances'
+            />
+          </Form.Field>
+          <Form.Field>
+            <Checkbox
+              label='Bath & Faucets'
+            />
+          </Form.Field>
+          <Form.Field>
+            <Checkbox
+              label='Building Materials'
+            />
+          </Form.Field>
+          <Form.Field>
+            <Checkbox
+              label='Doors & Windows'
+            />
+          </Form.Field>
+        </Form>
+      </Facet>
+      <Button
+        content='Expand'
+        onClick={onExpand}
+      />
+      <Button
+        content='Collapse'
+        onClick={onCollapse}
+      />
+    </>
+  );
+};

--- a/packages/storybook/src/semantic-ui/FacetList.stories.js
+++ b/packages/storybook/src/semantic-ui/FacetList.stories.js
@@ -1,7 +1,8 @@
 // @flow
 
 import { action } from '@storybook/addon-actions';
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
+import { Button } from 'semantic-ui-react';
 import FacetList from '../../../semantic-ui/src/components/FacetList';
 
 export default {
@@ -146,3 +147,83 @@ export const Toggleable = () => (
     })}
   />
 );
+
+export const ExpandCollapse = () => {
+  const ref = useRef();
+
+  /**
+   * Collapses the facet via the imperative function.
+   *
+   * @type {(function(): void)|*}
+   */
+  const onCollapse = useCallback(() => {
+    const { current: instance } = ref;
+
+    if (instance) {
+      instance.collapse();
+    }
+  }, [ref.current]);
+
+  /**
+   * Expands the facet via the imperative function.
+   *
+   * @type {(function(): void)|*}
+   */
+  const onExpand = useCallback(() => {
+    const { current: instance } = ref;
+
+    if (instance) {
+      instance.expand();
+    }
+  }, [ref.current]);
+
+  return (
+    <>
+      <FacetList
+        ref={ref}
+        toggleable
+        title='States'
+        useRefinementList={() => ({
+          items: [{
+            label: 'Alabama',
+            count: 55,
+            value: 'alabama'
+          }, {
+            label: 'Alaska',
+            count: 3,
+            value: 'alaska'
+          }, {
+            label: 'Arizona',
+            count: 70,
+            value: 'arizona'
+          }, {
+            label: 'Arkansas',
+            count: 12,
+            value: 'arkansas'
+          }, {
+            label: 'California',
+            count: 269,
+            value: 'california'
+          }, {
+            label: 'Colorado',
+            count: 100,
+            value: 'colorado'
+          }],
+          refine: action('refine'),
+          canToggleShowMore: true,
+          isShowingMore: false,
+          searchForItems: action('search'),
+          toggleShowMore: action('show more')
+        })}
+      />
+      <Button
+        content='Expand'
+        onClick={onExpand}
+      />
+      <Button
+        content='Collapse'
+        onClick={onCollapse}
+      />
+    </>
+  );
+};

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.18-beta.9",
+  "version": "1.0.18-beta.10",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.18-beta.9",
-    "@performant-software/shared-components": "^1.0.18-beta.9",
+    "@performant-software/semantic-components": "^1.0.18-beta.10",
+    "@performant-software/shared-components": "^1.0.18-beta.10",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.18-beta.9",
+  "version": "1.0.18-beta.10",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.18-beta.9"
+  "version": "1.0.18-beta.10"
 }


### PR DESCRIPTION
This pull request implements the imperative `expand` and `collapse` functions for the Facet component. The motivation for this is to give parent components a way to control the `active` state without having to make the Facet component controlled.

**Note:** This pull request also contains the changes in #195 and #196.