### PR TITLE
CDC #2 - Projects

### DIFF
--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.19-beta.2",
+  "version": "1.0.19-beta.3",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.19-beta.2",
-    "@performant-software/shared-components": "^1.0.19-beta.2",
+    "@performant-software/semantic-components": "^1.0.19-beta.3",
+    "@performant-software/shared-components": "^1.0.19-beta.3",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.19-beta.1",
+  "version": "1.0.19-beta.2",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.19-beta.1",
-    "@performant-software/shared-components": "^1.0.19-beta.1",
+    "@performant-software/semantic-components": "^1.0.19-beta.2",
+    "@performant-software/shared-components": "^1.0.19-beta.2",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.18",
+  "version": "1.0.19-beta.0",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.18",
-    "@performant-software/shared-components": "^1.0.18",
+    "@performant-software/semantic-components": "^1.0.19-beta.0",
+    "@performant-software/shared-components": "^1.0.19-beta.0",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.19-beta.3",
+  "version": "1.0.19",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.19-beta.3",
-    "@performant-software/shared-components": "^1.0.19-beta.3",
+    "@performant-software/semantic-components": "^1.0.19",
+    "@performant-software/shared-components": "^1.0.19",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "1.0.19-beta.0",
+  "version": "1.0.19-beta.1",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,8 +12,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.19-beta.0",
-    "@performant-software/shared-components": "^1.0.19-beta.0",
+    "@performant-software/semantic-components": "^1.0.19-beta.1",
+    "@performant-software/shared-components": "^1.0.19-beta.1",
     "i18next": "^21.9.2",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.19-beta.1",
+  "version": "1.0.19-beta.2",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.19-beta.1",
+    "@performant-software/shared-components": "^1.0.19-beta.2",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "i18next": "^19.4.4",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.19-beta.2",
+  "version": "1.0.19-beta.3",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.19-beta.2",
+    "@performant-software/shared-components": "^1.0.19-beta.3",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "i18next": "^19.4.4",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.18",
+  "version": "1.0.19-beta.0",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.18",
+    "@performant-software/shared-components": "^1.0.19-beta.0",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "i18next": "^19.4.4",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.19-beta.3",
+  "version": "1.0.19",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.19-beta.3",
+    "@performant-software/shared-components": "^1.0.19",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "i18next": "^19.4.4",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "1.0.19-beta.0",
+  "version": "1.0.19-beta.1",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -12,7 +12,7 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/shared-components": "^1.0.19-beta.0",
+    "@performant-software/shared-components": "^1.0.19-beta.1",
     "@react-google-maps/api": "^2.8.1",
     "axios": "^0.26.1",
     "i18next": "^19.4.4",

--- a/packages/semantic-ui/src/components/BreadcrumbItem.js
+++ b/packages/semantic-ui/src/components/BreadcrumbItem.js
@@ -1,0 +1,69 @@
+// @flow
+
+import React, { useEffect, useState, type ComponentType } from 'react';
+import { Breadcrumb, Loader } from 'semantic-ui-react';
+
+type Props = {
+  active: boolean,
+  as?: ComponentType<any>,
+  id?: number,
+  label?: string,
+  name: string,
+  onLoad: (id: number, name: string) => Promise<any>,
+  url: string
+};
+
+const BreadcrumbItem: ComponentType<any> = (props: Props) => {
+  const [loading, setLoading] = useState(false);
+  const [name, setName] = useState(null);
+
+  /**
+   * Sets or clears the name attribute on the state.
+   */
+  useEffect(() => {
+    if (props.id) {
+      props
+        .onLoad(props.id, props.name)
+        .then((n) => setName(n))
+        .finally(() => setLoading(false));
+
+      setLoading(true);
+    } else {
+      setName(null);
+    }
+  }, [props.id, props.name]);
+
+  return (
+    <>
+      <Breadcrumb.Section
+        active={props.active && !props.id}
+        as={props.as}
+        to={`/${props.url}`}
+      >
+        { props.label }
+      </Breadcrumb.Section>
+      { props.id && (
+        <Breadcrumb.Divider
+          icon='right chevron'
+        />
+      )}
+      { loading && (
+        <Loader
+          active
+          inline
+        />
+      )}
+      { name && props.id && (
+        <Breadcrumb.Section
+          active={props.active}
+          as={props.as}
+          to={`/${props.url}/${props.id}`}
+        >
+          { name }
+        </Breadcrumb.Section>
+      )}
+    </>
+  );
+};
+
+export default BreadcrumbItem;

