### PR TITLE
Add `MultiPolygon` support to `MapDraw`

### DIFF
--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -162,7 +162,9 @@ const MapDraw = (props: Props) => {
       onChange();
 
       // Call the onGeocoding selection callback
-      props.onGeocodingSelection(detail);
+      if (props.onGeocodingSelection) {
+        props.onGeocodingSelection(detail);
+      }
     }
   }, [isValid, onChange, props.onGeocodingSelection]);
 

--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -109,7 +109,8 @@ const DEFAULT_ZOOM_DELAY = 1000;
 const GeometryTypes = {
   geometryCollection: 'GeometryCollection',
   point: 'Point',
-  polygon: 'Polygon'
+  polygon: 'Polygon',
+  multiPolygon: 'MultiPolygon'
 };
 
 /**
@@ -138,7 +139,7 @@ const MapDraw = (props: Props) => {
     const { geometry: { type } } = detail;
 
     return (props.geocoding === 'point' && type === GeometryTypes.point)
-      || (props.geocoding === 'polygon' && type === GeometryTypes.polygon);
+      || (props.geocoding === 'polygon' && [GeometryTypes.polygon, GeometryTypes.multiPolygon].includes(type));
   }, [props.geocoding]);
 
   /**

--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -162,9 +162,7 @@ const MapDraw = (props: Props) => {
       onChange();
 
       // Call the onGeocoding selection callback
-      if (props.onGeocodingSelection) {
-        props.onGeocodingSelection(detail);
-      }
+      props.onGeocodingSelection(detail);
     }
   }, [isValid, onChange, props.onGeocodingSelection]);
 

--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -109,8 +109,7 @@ const DEFAULT_ZOOM_DELAY = 1000;
 const GeometryTypes = {
   geometryCollection: 'GeometryCollection',
   point: 'Point',
-  polygon: 'Polygon',
-  multiPolygon: 'MultiPolygon'
+  polygon: ['Polygon', 'MultiPolygon']
 };
 
 /**
@@ -139,7 +138,7 @@ const MapDraw = (props: Props) => {
     const { geometry: { type } } = detail;
 
     return (props.geocoding === 'point' && type === GeometryTypes.point)
-      || (props.geocoding === 'polygon' && [GeometryTypes.polygon, GeometryTypes.multiPolygon].includes(type));
+      || (props.geocoding === 'polygon' && GeometryTypes.polygon.includes(type));
   }, [props.geocoding]);
 
   /**


### PR DESCRIPTION
# Summary

The `isValid` function in the `MapDraw` component checks whether the type of a given geometry object matches the type set by the `geocoding` prop. However, the vast majority of results actually have the `MultiPolygon` type (e.g. countries with little bits that aren't connected to the mainland or [the Kentucky Bend](https://en.wikipedia.org/wiki/Kentucky_Bend)), which caused `isValid` to incorrectly reject the geometry for most polygon search results.

Accepting either Polygon or MultiPolygon when `geometry='polygon'` allows the data to be written to the map as expected.