### PR TITLE
CDC #308 - Media Upload Error

### DIFF
--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -448,7 +448,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
                 </Message.List>
               </Message>
             )}
-            { props.errors && (
+            { !_.isEmpty(props.errors) && (
               <Message
                 error
               >

--- a/packages/storybook/src/semantic-ui/FileUploadModal.stories.js
+++ b/packages/storybook/src/semantic-ui/FileUploadModal.stories.js
@@ -51,7 +51,7 @@ export const Default = withWrapper((props) => (
   />
 ));
 
-export const Errors = withWrapper((props) => (
+export const InputErrors = withWrapper((props) => (
   <FileUploadModal
     closeOnComplete={false}
     itemComponent={({
@@ -94,6 +94,28 @@ export const Errors = withWrapper((props) => (
     }}
     required={{
       name: 'Name'
+    }}
+  />
+));
+
+export const UploadErrors = withWrapper((props) => (
+  <FileUploadModal
+    errors={['File too large.']}
+    itemComponent={({ item }) => (
+      <Form.Input
+        label='Name'
+        value={item.name || ''}
+      />
+    )}
+    onAddFile={(file) => ({
+      name: file.name,
+      content: file,
+      type: file.type
+    })}
+    onClose={props.onClose}
+    onSave={() => {
+      action('save')();
+      return Promise.resolve();
     }}
   />
 ));


### PR DESCRIPTION
This pull request adds an `_.isEmpty` check to the `errors` prop before rendering the message in the `FileUploadModal` component.