--- a/packages/semantic-ui/src/components/Breadcrumbs.css
+++ b/packages/semantic-ui/src/components/Breadcrumbs.css
@@ -1,0 +1,4 @@
+.ui.breadcrumb:first-child {
+  margin-bottom: 1em;
+  margin-top: 0.5em;
+}

--- a/packages/semantic-ui/src/components/Breadcrumbs.js
+++ b/packages/semantic-ui/src/components/Breadcrumbs.js
@@ -1,0 +1,111 @@
+// @flow
+
+import React, { useCallback, useMemo, type ComponentType } from 'react';
+import { Breadcrumb } from 'semantic-ui-react';
+import _ from 'underscore';
+import BreadcrumbItem from './BreadcrumbItem';
+import './Breadcrumbs.css';
+
+const URL_DELIMITER = '/';
+
+type Props = {
+  /**
+   * Alternate component to use to render the breadcrumb.
+   */
+  as?: ComponentType<any>,
+
+  /**
+   * A key-value pair of types to labels to match the `pathname`.
+   */
+  labels: { key: string, value: string },
+
+  /**
+   * Callback fired to lookup the name of the passed breadcrumb item.
+   */
+  onLoad: (id: number, name: string) => Promise<any>,
+
+  /**
+   * The URL for which to generate the breadcrumb.
+   */
+  pathname: string
+};
+
+/**
+ * This component can be used to render a breadcrumb for the passed URL.
+ */
+const Breadcrumbs: ComponentType<any> = (props: Props) => {
+  /**
+   * Returns true if the passed string contains only digits.
+   *
+   * @type {function(*): boolean}
+   */
+  const isNumeric = useCallback((str: string) => /^\d+$/.test(str), []);
+
+  /**
+   * Sets the items to display based on the URL path.
+   *
+   * @type {[]}
+   */
+  const items = useMemo(() => {
+    const value = [];
+
+    const path = props.pathname.split(URL_DELIMITER).splice(1);
+
+    for (let i = 0; i < path.length; i += 1) {
+      const key = path[i];
+      const id = path[i + 1];
+      const url = path.slice(0, i + 1).join(URL_DELIMITER);
+
+      /*
+       * If the item in the path is non-numeric, we'll add it as the item label.
+       * If the next item is numeric, we'll add it as the ID.
+       * If the next item is non-numeric, it'll be added as a separate label on the next iteration.
+       */
+      if (!isNumeric(key)) {
+        const item = { key, url, id: undefined };
+
+        if (isNumeric(id)) {
+          item.id = id;
+        }
+
+        value.push(item);
+      }
+    }
+
+    return value;
+  }, [props.pathname]);
+
+  /**
+   * Returns true if there are more items to display.
+   *
+   * @type {function(*): boolean}
+   */
+  const hasMore = useCallback((index: number) => index < (items.length - 1), [items]);
+
+  return (
+    <Breadcrumb
+      size='large'
+    >
+      { _.map(items, (item, index) => (
+        <>
+          <BreadcrumbItem
+            active={!hasMore(index)}
+            as={props.as}
+            id={item.id}
+            label={props.labels[item.key]}
+            name={item.key}
+            onLoad={props.onLoad}
+            url={item.url}
+          />
+          { hasMore(index) && (
+            <Breadcrumb.Divider
+              icon='right chevron'
+            />
+          )}
+        </>
+      ))}
+    </Breadcrumb>
+  );
+};
+
+export default Breadcrumbs;

