### PR TITLE
Fix placemarkers component to handle null geometry

### DIFF
--- a/packages/core-data/src/components/PlaceMarkers.js
+++ b/packages/core-data/src/components/PlaceMarkers.js
@@ -73,8 +73,6 @@ const PlaceMarkers = (props: Props) => {
     return null;
   }
 
-  console.log('data', data);
-
   return (
     <LocationMarkers
       animate={props.animate}

--- a/packages/core-data/src/components/PlaceMarkers.js
+++ b/packages/core-data/src/components/PlaceMarkers.js
@@ -52,10 +52,12 @@ const PlaceMarkers = (props: Props) => {
    * @type {function(*): *}
    */
   const onLoad = useCallback((records) => (
-    _.map(records, (record) => setPlaces((prevPlaces) => [
-      ...prevPlaces,
-      feature(record.geometry, record.properties)
-    ]))
+    _.map(records, (record) => setPlaces((prevPlaces) => record.geometry
+      ? [
+        ...prevPlaces,
+        feature(record.geometry, record.properties)
+      ] 
+      : prevPlaces))
   ), []);
 
   /**
@@ -70,6 +72,8 @@ const PlaceMarkers = (props: Props) => {
   if (_.isEmpty(data?.features)) {
     return null;
   }
+
+  console.log('data', data);
 
   return (
     <LocationMarkers


### PR DESCRIPTION
### In this PR
Update to PR #265 , but now using the updated `PlaceMarkers` component. Adds handling to filter out places passed to the component that have null `geometry` fields and thus run the risk of crashing the component.

### Notes
When I tested this last week it seemed that the null geometry was handled somehow by the `feature` function imported from `@turf/turf`, but I must have misinterpreted that somehow because now it seems to be throwing a `coordinates must be a number` error. So hopefully this will fix that issue for real.