### PR TITLE
Archnet #1276 - Add DatetimeLocalInput

### DIFF
--- a/packages/semantic-ui/src/components/DatetimeLocalInput.css
+++ b/packages/semantic-ui/src/components/DatetimeLocalInput.css
@@ -1,0 +1,9 @@
+.datetime-local-input.ui.icon.input > i.icon.right {
+  cursor: pointer;
+  pointer-events: all !important;
+  left: auto;
+  right: 1px;
+}
+.datetime-local-input.ui.icon.input > input {
+  padding-right: calc(22px + 1.1em) !important;
+}

--- a/packages/semantic-ui/src/components/DatetimeLocalInput.js
+++ b/packages/semantic-ui/src/components/DatetimeLocalInput.js
@@ -1,0 +1,44 @@
+// @flow
+
+import React from 'react';
+import { Icon, Input } from 'semantic-ui-react';
+import './DatetimeLocalInput.css';
+
+type Props = {
+  /**
+   * Callback fired when the datetime string in the input field is changed.
+   */
+  onChange: (dateString: ?String) => void,
+  /**
+   * Current value of the datetime-local input form field, as a string, or null.
+   */
+  value?: ?String
+}
+
+/**
+ * This input component is used to input and display a date and time, using the browser's
+ * native date picker.
+ */
+const DatetimeLocalInput = (props: Props) => (
+  <Input
+    aria-label='Datetime Local Input'
+    className='datetime-local-input icon'
+  >
+    <input
+      onChange={(e) => props.onChange(e.target.value)}
+      type='datetime-local'
+      value={props.value}
+    />
+    <Icon
+      className='right icon'
+      name='times'
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        props.onChange('');
+      }}
+    />
+  </Input>
+);
+
+export default DatetimeLocalInput;

--- a/packages/semantic-ui/src/index.js
+++ b/packages/semantic-ui/src/index.js
@@ -27,6 +27,7 @@ export { default as DataView } from './components/DataView';
 export { default as DatabaseView } from './components/DatabaseView';
 export { default as DateInput } from './components/DateInput';
 export { default as DatePicker } from './components/DatePicker';
+export { default as DatetimeLocalInput } from './components/DatetimeLocalInput';
 export { default as DescriptorField } from './components/DescriptorField';
 export { default as DownloadButton } from './components/DownloadButton';
 export { default as Draggable } from './components/Draggable';


### PR DESCRIPTION
## In this PR

Per performant-software/archnet3#1276:
- A new component in semantic-components called `DatetimeLocalInput` that uses the browser's native `datetime-local` picker, so that a user can input both a date _and_ a time.


## Notes
- The consuming application will be responsible for handling formatting (it's ISO without the trailing `Z`) and timezone conversions.
- This input is available in [all major browsers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) as of 2021. However, there is one caveat: the calendar modal that pops up only allows picking dates, not times, in Firefox and Safari. But I think that should be fine, as you can still pick a time from the inline input in all browsers.