### PR TITLE
Add `showPolygons` prop to `SearchResultsLayer`

### DIFF
--- a/packages/core-data/src/components/SearchResultsLayer.js
+++ b/packages/core-data/src/components/SearchResultsLayer.js
@@ -50,7 +50,10 @@ const SearchResultsLayer = (props: Props) => {
    *
    * @type {unknown}
    */
-  const data = useMemo(() => !_.isEmpty(hits) && TypesenseUtils.toFeatureCollection(hits, props.showPolygons), [hits]);
+  const data = useMemo(
+    () => !_.isEmpty(hits) && TypesenseUtils.toFeatureCollection(hits, props.showPolygons),
+    [hits, props.showPolygons]
+  );
 
   /**
    * Here we'll implement our own fitting of the bounding box once the search has completed and the map has loaded,

--- a/packages/core-data/src/components/SearchResultsLayer.js
+++ b/packages/core-data/src/components/SearchResultsLayer.js
@@ -26,8 +26,14 @@ type Props = {
   /**
    * If `true`, the map will fit the bounding box around the passed data.
    */
-  fitBoundingBox?: boolean
-};
+  fitBoundingBox?: boolean,
+
+  /**
+   * If `true`, polygons will be shown (when available) on the map
+   * instead of points.
+   */
+  showPolygons?: boolean
+}
 
 /**
  * This component renders a map layer for the search results from a Typesense search index.
@@ -44,7 +50,7 @@ const SearchResultsLayer = (props: Props) => {
    *
    * @type {unknown}
    */
-  const data = useMemo(() => !_.isEmpty(hits) && TypesenseUtils.toFeatureCollection(hits), [hits]);
+  const data = useMemo(() => !_.isEmpty(hits) && TypesenseUtils.toFeatureCollection(hits, props.showPolygons), [hits]);
 
   /**
    * Here we'll implement our own fitting of the bounding box once the search has completed and the map has loaded,

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -155,6 +155,7 @@ const normalizeResults = (results: Array<TypesenseSearchResult>) => (
  * Returns the passed Typesense search result as a GeoJSON feature.
  *
  * @param result
+ * @param polygons
  *
  * @returns {*}
  */
@@ -188,6 +189,7 @@ const toFeature = (result: any, polygons?: boolean) => {
  * Returns the passed array of Typesense search results as a GeoJSON feature collection.
  *
  * @param results
+ * @param polygons
  *
  * @returns {FeatureCollection<Geometry, Properties>}
  */

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -158,9 +158,7 @@ const normalizeResults = (results: Array<TypesenseSearchResult>) => (
  *
  * @returns {*}
  */
-const toFeature = (result: TypesenseSearchResult) => {
-  let value;
-
+const toFeature = (result: any, polygons?: boolean) => {
   const properties = {
     id: result.record_id,
     ccode: [],
@@ -174,14 +172,16 @@ const toFeature = (result: TypesenseSearchResult) => {
 
   const id = parseInt(result.record_id, 10);
 
-  if (result.coordinates) {
-    const coordinates = result.coordinates.slice().reverse();
-    value = point(coordinates, properties, { id });
-  } else {
-    value = feature(result.geometry, properties, { id });
+  if (polygons) {
+    return feature(result.geometry, properties, { id });
   }
 
-  return value;
+  if (result.coordinates) {
+    const coordinates = result.coordinates.slice().reverse();
+    return point(coordinates, properties, { id });
+  }
+
+  return feature(result.geometry, properties, { id });
 };
 
 /**
@@ -191,8 +191,8 @@ const toFeature = (result: TypesenseSearchResult) => {
  *
  * @returns {FeatureCollection<Geometry, Properties>}
  */
-const toFeatureCollection = (results: Array<TypesenseSearchResult>) => (
-  featureCollection(_.map(results, toFeature))
+const toFeatureCollection = (results: Array<any>, polygons?: boolean) => (
+  featureCollection(_.map(results, (result) => toFeature(result, polygons)))
 );
 
 export default {


### PR DESCRIPTION
# Summary

- adds a new prop called `showPolygons`. When enabled, the component will prefer polygonal data over points. Points will still be displayed if there's no polygon data.
- updates the `toFeatureCollection` and `toFeature` functions in `TypesenseUtils` with a new, optional boolean param called `polygons`