--- a/packages/semantic-ui/src/components/ItemsToggle.js
+++ b/packages/semantic-ui/src/components/ItemsToggle.js
@@ -72,6 +72,15 @@ const useItemsToggle = (WrappedComponent: ComponentType<any>) => (
     }
 
     /**
+     * Returns true if the component should be hidden.
+     *
+     * @returns {boolean|*}
+     */
+    isHidden() {
+      return this.props.hideToggle && _.isEmpty(this.props.sort);
+    }
+
+    /**
      * Calls the onSort prop.
      *
      * @param sort
@@ -98,7 +107,7 @@ const useItemsToggle = (WrappedComponent: ComponentType<any>) => (
      * @returns {*}
      */
     render() {
-      const renderListHeader = this.props.hideToggle
+      const renderListHeader = this.isHidden()
         ? undefined
         : this.renderHeader.bind(this);
 
@@ -121,27 +130,31 @@ const useItemsToggle = (WrappedComponent: ComponentType<any>) => (
      * @returns {*}
      */
     renderHeader() {
-      if (this.props.hideToggle) {
+      if (this.isHidden()) {
         return null;
       }
 
       return (
         <>
-          <Button
-            active={this.state.view === Views.list}
-            aria-label='List View'
-            basic
-            icon='list'
-            onClick={() => this.setState({ view: Views.list })}
-          />
-          <Button
-            active={this.state.view === Views.grid}
-            aria-label='Grid View'
-            basic
-            icon='grid layout'
-            onClick={() => this.setState({ view: Views.grid })}
-          />
-          { this.props.sort && this.props.sort.length > 1 && this.props.onSort && (
+          { !this.props.hideToggle && (
+            <>
+              <Button
+                active={this.state.view === Views.list}
+                aria-label='List View'
+                basic
+                icon='list'
+                onClick={() => this.setState({ view: Views.list })}
+              />
+              <Button
+                active={this.state.view === Views.grid}
+                aria-label='Grid View'
+                basic
+                icon='grid layout'
+                onClick={() => this.setState({ view: Views.grid })}
+              />
+            </>
+          )}
+          { !_.isEmpty(this.props.sort) && this.props.onSort && (
             <Button.Group
               basic
               style={{

--- a/packages/semantic-ui/src/components/SimpleEditPage.css
+++ b/packages/semantic-ui/src/components/SimpleEditPage.css
@@ -1,0 +1,7 @@
+.simple-edit-page.ui.grid {
+  padding-bottom: 2.5em;
+}
+
+.simple-edit-page .menu .item.button-container > .button {
+  margin-right: 0.25em;
+}

--- a/packages/semantic-ui/src/components/SimpleEditPage.js
+++ b/packages/semantic-ui/src/components/SimpleEditPage.js
@@ -1,0 +1,246 @@
+// @flow
+
+import { Element } from '@performant-software/shared-components';
+import type { EditContainerProps } from '@performant-software/shared-components/types';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import {
+  Button,
+  Form,
+  Grid,
+  Menu,
+  MenuProps,
+  Message,
+  Ref,
+  Sticky
+} from 'semantic-ui-react';
+import _ from 'underscore';
+import i18n from '../i18n/i18n';
+import Toaster from './Toaster';
+import './SimpleEditPage.css';
+
+type Props = EditContainerProps & {
+  /**
+   * Additional class attribute to apply to the root DOM element.
+   */
+  className?: string,
+
+  /**
+   * Sets the default visible tab. If no value is provided, the first tab will be visible.
+   */
+  defaultTab?: string,
+
+  /**
+   * Props to provide to the Semantic UI `Menu` component.
+   */
+  menuProps?: typeof MenuProps,
+
+  /**
+   * Callback fired when the "Cancel" button is clicked.
+   */
+  onCancel: () => void,
+
+  /**
+   * Callback fired when a tab is clicked.
+   *
+   * @param tab
+   */
+  onTabClick?: (tab: string) => void,
+
+  /**
+   * If `true`, the saved toaster will display when the component is mounted.
+   */
+  saved?: boolean,
+
+  /**
+   * If `true`, the tabs menu will "stick" to the top of the window.
+   */
+  stickyMenu?: boolean
+};
+
+/**
+ * This component can be used to render the layout for a form/page with edit capabilities. Use in conjunction with the
+ * `withEditPage` higher-order component for a fully fledged record editing environment.
+ */
+const SimpleEditPage: any = (props: Props) => {
+  const [currentTab, setCurrentTab] = useState();
+  const [saved, setSaved] = useState(false);
+
+  const contentRef = useRef();
+
+  // $FlowIgnore
+  const tabs = Element.findByType(props.children, SimpleEditPage.Tab);
+  const tab = useMemo(() => _.find(tabs, (nextTab) => nextTab.key === currentTab), [currentTab, tabs]);
+
+  /**
+   * Memo-izes the class name variable.
+   *
+   * @type {string}
+   */
+  const className = useMemo(() => {
+    const classNames = ['simple-edit-page'];
+
+    if (props.className) {
+      classNames.push(props.className);
+    }
+
+    return classNames.join(' ');
+  }, [props.className]);
+
+  /**
+   * Sets the current tab.
+   *
+   * @type {(function(*): void)|*}
+   */
+  const onTabClick = useCallback((item) => {
+    const { key } = item;
+    setCurrentTab(key);
+
+    if (props.onTabClick) {
+      props.onTabClick(key);
+    }
+  }, [props.onTabClick]);
+
+  /**
+   * Renders the tab menu component.
+   *
+   * @type {(function(): (*))|*}
+   */
+  const renderTabs = useCallback(() => {
+    const menu = (
+      <Menu
+        {...props.menuProps}
+      >
+        { tabs?.length > 1 && _.map(tabs, (item) => (
+          <Menu.Item
+            active={item.key === currentTab}
+            disabled={props.loading || props.saving}
+            key={item.key}
+            name={item.props.name}
+            onClick={() => onTabClick(item)}
+          />
+        ))}
+        <Menu.Menu
+          position='right'
+        >
+          <Menu.Item
+            className='button-container'
+          >
+            <Button
+              content={i18n.t('Common.buttons.save')}
+              disabled={props.loading || props.saving}
+              onClick={props.onSave}
+              primary
+            />
+            <Button
+              basic
+              content={i18n.t('Common.buttons.cancel')}
+              disabled={props.loading || props.saving}
+              onClick={props.onCancel}
+            />
+          </Menu.Item>
+        </Menu.Menu>
+      </Menu>
+    );
+
+    if (props.stickyMenu) {
+      return (
+        <Sticky
+          context={contentRef}
+          offset={20}
+        >
+          { menu }
+        </Sticky>
+      );
+    }
+
+    return menu;
+  });
+
+  useEffect(() => {
+    // Sets the default tab to the first tab in the list, or the tab on the URL state
+    let defaultTab;
+
+    if (props.defaultTab) {
+      defaultTab = { key: props.defaultTab };
+    } else {
+      defaultTab = _.first(tabs);
+    }
+
+    if (defaultTab) {
+      onTabClick(defaultTab);
+    }
+
+    // Sets the saved indicator based on the URL state
+    if (props.saved) {
+      setSaved(true);
+    }
+  }, []);
+
+  return (
+    <Grid
+      className={className}
+    >
+      <Grid.Row>
+        <Grid.Column>
+          { renderTabs() }
+        </Grid.Column>
+      </Grid.Row>
+      <Grid.Row>
+        <Grid.Column>
+          <Ref
+            innerRef={contentRef}
+          >
+            <div>
+              <Form
+                error={!_.isEmpty(props.errors)}
+                loading={props.loading || props.saving}
+                noValidate
+              >
+                <Message
+                  error
+                  header={i18n.t('Common.errors.save')}
+                  list={props.errors}
+                />
+                { tab && tab.props.children }
+              </Form>
+              { saved && (
+                <Toaster
+                  onDismiss={() => setSaved(false)}
+                  type={Toaster.MessageTypes.positive}
+                >
+                  <Message.Header
+                    content={i18n.t('Common.messages.save.header')}
+                  />
+                  <Message.Content
+                    content={i18n.t('Common.messages.save.content')}
+                  />
+                </Toaster>
+              )}
+            </div>
+          </Ref>
+        </Grid.Column>
+      </Grid.Row>
+    </Grid>
+  );
+};
+
+SimpleEditPage.defaultProps = {
+  menuProps: {
+    pointing: true,
+    secondary: true
+  }
+};
+
+const Tab = (props: any) => props.children;
+Tab.displayName = 'Tab';
+
+// $FlowIgnore
+const SimpleEditPageStatic = Object.assign(SimpleEditPage, { Tab });
+
+export default SimpleEditPageStatic;

--- a/packages/semantic-ui/src/components/SimpleEditPage.js
+++ b/packages/semantic-ui/src/components/SimpleEditPage.js
@@ -36,6 +36,11 @@ type Props = EditContainerProps & {
   defaultTab?: string,
 
   /**
+   * If `false`, the save button will be hidden.
+   */
+  editable?: boolean,
+
+  /**
    * Props to provide to the Semantic UI `Menu` component.
    */
   menuProps?: typeof MenuProps,
@@ -131,12 +136,14 @@ const SimpleEditPage: any = (props: Props) => {
           <Menu.Item
             className='button-container'
           >
-            <Button
-              content={i18n.t('Common.buttons.save')}
-              disabled={props.loading || props.saving}
-              onClick={props.onSave}
-              primary
-            />
+            { props.editable && (
+              <Button
+                content={i18n.t('Common.buttons.save')}
+                disabled={props.loading || props.saving}
+                onClick={props.onSave}
+                primary
+              />
+            )}
             <Button
               basic
               content={i18n.t('Common.buttons.cancel')}
@@ -231,6 +238,7 @@ const SimpleEditPage: any = (props: Props) => {
 };
 
 SimpleEditPage.defaultProps = {
+  editable: true,
   menuProps: {
     pointing: true,
     secondary: true

--- a/packages/semantic-ui/src/i18n/en.json
+++ b/packages/semantic-ui/src/i18n/en.json
@@ -55,7 +55,9 @@
       "upload": "Upload"
     },
     "errors": {
-      "title": "Oops!"
+      "save": "There was an error saving the record.",
+      "title": "Oops!",
+      "unauthorized": "You do not have permission to access this record."
     },
     "labels": {
       "noRecords": "No records."

--- a/packages/semantic-ui/src/i18n/en.json
+++ b/packages/semantic-ui/src/i18n/en.json
@@ -31,6 +31,11 @@
       "placeholder": "Enter a URL, ISBN, DOI, PMID, arXiv ID"
     }
   },
+  "BreadcrumbItem": {
+    "labels": {
+      "new": "New"
+    }
+  },
   "Citation": {
     "labels": {
       "untitled": "Untitled"

--- a/packages/semantic-ui/src/index.js
+++ b/packages/semantic-ui/src/index.js
@@ -14,6 +14,7 @@ export { default as BibliographyForm } from './components/BibliographyForm';
 export { default as BibliographyList } from './components/BibliographyList';
 export { default as BibliographySearchInput } from './components/BibliographySearchInput';
 export { default as BooleanIcon } from './components/BooleanIcon';
+export { default as Breadcrumbs } from './components/Breadcrumbs';
 export { default as CancelButton } from './components/CancelButton';
 export { default as ColorButton } from './components/ColorButton';
 export { default as ColorPickerModal } from './components/ColorPickerModal';

--- a/packages/semantic-ui/src/index.js
+++ b/packages/semantic-ui/src/index.js
@@ -88,6 +88,7 @@ export { default as Section } from './components/Section';
 export { default as Selectize } from './components/Selectize';
 export { default as SelectizeHeader } from './components/SelectizeHeader';
 export { default as SelectizeImageHeader } from './components/SelectizeImageHeader';
+export { default as SimpleEditPage } from './components/SimpleEditPage';
 export { default as StyleSelector } from './components/StyleSelector';
 export { default as TabbedModal } from './components/TabbedModal';
 export { default as TabsMenu } from './components/TabsMenu';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.19-beta.1",
+  "version": "1.0.19-beta.2",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.19-beta.2",
+  "version": "1.0.19-beta.3",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.19-beta.3",
+  "version": "1.0.19",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.19-beta.0",
+  "version": "1.0.19-beta.1",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "1.0.18",
+  "version": "1.0.19-beta.0",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/shared/src/hooks/EditPage.js
+++ b/packages/shared/src/hooks/EditPage.js
@@ -1,0 +1,84 @@
+// @flow
+
+import React, { useCallback, type ComponentType } from 'react';
+import _ from 'underscore';
+import i18n from '../i18n/i18n';
+import useEditContainer from '../components/EditContainer';
+
+type Config = {
+  afterSave?: (item: any, tab: string) => Promise<any>,
+  id: string,
+  onCancel: () => void,
+  onInitialize: (item: any) => Promise<any>,
+  onSave: (item: any) => Promise<any>,
+  required?: Array<string>,
+  resolveValidationError?: (params: any) => any,
+  validate?: (item: any) => any
+};
+
+const withEditPage = (WrappedComponent: ComponentType<any>, config: Config): any => (props: any) => {
+  const { id } = config;
+
+  let tab;
+
+  /**
+   * Adds the authorization error.
+   *
+   * @type {function(*): {}}
+   */
+  const resolveValidationError = useCallback((errorProps) => {
+    const errors = {};
+
+    if (config.resolveValidationError) {
+      _.extend(errors, config.resolveValidationError(errorProps));
+    }
+
+    if (errorProps.status === 403) {
+      _.extend(errors, { base: i18n.t('Common.errors.unauthorized') });
+    }
+
+    return errors;
+  }, [config.resolveValidationError]);
+
+  /**
+   * Saves the passed item then calls the "afterSave" prop.
+   *
+   * @type {function(*): *}
+   */
+  const onSave = useCallback((item) => (
+    config
+      .onSave(item)
+      .then((record) => config.afterSave && config.afterSave(record, tab))
+  ), [config.afterSave, config.onSave]);
+
+  // eslint-disable-next-line react/no-unstable-nested-components
+  const EditPage = (innerProps: any) => (
+    <WrappedComponent
+      {...innerProps}
+      onTabClick={(newTab) => {
+        tab = newTab;
+      }}
+    />
+  );
+
+  const EditContainer = useEditContainer(EditPage);
+
+  return (
+    <EditContainer
+      {...props}
+      item={{ id }}
+      onCancel={config.onCancel}
+      onInitialize={config.onInitialize}
+      onSave={onSave}
+      required={config.required}
+      resolveValidationError={resolveValidationError}
+      validate={config.validate}
+    />
+  );
+};
+
+export default withEditPage;
+
+export type {
+  Config
+};

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -12,6 +12,7 @@ export { default as RichTextArea } from './components/RichTextArea';
 
 // Hooks
 export { default as useCitationStyles } from './hooks/CitationStyles';
+export { default as withEditPage } from './hooks/EditPage';
 
 // I18n
 export { default as i18n } from './i18n/i18n';
@@ -41,6 +42,7 @@ export { default as Timer } from './utils/Timer';
 
 // Types
 export type { CitationsStyleProps } from './hooks/CitationStyles';
+export type { Config as EditPageConfig } from './hooks/EditPage';
 export type { EditContainerProps as EditModalProps } from './components/EditContainer'; // Backwards compatability
 export type { EditContainerProps } from './components/EditContainer';
 export type { RichTextAreaProps } from './components/RichTextArea';

--- a/packages/storybook/src/semantic-ui/Breadcrumbs.stories.js
+++ b/packages/storybook/src/semantic-ui/Breadcrumbs.stories.js
@@ -1,0 +1,19 @@
+// @flow
+
+import React from 'react';
+import Breadcrumbs from '../../../semantic-ui/src/components/Breadcrumbs';
+
+export default {
+  title: 'Components/Semantic UI/Breadcrumbs',
+  component: Breadcrumbs
+};
+
+export const Default = () => (
+  <Breadcrumbs
+    labels={{
+      books: 'Books'
+    }}
+    onLoad={() => Promise.resolve('Great Expectations')}
+    pathname='/books/12'
+  />
+);

--- a/packages/storybook/src/semantic-ui/SimpleEditPage.stories.js
+++ b/packages/storybook/src/semantic-ui/SimpleEditPage.stories.js
@@ -1,0 +1,32 @@
+// @flow
+
+import { action } from '@storybook/addon-actions';
+import React from 'react';
+import { Form } from 'semantic-ui-react';
+import SimpleEditPage from '../../../semantic-ui/src/components/SimpleEditPage';
+
+export default {
+  title: 'Components/Semantic UI/SimpleEditPage',
+  component: SimpleEditPage
+};
+
+export const Default = () => (
+  <SimpleEditPage
+    menuProps={{
+      text: true
+    }}
+    onCancel={action('cancel')}
+  >
+    <SimpleEditPage.Tab
+      key='default'
+    >
+      <Form.Input
+        autoFocus
+        label='Name'
+      />
+      <Form.Input
+        label='Address'
+      />
+    </SimpleEditPage.Tab>
+  </SimpleEditPage>
+);

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.19-beta.0",
+  "version": "1.0.19-beta.1",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.19-beta.0",
-    "@performant-software/shared-components": "^1.0.19-beta.0",
+    "@performant-software/semantic-components": "^1.0.19-beta.1",
+    "@performant-software/shared-components": "^1.0.19-beta.1",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.19-beta.3",
+  "version": "1.0.19",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.19-beta.3",
-    "@performant-software/shared-components": "^1.0.19-beta.3",
+    "@performant-software/semantic-components": "^1.0.19",
+    "@performant-software/shared-components": "^1.0.19",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.19-beta.1",
+  "version": "1.0.19-beta.2",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.19-beta.1",
-    "@performant-software/shared-components": "^1.0.19-beta.1",
+    "@performant-software/semantic-components": "^1.0.19-beta.2",
+    "@performant-software/shared-components": "^1.0.19-beta.2",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.18",
+  "version": "1.0.19-beta.0",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.18",
-    "@performant-software/shared-components": "^1.0.18",
+    "@performant-software/semantic-components": "^1.0.19-beta.0",
+    "@performant-software/shared-components": "^1.0.19-beta.0",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "1.0.19-beta.2",
+  "version": "1.0.19-beta.3",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./build/index.js",
@@ -9,8 +9,8 @@
     "build": "webpack --mode production && flow-copy-source -v src types"
   },
   "dependencies": {
-    "@performant-software/semantic-components": "^1.0.19-beta.2",
-    "@performant-software/shared-components": "^1.0.19-beta.2",
+    "@performant-software/semantic-components": "^1.0.19-beta.3",
+    "@performant-software/shared-components": "^1.0.19-beta.3",
     "i18next": "^21.9.1",
     "semantic-ui-react": "^2.1.2",
     "underscore": "^1.13.2"

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.19-beta.0",
+  "version": "1.0.19-beta.1",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.18",
+  "version": "1.0.19-beta.0",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.19-beta.2",
+  "version": "1.0.19-beta.3",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.19-beta.1",
+  "version": "1.0.19-beta.2",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "1.0.19-beta.3",
+  "version": "1.0.19",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./build/index.js",

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.19-beta.3"
+  "version": "1.0.19"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.19-beta.0"
+  "version": "1.0.19-beta.1"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.19-beta.2"
+  "version": "1.0.19-beta.3"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.19-beta.1"
+  "version": "1.0.19-beta.2"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -6,5 +6,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "1.0.18"
+  "version": "1.0.19-beta.0"
 }


### PR DESCRIPTION
This pull request adds the following components:
- useEditPage - a wrapper for the `useEditContainer` hook, simplifying the onSave and validation
- SimpleEditPage - used to render an edit page with simple tab interface
- Breadcrumbs - Parses the URL and renders breadcrumbs as links

Fixes the following bugs:
- Fixes an issue in the ItemToggle component where the sort dropdown was being hidden when the view icon was hidden