### PR TITLE
Allow default sort typesense configuration (#304)

### DIFF
--- a/packages/core-data/src/types/RuntimeConfig.js
+++ b/packages/core-data/src/types/RuntimeConfig.js
@@ -34,7 +34,8 @@ export type RuntimeConfig = {
     facets?: {
       include?: string[],
       exclude?: string[]
-    }
+    },
+    default_sort?: string
   },
   core_data: {
     project_ids: number[],

--- a/packages/core-data/src/utils/Peripleo.js
+++ b/packages/core-data/src/utils/Peripleo.js
@@ -30,7 +30,8 @@ const normalize = (config: RuntimeConfig) => ({
   typesense: {
     ...config.typesense,
     host: config.typesense.host || '443',
-    protocol: config.typesense.protocol || 'https'
+    protocol: config.typesense.protocol || 'https',
+    sort_by: `_text_match:desc${config.typesense.default_sort ? `,${config.typesense.default_sort}:asc` : ''}`
   },
   core_data: {
     ...config.core_data,

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -14,7 +14,8 @@ type TypesenseConfig = {
   limit: number,
   port: number,
   protocol: string,
-  query_by: string
+  query_by: string,
+  default_sort?: string
 };
 
 const ATTRIBUTE_DELIMITER = '.';
@@ -100,7 +101,8 @@ const createTypesenseAdapter = (config: TypesenseConfig, options = {}) => (
     geoLocationField: 'coordinates',
     additionalSearchParameters: {
       query_by: config.query_by,
-      limit: config.limit || 250
+      limit: config.limit || 250,
+      sort_by: `_text_match:desc${config.default_sort ? `,${config.default_sort}:asc` : ''}`
     },
     ...options
   })

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -15,7 +15,7 @@ type TypesenseConfig = {
   port: number,
   protocol: string,
   query_by: string,
-  default_sort?: string
+  sort_by: string
 };
 
 const ATTRIBUTE_DELIMITER = '.';
@@ -102,7 +102,7 @@ const createTypesenseAdapter = (config: TypesenseConfig, options = {}) => (
     additionalSearchParameters: {
       query_by: config.query_by,
       limit: config.limit || 250,
-      sort_by: `_text_match:desc${config.default_sort ? `,${config.default_sort}:asc` : ''}`
+      sort_by: config.sort_by
     },
     ...options
   })


### PR DESCRIPTION
## In this PR

Per #304 (see also performant-software/core-data-cloud#323):
- Allow users to set a default sort in the typesense configuration
  - `_text_match:desc` is the default if no `sort_by` is passed; include that as the primary sort, then configured option as the secondary (i.e. the default sort if no text query is entered, and the tiebreaker for equivalent text matches)

## Questions

- Are these the right places to set this? I basically just looked for wherever a typesense configuration was set.
- Is it ok to assume we just want an ascending sort on whatever field is passed to `default_sort`, or should the user have to specify direction?
- Should I publish a beta version in order to test this?