### PR TITLE
Remove unneeded arguments from `onLoad` in Core Data hook

### DIFF
--- a/packages/core-data/src/hooks/CoreData.js
+++ b/packages/core-data/src/hooks/CoreData.js
@@ -85,7 +85,7 @@ export const useLoader = (onLoad, params = {}, deps = []) => {
   useEffect(() => {
     setLoading(true);
 
-    onLoad(baseUrl, projectIds, { ...params, page })
+    onLoad({ ...params, page })
       .then((d) => setData(d))
       .finally(() => setLoading(false));
   }, [...deps, page]);


### PR DESCRIPTION
# Summary

- removes the `baseUrl` and `projectIds` arguments from the call to `onLoad` in the Core Data hook
  - these were left over from a previous version of the package where these arguments had been required

Closes #279 