### PR TITLE
Add documentation and story for DateInput component

### DIFF
--- a/packages/semantic-ui/src/components/DateInput.css
+++ b/packages/semantic-ui/src/components/DateInput.css
@@ -4,3 +4,6 @@
   left: auto;
   right: 1px;
 }
+.date-input.ui.icon.input > input {
+  padding-right: calc(22px + 1.1em) !important;
+}

--- a/packages/semantic-ui/src/components/DateInput.js
+++ b/packages/semantic-ui/src/components/DateInput.js
@@ -22,7 +22,8 @@ type Props = {
    */
   onChange: (date: ?Date) => void,
   /**
-   * Callback fired when the date input field is clicked.
+   * Callback fired when the date input field is clicked, typically opening the actual method of
+   * input (such as the <code>DatePicker</code> component).
    */
   onClick: () => void,
   /**
@@ -31,6 +32,10 @@ type Props = {
   value?: ?Date
 }
 
+/**
+ * This input component is used to display and clear a date. It must be used with an additional
+ * component, such as `DatePicker`, to actually input the date.
+ */
 const DateInput = (props: Props) => {
   const formatDate = () => {
     let date = '';

--- a/packages/semantic-ui/src/components/DateInput.js
+++ b/packages/semantic-ui/src/components/DateInput.js
@@ -5,11 +5,29 @@ import { Icon, Input } from 'semantic-ui-react';
 import './DateInput.css';
 
 type Props = {
+  /**
+   * Display date, which will override the default date formatting.
+   */
   display?: string,
-  formatOptions?: any,
+  /**
+   * An object containing date-time formatting options used by JavaScript Date objects.
+   */
+  formatOptions?: DateTimeFormatOptions,
+  /**
+   * Locale identifier (Unicode CLDR) for formatting dates and times.
+   */
   locale?: string,
+  /**
+   * Callback fired when the date in the input field is changed.
+   */
   onChange: (date: ?Date) => void,
+  /**
+   * Callback fired when the date input field is clicked.
+   */
   onClick: () => void,
+  /**
+   * Current value of the date input form field, as a JavaScript Date object, or null.
+   */
   value?: ?Date
 }
 

--- a/packages/storybook/src/semantic-ui/DateInput.stories.js
+++ b/packages/storybook/src/semantic-ui/DateInput.stories.js
@@ -5,7 +5,8 @@ import { action } from '@storybook/addon-actions';
 import DateInput from '../../../semantic-ui/src/components/DateInput';
 
 export default {
-  title: 'Components/Semantic UI/DateInput'
+  title: 'Components/Semantic UI/DateInput',
+  component: DateInput,
 };
 
 export const Default = () => {

--- a/packages/storybook/src/semantic-ui/DateInput.stories.js
+++ b/packages/storybook/src/semantic-ui/DateInput.stories.js
@@ -1,0 +1,63 @@
+// @flow
+
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import DateInput from '../../../semantic-ui/src/components/DateInput';
+
+export default {
+  title: 'Components/Semantic UI/DateInput'
+};
+
+export const Default = () => {
+  const [date, setDate] = useState(new Date());
+
+  return (
+    <DateInput
+      onChange={(d) => setDate(d)}
+      onClick={action('click')}
+      value={date}
+    />
+  );
+};
+
+export const WithLocale = () => {
+  const [date, setDate] = useState(new Date());
+
+  return (
+    <DateInput
+      locale='de'
+      onChange={(d) => setDate(d)}
+      onClick={action('click')}
+      value={date}
+    />
+  );
+};
+
+export const WithLocaleAndFormatOptions = () => {
+  const [date, setDate] = useState(new Date());
+
+  return (
+    <DateInput
+      formatOptions={{
+        weekday: 'long', day: 'numeric', month: 'numeric', hour: 'numeric'
+      }}
+      locale='fr'
+      onChange={(d) => setDate(d)}
+      onClick={action('click')}
+      value={date}
+    />
+  );
+};
+
+export const WithDisplay = () => {
+  const [date, setDate] = useState(new Date());
+
+  return (
+    <DateInput
+      display={date ? `Today is ${date}` : 'Cleared!'}
+      onChange={(d) => setDate(d)}
+      onClick={action('click')}
+      value={date}
+    />
+  );
+};


### PR DESCRIPTION
## In this PR

- Add props documentation, component comment, and stories for `DateInput`
- Update the prop type of `formatOptions` from `any` to `DateTimeFormatOptions`
- Fix a bug where the text input did not have enough right-padding to accommodate a right icon when there is also a left icon
  - Note that I used the formula `(verticalPadding * 2) + glyphWidth` [from semantic-ui](https://github.com/Semantic-Org/Semantic-UI/blob/47acaa0ce4c8dcde6c76080483cf8a3566576770/src/themes/default/elements/input.variables#L35), which is how they end up with the crazy number `2.67142857em`
  - This CSS could also be used for any other inputs that need both right and left icons, something that Semantic UI doesn't support out of the box