### PR TITLE
CDC #121 - Geocoding

### DIFF
--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "2.1.2-beta.4",
+  "version": "2.1.2",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.2-beta.4",
-    "@performant-software/shared-components": "^2.1.2-beta.4",
+    "@performant-software/semantic-components": "^2.1.2",
+    "@performant-software/shared-components": "^2.1.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.1",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.1",
-    "@performant-software/shared-components": "^2.1.1",
+    "@performant-software/semantic-components": "^2.1.2-beta.1",
+    "@performant-software/shared-components": "^2.1.2-beta.1",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "2.1.2-beta.3",
+  "version": "2.1.2-beta.4",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.2-beta.3",
-    "@performant-software/shared-components": "^2.1.2-beta.3",
+    "@performant-software/semantic-components": "^2.1.2-beta.4",
+    "@performant-software/shared-components": "^2.1.2-beta.4",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "2.1.2-beta.1",
+  "version": "2.1.2-beta.2",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.2-beta.1",
-    "@performant-software/shared-components": "^2.1.2-beta.1",
+    "@performant-software/semantic-components": "^2.1.2-beta.2",
+    "@performant-software/shared-components": "^2.1.2-beta.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/controlled-vocabulary",
-  "version": "2.1.2-beta.2",
+  "version": "2.1.2-beta.3",
   "description": "A package of components to allow user to configure dropdown elements. Use with the \"controlled_vocabulary\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.2-beta.2",
-    "@performant-software/shared-components": "^2.1.2-beta.2",
+    "@performant-software/semantic-components": "^2.1.2-beta.3",
+    "@performant-software/shared-components": "^2.1.2-beta.3",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/core-data",
-  "version": "2.1.2-beta.2",
+  "version": "2.1.2-beta.3",
   "description": "A package of components used with the Core Data platform.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -38,7 +38,7 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/geospatial": "^2.1.2-beta.2",
+    "@performant-software/geospatial": "^2.1.2-beta.3",
     "@peripleo/maplibre": "^0.5.2",
     "@peripleo/peripleo": "^0.5.2",
     "react": ">= 16.13.1 < 19.0.0",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/core-data",
-  "version": "2.1.2-beta.4",
+  "version": "2.1.2",
   "description": "A package of components used with the Core Data platform.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -38,7 +38,7 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/geospatial": "^2.1.2-beta.4",
+    "@performant-software/geospatial": "^2.1.2",
     "@peripleo/maplibre": "^0.5.2",
     "@peripleo/peripleo": "^0.5.2",
     "react": ">= 16.13.1 < 19.0.0",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/core-data",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.1",
   "description": "A package of components used with the Core Data platform.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -38,7 +38,7 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/geospatial": "^2.1.1",
+    "@performant-software/geospatial": "^2.1.2-beta.1",
     "@peripleo/maplibre": "^0.5.2",
     "@peripleo/peripleo": "^0.5.2",
     "react": ">= 16.13.1 < 19.0.0",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/core-data",
-  "version": "2.1.2-beta.1",
+  "version": "2.1.2-beta.2",
   "description": "A package of components used with the Core Data platform.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -38,7 +38,7 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/geospatial": "^2.1.2-beta.1",
+    "@performant-software/geospatial": "^2.1.2-beta.2",
     "@peripleo/maplibre": "^0.5.2",
     "@peripleo/peripleo": "^0.5.2",
     "react": ">= 16.13.1 < 19.0.0",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/core-data",
-  "version": "2.1.2-beta.3",
+  "version": "2.1.2-beta.4",
   "description": "A package of components used with the Core Data platform.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -38,7 +38,7 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/geospatial": "^2.1.2-beta.3",
+    "@performant-software/geospatial": "^2.1.2-beta.4",
     "@peripleo/maplibre": "^0.5.2",
     "@peripleo/peripleo": "^0.5.2",
     "react": ">= 16.13.1 < 19.0.0",

