### PR TITLE
Hide empty leftover `GeocodingControl` container with CSS

### DIFF
--- a/packages/geospatial/src/components/GeocodingControl.css
+++ b/packages/geospatial/src/components/GeocodingControl.css
@@ -1,0 +1,3 @@
+.maplibregl-ctrl-top-left .maplibregl-ctrl:empty {
+  margin: 0;
+}

--- a/packages/geospatial/src/components/GeocodingControl.js
+++ b/packages/geospatial/src/components/GeocodingControl.js
@@ -4,6 +4,7 @@ import { GeocodingControl as MapTilerGeocoding } from '@maptiler/geocoding-contr
 import maplibregl from 'maplibre-gl';
 import { forwardRef, useImperativeHandle } from 'react';
 import { useControl, type ControlPosition } from 'react-map-gl';
+import './GeocodingControl.css';
 
 type Props = {
   apiKey: string,


### PR DESCRIPTION
# Summary

This PR is an ugly fix for an issue where `@maptiler/geocoding-control/maplibregl`'s `GeocodingControl` component doesn't clean up its outermost container element on unmount, resulting in a new container spawning every time. Combined with the `key` re-mounting trick from #313, this means that the button slides down the page as the user toggles between modes.

These empty elements are visible because we're setting top/left margins on them via CSS. I would prefer to fix the issue at its root by making sure the elements get removed when `GeocodingControl` unmounts, but that seems to be the control's responsibility and we don't have a way to hook into it and do it ourselves. So in this PR I use the `:empty` selector to disable the margins on empty `.maplibregl-ctrl` elements, making them effectively invisible.

@dleadbetter I'm open to better ideas for how to deal with this - I know I could probably set up a `useEffect` in `MapDraw` that watches for `props.geocoding` and queries the nodes with `mapRef.current.querySelectorAll('.maplibregl-ctrl:empty')` and deletes them, but direct DOM manipulation inside a React component is pretty scary.

## The Bug

https://github.com/user-attachments/assets/24557048-f20d-43cf-a273-e8e1e2441453

## The DOM

The node at the bottom is the container for the current Geocoding Control. The previous ones are from previous mounts.

<img width="815" alt="Screenshot 2025-01-08 at 3 47 08 PM" src="https://github.com/user-attachments/assets/64b9bfd5-b784-4f4e-824c-6017e4460891" />

