### PR TITLE
Add Storybook doc page for the ListLoader component

### DIFF
--- a/packages/semantic-ui/src/components/ListLoader.js
+++ b/packages/semantic-ui/src/components/ListLoader.js
@@ -7,13 +7,13 @@ import './ListLoader.css';
 
 type Props = {
   /**
-   * Loaders are hidden unless has prop active or inside an Dimmer active.
+   * If true, the list loader spinner will display.
    */
   active: boolean
 };
 
 /**
- * A loader alerts a user to wait for an activity to complete.
+ * A loader displays a spinner when active.
  */
 const ListLoader = (props: Props) => (
   <Dimmer.Dimmable

--- a/packages/semantic-ui/src/components/ListLoader.js
+++ b/packages/semantic-ui/src/components/ListLoader.js
@@ -6,9 +6,15 @@ import i18n from '../i18n/i18n';
 import './ListLoader.css';
 
 type Props = {
+  /**
+   * Loaders are hidden unless has prop active or inside an Dimmer active.
+   */
   active: boolean
 };
 
+/**
+ * A loader alerts a user to wait for an activity to complete.
+ */
 const ListLoader = (props: Props) => (
   <Dimmer.Dimmable
     as={Segment}

--- a/packages/semantic-ui/src/components/ListLoader.js
+++ b/packages/semantic-ui/src/components/ListLoader.js
@@ -7,7 +7,7 @@ import './ListLoader.css';
 
 type Props = {
   /**
-   * If true, the list loader spinner will display.
+   * If present, the list loader spinner will display.
    */
   active: boolean
 };

--- a/packages/storybook/src/semantic-ui/ListLoader.stories.js
+++ b/packages/storybook/src/semantic-ui/ListLoader.stories.js
@@ -12,6 +12,6 @@ export default {
 
 export const Default = () => (
   <ListLoader
-    active={boolean('Value', true)}
+    active
   />
 );

--- a/packages/storybook/src/semantic-ui/ListLoader.stories.js
+++ b/packages/storybook/src/semantic-ui/ListLoader.stories.js
@@ -1,0 +1,17 @@
+// @flow
+
+import React from 'react';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import ListLoader from '../../../semantic-ui/src/components/ListLoader';
+
+export default {
+  title: 'Components/Semantic UI/ListLoader',
+  component: ListLoader,
+  decorators: [withKnobs]
+};
+
+export const Default = () => (
+  <ListLoader
+    active={boolean('Value', true)}
+  />
+);


### PR DESCRIPTION
This pull request adds documentation for the ListLoader component, which simply displays a spinner if active.

<img width="1079" alt="Screen Shot 2023-09-27 at 3 01 32 PM" src="https://github.com/performant-software/react-components/assets/11439/1c3011e3-af88-4d08-8ec5-0c8121c62bcb">