--- a/packages/core-data/src/components/SearchResultsLayer.js
+++ b/packages/core-data/src/components/SearchResultsLayer.js
@@ -63,8 +63,11 @@ const SearchResultsLayer = (props: Props) => {
   useEffect(() => {
     if (props.fitBoundingBox && data && mapLoaded && searchCompleted) {
       // Set the bounding box on the map
-      const boundingBox = MapUtils.getBoundingBox(data, props.buffer);
-      map.fitBounds(boundingBox, props.boundingBoxOptions, props.boundingBoxData);
+      const bbox = MapUtils.getBoundingBox(data, props.buffer);
+
+      if (bbox) {
+        map.fitBounds(bbox, props.boundingBoxOptions, props.boundingBoxData);
+      }
 
       // Reset search completed
       setSearchCompleted(false);

--- a/packages/geospatial/package.json
+++ b/packages/geospatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/geospatial",
-  "version": "2.1.2-beta.4",
+  "version": "2.1.2",
   "description": "A package of components for all things map-related.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/geospatial/package.json
+++ b/packages/geospatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/geospatial",
-  "version": "2.1.2-beta.1",
+  "version": "2.1.2-beta.2",
   "description": "A package of components for all things map-related.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/geospatial/package.json
+++ b/packages/geospatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/geospatial",
-  "version": "2.1.2-beta.2",
+  "version": "2.1.2-beta.3",
   "description": "A package of components for all things map-related.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/geospatial/package.json
+++ b/packages/geospatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/geospatial",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.1",
   "description": "A package of components for all things map-related.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/geospatial/package.json
+++ b/packages/geospatial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/geospatial",
-  "version": "2.1.2-beta.3",
+  "version": "2.1.2-beta.4",
   "description": "A package of components for all things map-related.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/geospatial/package.json
+++ b/packages/geospatial/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.4.3",
+    "@maptiler/geocoding-control": "^1.2.2",
     "@turf/turf": "^6.5.0",
     "mapbox-gl": "npm:empty-npm-package@1.0.0",
     "maplibre-gl": "^3.6.2",

--- a/packages/geospatial/src/components/GeocodingControl.js
+++ b/packages/geospatial/src/components/GeocodingControl.js
@@ -1,0 +1,33 @@
+// @flow
+
+import { GeocodingControl as MapTilerGeocoding } from '@maptiler/geocoding-control/maplibregl';
+import maplibregl from 'maplibre-gl';
+import { forwardRef, useImperativeHandle } from 'react';
+import { useControl, type ControlPosition } from 'react-map-gl';
+
+type Props = {
+  apiKey: string,
+  onSelection: () => void,
+  position?: ControlPosition
+};
+
+const GeocodingControl = forwardRef(({ position, ...props }: Props, ref) => {
+  /**
+   * Creates the drawer ref using MapboxDraw.
+   */
+  const geocodingRef = useControl(() => {
+    const control = new MapTilerGeocoding({ ...props, maplibregl });
+    control.addEventListener('pick', props.onSelection);
+
+    return control;
+  }, { position });
+
+  /**
+   * Exposes the ref for the MapboxDraw object.
+   */
+  useImperativeHandle(ref, () => geocodingRef, [geocodingRef]);
+
+  return null;
+});
+
+export default GeocodingControl;

--- a/packages/geospatial/src/components/LocationMarkers.js
+++ b/packages/geospatial/src/components/LocationMarkers.js
@@ -104,8 +104,11 @@ const LocationMarkers = (props: Props) => {
    */
   useEffect(() => {
     if (map && data && props.fitBoundingBox) {
-      const boundingBox = MapUtils.getBoundingBox(props.data, props.buffer);
-      map.fitBounds(boundingBox, props.boundingBoxOptions, props.boundingBoxData);
+      const bbox = MapUtils.getBoundingBox(data, props.buffer);
+
+      if (bbox) {
+        map.fitBounds(bbox, props.boundingBoxOptions, props.boundingBoxData);
+      }
     }
   }, [map, props.buffer, props.data, props.boundingBoxData, props.boundingBoxOptions, props.fitBoundingBox]);
 

--- a/packages/geospatial/src/components/MapDraw.css
+++ b/packages/geospatial/src/components/MapDraw.css
@@ -1,2 +1,3 @@
 @import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
+@import '@maptiler/geocoding-control/style.css';
 @import 'maplibre-gl/dist/maplibre-gl.css';

--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -197,7 +197,6 @@ const MapDraw = (props: Props) => {
       { props.geocoding && (
         <GeocodingControl
           apiKey={props.apiKey}
-          collapsed
           marker={false}
           position='top-left'
           onSelection={onSelection}

--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -104,10 +104,16 @@ const MapDraw = (props: Props) => {
    *
    * @type {function({geometry: {type: *}}): *}
    */
-  const isValid = useCallback(({ geometry: { type } }) => (
-    (props.geocoding === 'point' && type === GeometryTypes.point)
-    || (props.geocoding === 'polygon' && type === GeometryTypes.polygon)
-  ), [props.geocoding]);
+  const isValid = useCallback((detail) => {
+    if (!detail) {
+      return false;
+    }
+
+    const { geometry: { type } } = detail;
+
+    return (props.geocoding === 'point' && type === GeometryTypes.point)
+      || (props.geocoding === 'polygon' && type === GeometryTypes.polygon);
+  }, [props.geocoding]);
 
   /**
    * Calls the onChange prop with all of the geometries in the current drawer.
@@ -200,6 +206,7 @@ const MapDraw = (props: Props) => {
           marker={false}
           position='top-left'
           onSelection={onSelection}
+          showFullGeometry={props.geocoding === 'polygon'}
           showResultMarkers={false}
         />
       )}

--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -153,15 +153,11 @@ const MapDraw = (props: Props) => {
    */
   useEffect(() => {
     if (loaded && props.data) {
-      // Get the bounding box for the passed data
-      const boundingBox = MapUtils.getBoundingBox(props.data, props.buffer);
-
       // Sets the bounding box for the current geometry
-      if (_.every(boundingBox, _.isFinite)) {
-        const [minLng, minLat, maxLng, maxLat] = boundingBox;
-        const bounds = [[minLng, minLat], [maxLng, maxLat]];
+      const bbox = MapUtils.getBoundingBox(props.data, props.buffer);
 
-        mapRef.current.fitBounds(bounds, { duration: props.zoomDuration });
+      if (bbox) {
+        mapRef.current.fitBounds(bbox, { duration: props.zoomDuration });
       }
 
       // Handle special cases for geometry collection (not supported by mabox-gl-draw) and point

--- a/packages/geospatial/src/index.js
+++ b/packages/geospatial/src/index.js
@@ -3,6 +3,7 @@
 // Components
 export { default as DrawControl } from './components/DrawControl';
 export { default as GeoJsonLayer } from './components/GeoJsonLayer';
+export { default as GeocodingControl } from './components/GeocodingControl';
 export { default as LayerMenu } from './components/LayerMenu';
 export { default as LocationMarkers } from './components/LocationMarkers';
 export { default as MapControl } from './components/MapControl';

--- a/packages/geospatial/src/utils/Map.js
+++ b/packages/geospatial/src/utils/Map.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { bbox, bboxPolygon, buffer } from '@turf/turf';
+import _ from 'underscore';
 
 const MIN_LATITUDE = -90;
 const MAX_LATITUDE = 90;
@@ -10,14 +11,18 @@ const MAX_LONGITUDE = 180;
 /**
  * Returns a bounding box for the passed geometry (with optional buffer).
  *
- * @param geometry
+ * @param data
  * @param bufferDistance
  *
  * @returns {BBox}
  */
-const getBoundingBox = (geometry, bufferDistance = null) => {
+const getBoundingBox = (data, bufferDistance = null) => {
   // Convert the GeoJSON into a bounding box
-  const box = bbox(geometry);
+  const box = bbox(data);
+
+  if (!validateBoundingBox(box)) {
+    return null;
+  }
 
   // Convert the bounding box to a polygon
   const polygon = bboxPolygon(box);
@@ -34,6 +39,15 @@ const getBoundingBox = (geometry, bufferDistance = null) => {
   // Convert the buffer to a bounding box
   return bbox(polygonBuffer);
 };
+
+/**
+ * Validates that the passed bounding box contains finite coordinates.
+ *
+ * @param boundingBox
+ *
+ * @returns {*}
+ */
+const validateBoundingBox = (boundingBox: Array<number>) => _.every(boundingBox, _.isFinite);
 
 /**
  * Returns true if the passed coordinates are valid.
@@ -59,5 +73,6 @@ const validateCoordinates = (coordinates) => {
 
 export default {
   getBoundingBox,
+  validateBoundingBox,
   validateCoordinates
 };

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.1",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -35,7 +35,7 @@
     "zotero-translation-client": "^5.0.1"
   },
   "peerDependencies": {
-    "@performant-software/shared-components": "^2.1.1",
+    "@performant-software/shared-components": "^2.1.2-beta.1",
     "@samvera/clover-iiif": "^2.3.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dnd": "^11.1.3",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "2.1.2-beta.2",
+  "version": "2.1.2-beta.3",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -35,7 +35,7 @@
     "zotero-translation-client": "^5.0.1"
   },
   "peerDependencies": {
-    "@performant-software/shared-components": "^2.1.2-beta.2",
+    "@performant-software/shared-components": "^2.1.2-beta.3",
     "@samvera/clover-iiif": "^2.3.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dnd": "^11.1.3",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "2.1.2-beta.4",
+  "version": "2.1.2",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -35,7 +35,7 @@
     "zotero-translation-client": "^5.0.1"
   },
   "peerDependencies": {
-    "@performant-software/shared-components": "^2.1.2-beta.4",
+    "@performant-software/shared-components": "^2.1.2",
     "@samvera/clover-iiif": "^2.3.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dnd": "^11.1.3",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "2.1.2-beta.1",
+  "version": "2.1.2-beta.2",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -35,7 +35,7 @@
     "zotero-translation-client": "^5.0.1"
   },
   "peerDependencies": {
-    "@performant-software/shared-components": "^2.1.2-beta.1",
+    "@performant-software/shared-components": "^2.1.2-beta.2",
     "@samvera/clover-iiif": "^2.3.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dnd": "^11.1.3",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/semantic-components",
-  "version": "2.1.2-beta.3",
+  "version": "2.1.2-beta.4",
   "description": "A package of shared components based on the Semantic UI Framework.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -35,7 +35,7 @@
     "zotero-translation-client": "^5.0.1"
   },
   "peerDependencies": {
-    "@performant-software/shared-components": "^2.1.2-beta.3",
+    "@performant-software/shared-components": "^2.1.2-beta.4",
     "@samvera/clover-iiif": "^2.3.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dnd": "^11.1.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "2.1.2-beta.1",
+  "version": "2.1.2-beta.2",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "2.1.2-beta.3",
+  "version": "2.1.2-beta.4",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "2.1.2-beta.4",
+  "version": "2.1.2",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.1",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/shared-components",
-  "version": "2.1.2-beta.2",
+  "version": "2.1.2-beta.3",
   "description": "A package of shared, framework agnostic, components.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/storybook/src/geospatial/MapDraw.stories.js
+++ b/packages/storybook/src/geospatial/MapDraw.stories.js
@@ -21,21 +21,24 @@ export default {
 
 export const Default = () => (
   <MapDraw
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    apiKey={mapTilerKey}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   />
 );
 
 export const GeoJSON = () => (
   <MapDraw
+    apiKey={mapTilerKey}
     data={bostonBoundaryData}
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   />
 );
 
 export const Point = () => (
   <MapDraw
+    apiKey={mapTilerKey}
     data={{
       type: 'Point',
       coordinates: [
@@ -43,13 +46,14 @@ export const Point = () => (
         31.4252249
       ]
     }}
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   />
 );
 
 export const GeoJSONFillLayer = () => (
   <MapDraw
+    apiKey={mapTilerKey}
     data={{
       type: 'GeometryCollection',
       geometries: [
@@ -62,7 +66,7 @@ export const GeoJSONFillLayer = () => (
         }
       ]
     }}
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   >
     <LayerMenu
@@ -79,6 +83,7 @@ export const GeoJSONFillLayer = () => (
 
 export const GeoJSONCircleLayer = () => (
   <MapDraw
+    apiKey={mapTilerKey}
     data={{
       type: 'GeometryCollection',
       geometries: [
@@ -91,7 +96,7 @@ export const GeoJSONCircleLayer = () => (
         }
       ]
     }}
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   >
     <LayerMenu
@@ -108,6 +113,7 @@ export const GeoJSONCircleLayer = () => (
 
 export const GeoJSONLayerStyles = () => (
   <MapDraw
+    apiKey={mapTilerKey}
     data={{
       type: 'GeometryCollection',
       geometries: [
@@ -120,7 +126,7 @@ export const GeoJSONLayerStyles = () => (
         }
       ]
     }}
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   >
     <LayerMenu
@@ -141,6 +147,7 @@ export const GeoJSONLayerStyles = () => (
 
 export const RasterLayer = () => (
   <MapDraw
+    apiKey={mapTilerKey}
     buffer={120}
     data={{
       type: 'GeometryCollection',
@@ -154,7 +161,7 @@ export const RasterLayer = () => (
         }
       ]
     }}
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   >
     <LayerMenu
@@ -176,6 +183,7 @@ export const RasterLayer = () => (
 
 export const EmptyLayerMenu = () => (
   <MapDraw
+    apiKey={mapTilerKey}
     data={{
       type: 'Point',
       coordinates: [
@@ -183,7 +191,7 @@ export const EmptyLayerMenu = () => (
         31.4252249
       ]
     }}
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   >
     <LayerMenu names={[]} />
@@ -192,7 +200,8 @@ export const EmptyLayerMenu = () => (
 
 export const CustomControl = () => (
   <MapDraw
-    mapStyle={`https://api.maptiler.com/maps/basic-v2/style.json?key=${mapTilerKey}`}
+    apiKey={mapTilerKey}
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
     onChange={action('onChange')}
   >
     <MapControl
@@ -207,4 +216,24 @@ export const CustomControl = () => (
       </button>
     </MapControl>
   </MapDraw>
+);
+
+export const GeocodingPoints = () => (
+  <MapDraw
+    apiKey={mapTilerKey}
+    geocoding='point'
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
+    onChange={action('onChange')}
+    onGeocodingSelection={action('onGeocodingSelection')}
+  />
+);
+
+export const GeocodingPolygons = () => (
+  <MapDraw
+    apiKey={mapTilerKey}
+    geocoding='polygon'
+    mapStyle='https://api.maptiler.com/maps/basic-v2/style.json'
+    onChange={action('onChange')}
+    onGeocodingSelection={action('onGeocodingSelection')}
+  />
 );

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "2.1.2-beta.3",
+  "version": "2.1.2-beta.4",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.2-beta.3",
-    "@performant-software/shared-components": "^2.1.2-beta.3",
+    "@performant-software/semantic-components": "^2.1.2-beta.4",
+    "@performant-software/shared-components": "^2.1.2-beta.4",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.1",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.1",
-    "@performant-software/shared-components": "^2.1.1",
+    "@performant-software/semantic-components": "^2.1.2-beta.1",
+    "@performant-software/shared-components": "^2.1.2-beta.1",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "2.1.2-beta.2",
+  "version": "2.1.2-beta.3",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.2-beta.2",
-    "@performant-software/shared-components": "^2.1.2-beta.2",
+    "@performant-software/semantic-components": "^2.1.2-beta.3",
+    "@performant-software/shared-components": "^2.1.2-beta.3",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "2.1.2-beta.4",
+  "version": "2.1.2",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.2-beta.4",
-    "@performant-software/shared-components": "^2.1.2-beta.4",
+    "@performant-software/semantic-components": "^2.1.2",
+    "@performant-software/shared-components": "^2.1.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/user-defined-fields",
-  "version": "2.1.2-beta.1",
+  "version": "2.1.2-beta.2",
   "description": "A package of components used for allowing end users to define fields on models. Use with the \"user_defined_fields\" gem.",
   "license": "MIT",
   "main": "./dist/index.cjs.js",
@@ -23,8 +23,8 @@
     "underscore": "^1.13.2"
   },
   "peerDependencies": {
-    "@performant-software/semantic-components": "^2.1.2-beta.1",
-    "@performant-software/shared-components": "^2.1.2-beta.1",
+    "@performant-software/semantic-components": "^2.1.2-beta.2",
+    "@performant-software/shared-components": "^2.1.2-beta.2",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "2.1.2-beta.3",
+  "version": "2.1.2-beta.4",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.1",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "2.1.2-beta.4",
+  "version": "2.1.2",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "2.1.2-beta.2",
+  "version": "2.1.2-beta.3",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@performant-software/visualize",
-  "version": "2.1.2-beta.1",
+  "version": "2.1.2-beta.2",
   "description": "A package of components used for data visualization",
   "license": "MIT",
   "main": "./dist/index.cjs.js",

--- a/react-components.json
+++ b/react-components.json
@@ -8,5 +8,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "2.1.2-beta.2"
+  "version": "2.1.2-beta.3"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -8,5 +8,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "2.1.2-beta.4"
+  "version": "2.1.2"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -8,5 +8,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "2.1.2-beta.3"
+  "version": "2.1.2-beta.4"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -8,5 +8,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "2.1.1"
+  "version": "2.1.2-beta.1"
 }

--- a/react-components.json
+++ b/react-components.json
@@ -8,5 +8,5 @@
     "packages/user-defined-fields",
     "packages/visualize"
   ],
-  "version": "2.1.2-beta.1"
+  "version": "2.1.2-beta.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,6 +2089,13 @@
     rw "^1.3.3"
     sort-object "^3.0.3"
 
+"@maptiler/geocoding-control@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@maptiler/geocoding-control/-/geocoding-control-1.2.2.tgz#319b1b2abaa2b4de6cc91e1a2990e58b18557960"
+  integrity sha512-w0JH0MOWN/z4l5t89LPinn9P9CGUg+L9R0WslXSVFP8gX9SYUMaqmGB28txXlSJsckA5/oyYfOe5UOBgXK7sbw==
+  dependencies:
+    geo-coordinates-parser "^1.6.4"
+
 "@mdx-js/react@^2.1.5":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-2.3.0.tgz#4208bd6d70f0d0831def28ef28c26149b03180b3"
@@ -9055,6 +9062,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+geo-coordinates-parser@^1.6.4:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/geo-coordinates-parser/-/geo-coordinates-parser-1.6.6.tgz#856ea86639b5fb4ea20208418b7cfcf465d55fc2"
+  integrity sha512-+zmVBzbTrC/LyFUMcYrvUqi+XUYkJ6bWqPHywfCsMYLa9BEGHEzLsBgltwXS9Ul5oJcFbrdt2y/CjjxNtTTQ+w==
 
 geojson-equality@0.1.6:
   version "0.1.6"


### PR DESCRIPTION
This pull request adds the GeocodingControl component and the `geocoding` prop to the MapDraw component. When set to "point" or "polygon", the map will render a search input that uses Map Tiler's geocoding API to lookup geometries by the entered place name. A value of "point" will add a lat/lng point to the map. A value of "polygon" will add a polygon outline of the location to the map.

## Search Input
![Screenshot 2024-04-11 at 7 26 08 AM](https://github.com/performant-software/react-components/assets/20641961/110c84de-ba5f-45b0-8f99-2bc0b057d9ae)

## Point Selection
![Screenshot 2024-04-11 at 7 26 17 AM](https://github.com/performant-software/react-components/assets/20641961/30e777c7-aca1-4fed-b63a-31f29285dda6)

## Polygon Selection
![Screenshot 2024-04-11 at 7 26 33 AM](https://github.com/performant-software/react-components/assets/20641961/cd8bc1fb-c488-4d5e-af79-87f46e68cf57)
