### PR TITLE
Fix incorrect substring index in Core Data `getFieldId` helper function

### DIFF
--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -107,7 +107,7 @@ const getFieldId = (attribute: string) => {
 
   let value = attribute.replaceAll(SUFFIX_FACET, '');
   if (value.includes(ATTRIBUTE_DELIMITER)) {
-    value = value.substring(value.indexOf(ATTRIBUTE_DELIMITER) + 1, value.length - 1);
+    value = value.substring(value.indexOf(ATTRIBUTE_DELIMITER) + 1, value.length);
   }
 
   return value;


### PR DESCRIPTION
# Summary

- fixes #280 by changing the second index in `getFieldId`'s `substring` call to `value.length` instead of `value.length - 1`