### PR TITLE
Archnet #1316 - Update preview label, disallow DL for blobs

### DIFF
--- a/packages/semantic-ui/src/components/LazyAudio.js
+++ b/packages/semantic-ui/src/components/LazyAudio.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useMemo, useState, type Node } from 'react';
+import React, { useState, type Node } from 'react';
 import {
   Button,
   Dimmer,
@@ -24,6 +24,7 @@ type Props = {
   duration?: number,
   image?: any,
   name?: string,
+  playButtonLabel?: string,
   preview?: string,
   size?: string,
   src?: string
@@ -35,13 +36,6 @@ const LazyAudio = (props: Props) => {
   const [loaded, setLoaded] = useState(!props.preview);
   const [modal, setModal] = useState(false);
   const [visible, setVisible] = useState(false);
-
-  const playButtonLabel = useMemo(() => {
-    if (props.src?.startsWith('blob:')) {
-      return i18n.t('LazyMedia.buttons.preview');
-    }
-    return i18n.t('LazyAudio.buttons.play');
-  }, [props.src]);
 
   if (!visible) {
     return (
@@ -115,13 +109,13 @@ const LazyAudio = (props: Props) => {
               >
                 { props.src && (
                   <Button
-                    content={playButtonLabel}
+                    content={props.playButtonLabel || i18n.t('LazyAudio.buttons.play')}
                     icon='play circle outline'
                     onClick={() => setModal(true)}
                     primary
                   />
                 )}
-                { props.download && !props.download.startsWith('blob:') && (
+                { props.download && (
                   <DownloadButton
                     color='green'
                     filename={props.name}

--- a/packages/semantic-ui/src/components/LazyAudio.js
+++ b/packages/semantic-ui/src/components/LazyAudio.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useState, type Node } from 'react';
+import React, { useMemo, useState, type Node } from 'react';
 import {
   Button,
   Dimmer,
@@ -35,6 +35,13 @@ const LazyAudio = (props: Props) => {
   const [loaded, setLoaded] = useState(!props.preview);
   const [modal, setModal] = useState(false);
   const [visible, setVisible] = useState(false);
+
+  const playButtonLabel = useMemo(() => {
+    if (props.src?.startsWith('blob:')) {
+      return i18n.t('LazyMedia.buttons.preview');
+    }
+    return i18n.t('LazyAudio.buttons.play');
+  }, [props.src]);
 
   if (!visible) {
     return (
@@ -108,13 +115,13 @@ const LazyAudio = (props: Props) => {
               >
                 { props.src && (
                   <Button
-                    content={i18n.t('LazyAudio.buttons.play')}
+                    content={playButtonLabel}
                     icon='play circle outline'
                     onClick={() => setModal(true)}
                     primary
                   />
                 )}
-                { props.download && (
+                { props.download && !props.download.startsWith('blob:') && (
                   <DownloadButton
                     color='green'
                     filename={props.name}

--- a/packages/semantic-ui/src/components/LazyDocument.js
+++ b/packages/semantic-ui/src/components/LazyDocument.js
@@ -144,7 +144,7 @@ const LazyDocument = (props: Props) => {
               <div
                 className='buttons'
               >
-                {props.download && !props.download.startsWith('blob:') && (
+                {props.download && (
                   <DownloadButton
                     primary
                     url={props.download || props.src}

--- a/packages/semantic-ui/src/components/LazyDocument.js
+++ b/packages/semantic-ui/src/components/LazyDocument.js
@@ -144,7 +144,7 @@ const LazyDocument = (props: Props) => {
               <div
                 className='buttons'
               >
-                {props.download && (
+                {props.download && !props.download.startsWith('blob:') && (
                   <DownloadButton
                     primary
                     url={props.download || props.src}

--- a/packages/semantic-ui/src/components/LazyImage.js
+++ b/packages/semantic-ui/src/components/LazyImage.js
@@ -1,6 +1,11 @@
 // @flow
 
-import React, { useCallback, useState, type Node } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+  type Node
+} from 'react';
 import {
   Button,
   Dimmer,
@@ -54,6 +59,13 @@ const LazyImage = (props: Props) => {
 
     return classNames.join(' ');
   }, [loaded]);
+
+  const viewButtonLabel = useMemo(() => {
+    if (props.src?.startsWith('blob:')) {
+      return i18n.t('LazyMedia.buttons.preview');
+    }
+    return i18n.t('LazyImage.buttons.view');
+  }, [props.src]);
 
   if (!visible) {
     return (
@@ -128,13 +140,13 @@ const LazyImage = (props: Props) => {
               >
                 { props.src && (
                   <Button
-                    content={i18n.t('LazyImage.buttons.view')}
+                    content={viewButtonLabel}
                     icon='photo'
                     onClick={() => setModal(true)}
                     primary
                   />
                 )}
-                { props.download && (
+                { props.download && !props.download.startsWith('blob:') && (
                   <DownloadButton
                     color='green'
                     filename={props.name}

--- a/packages/semantic-ui/src/components/LazyImage.js
+++ b/packages/semantic-ui/src/components/LazyImage.js
@@ -1,11 +1,6 @@
 // @flow
 
-import React, {
-  useCallback,
-  useMemo,
-  useState,
-  type Node
-} from 'react';
+import React, { useCallback, useState, type Node } from 'react';
 import {
   Button,
   Dimmer,
@@ -31,7 +26,8 @@ type Props = {
   name?: string,
   preview?: string,
   size?: string,
-  src?: string
+  src?: string,
+  viewButtonLabel?: string
 };
 
 const LazyImage = (props: Props) => {
@@ -59,13 +55,6 @@ const LazyImage = (props: Props) => {
 
     return classNames.join(' ');
   }, [loaded]);
-
-  const viewButtonLabel = useMemo(() => {
-    if (props.src?.startsWith('blob:')) {
-      return i18n.t('LazyMedia.buttons.preview');
-    }
-    return i18n.t('LazyImage.buttons.view');
-  }, [props.src]);
 
   if (!visible) {
     return (
@@ -140,13 +129,13 @@ const LazyImage = (props: Props) => {
               >
                 { props.src && (
                   <Button
-                    content={viewButtonLabel}
+                    content={props.viewButtonLabel || i18n.t('LazyImage.buttons.view')}
                     icon='photo'
                     onClick={() => setModal(true)}
                     primary
                   />
                 )}
-                { props.download && !props.download.startsWith('blob:') && (
+                { props.download && (
                   <DownloadButton
                     color='green'
                     filename={props.name}

--- a/packages/semantic-ui/src/components/LazyMedia.js
+++ b/packages/semantic-ui/src/components/LazyMedia.js
@@ -52,6 +52,8 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
   const [name, setName] = useState(props.name);
   const [preview, setPreview] = useState(props.preview);
   const [source, setSource] = useState(props.src);
+  const [downloadUrl, setDownloadUrl] = useState(props.downloadUrl);
+  const [viewButtonLabel, setViewButtonLabel] = useState(null);
 
   /**
    * Sets the file extension based on the name.
@@ -80,13 +82,16 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
     setContentType(file.type);
     setName(file.name);
     setPreview(null);
+    setDownloadUrl(null);
 
     if (_.contains(WebContentTypes, file.type)
       || file.type.startsWith(ContentTypes.audio)
       || file.type === ContentTypes.pdf) {
       setSource(URL.createObjectURL(file));
+      setViewButtonLabel(i18n.t('LazyMedia.buttons.preview'));
     } else {
       setSource(null);
+      setViewButtonLabel(null);
     }
 
     props.onUpload(file);
@@ -121,10 +126,11 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
       return (
         <LazyImage
           dimmable={props.dimmable}
-          download={props.downloadUrl}
+          download={downloadUrl}
           preview={preview}
           src={source}
           size={props.size}
+          viewButtonLabel={viewButtonLabel}
         >
           { renderChildren() }
         </LazyImage>
@@ -135,7 +141,8 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
       return (
         <LazyVideo
           dimmable={props.dimmable}
-          download={props.downloadUrl}
+          download={downloadUrl}
+          playButtonLabel={viewButtonLabel}
           preview={preview}
           src={source}
           size={props.size}
@@ -149,7 +156,8 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
       return (
         <LazyAudio
           dimmable={props.dimmable}
-          download={props.downloadUrl}
+          download={downloadUrl}
+          playButtonLabel={viewButtonLabel}
           preview={preview}
           src={source}
           size={props.size}
@@ -162,7 +170,7 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
     return (
       <LazyDocument
         dimmable={props.dimmable}
-        download={props.downloadUrl}
+        download={downloadUrl}
         pdf={contentType === ContentTypes.pdf}
         preview={preview}
         src={source}
@@ -171,7 +179,7 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
         { renderChildren() }
       </LazyDocument>
     );
-  }, [contentType, preview, source, props.dimmable, props.downloadUrl, props.size]);
+  }, [contentType, preview, source, props.dimmable, downloadUrl, props.size]);
 
   /**
    * Renders the upload message.

--- a/packages/semantic-ui/src/components/LazyVideo.js
+++ b/packages/semantic-ui/src/components/LazyVideo.js
@@ -2,7 +2,6 @@
 
 import React, {
   useCallback,
-  useMemo,
   useState,
   type Element,
   type Node
@@ -33,6 +32,7 @@ type Props = {
   icon?: string | Element<any>,
   image?: any,
   name?: string,
+  playButtonLabel?: string,
   preview?: ?string,
   size?: string,
   src?: string
@@ -63,13 +63,6 @@ const LazyVideo = (props: Props) => {
 
     return classNames.join(' ');
   }, [loaded]);
-
-  const playButtonLabel = useMemo(() => {
-    if (props.src?.startsWith('blob:')) {
-      return i18n.t('LazyMedia.buttons.preview');
-    }
-    return i18n.t('LazyVideo.buttons.play');
-  }, [props.src]);
 
   if (!visible) {
     return (
@@ -163,13 +156,13 @@ const LazyVideo = (props: Props) => {
               >
                 { props.src && (
                   <Button
-                    content={playButtonLabel}
+                    content={props.playButtonLabel || i18n.t('LazyVideo.buttons.play')}
                     icon='video'
                     onClick={() => setModal(true)}
                     primary
                   />
                 )}
-                { props.download && !props.download.startsWith('blob:') && (
+                { props.download && (
                   <DownloadButton
                     color='green'
                     filename={props.name}

--- a/packages/semantic-ui/src/components/LazyVideo.js
+++ b/packages/semantic-ui/src/components/LazyVideo.js
@@ -2,6 +2,7 @@
 
 import React, {
   useCallback,
+  useMemo,
   useState,
   type Element,
   type Node
@@ -62,6 +63,13 @@ const LazyVideo = (props: Props) => {
 
     return classNames.join(' ');
   }, [loaded]);
+
+  const playButtonLabel = useMemo(() => {
+    if (props.src?.startsWith('blob:')) {
+      return i18n.t('LazyMedia.buttons.preview');
+    }
+    return i18n.t('LazyVideo.buttons.play');
+  }, [props.src]);
 
   if (!visible) {
     return (
@@ -155,13 +163,13 @@ const LazyVideo = (props: Props) => {
               >
                 { props.src && (
                   <Button
-                    content={i18n.t('LazyVideo.buttons.play')}
+                    content={playButtonLabel}
                     icon='video'
                     onClick={() => setModal(true)}
                     primary
                   />
                 )}
-                { props.download && (
+                { props.download && !props.download.startsWith('blob:') && (
                   <DownloadButton
                     color='green'
                     filename={props.name}

--- a/packages/semantic-ui/src/i18n/en.json
+++ b/packages/semantic-ui/src/i18n/en.json
@@ -236,6 +236,9 @@
     }
   },
   "LazyMedia": {
+    "buttons": {
+      "preview": "Preview before upload"
+    },
     "messages": {
       "uploaded": "Your <bold>{{type}}</bold> has been received"
     }


### PR DESCRIPTION
## In this PR

Per performant-software/archnet3#1316:
- Update the button text to read "preview before upload" for viewing video/audio/image files before they have been uploaded to the server
- Hide download button for all files until they have been uploaded to the server

## Notes

- Somewhat surprisingly to me, it seems detecting the presence of a local file in the browser (i.e. a url created by `URL.createObjectURL`) is as simple as checking that it begins with `blob:`. I can't test with Windows but this appears to be [defined in the File API spec](https://www.w3.org/TR/FileAPI/#url-intro).
- For video files, it looks like this across Mac Safari, Chrome, and FF:
   <img width="299" src="https://github.com/user-attachments/assets/0f37178e-e68b-4f4a-ae8b-863625ca1974" />
   And after saving the record and waiting for the data to be fetched:
   ![after save](https://github.com/user-attachments/assets/4fdaa7d3-3703-491a-8c31-c25fee727e68)
   Results are similar across other file types.
