### PR TITLE
Add `onSSO` prop and conditionally rendered button to LoginModal

### DIFF
--- a/packages/semantic-ui/src/components/LoginModal.css
+++ b/packages/semantic-ui/src/components/LoginModal.css
@@ -2,6 +2,14 @@
   margin: 15px 150px 0px 150px;
 }
 
+.login-modal .ui.grid > .column > .sso-row {
+  margin: 15px 150px 15px 150px;
+}
+
+.login-modal .ui.grid > .column {
+  padding-top: 0;
+}
+
 .login-modal .ui.input.form-field {
   display: block;
 }

--- a/packages/semantic-ui/src/components/LoginModal.js
+++ b/packages/semantic-ui/src/components/LoginModal.js
@@ -4,6 +4,7 @@ import { ModalContext } from '@performant-software/shared-components';
 import React, { type Element } from 'react';
 import {
   Button,
+  Divider,
   Form,
   Grid,
   Header,
@@ -21,6 +22,7 @@ type Props = {
   onClose: () => void,
   onLogin: () => void,
   onPasswordChange: () => void,
+  onSSO?: () => void,
   onUsernameChange: () => void,
   open: boolean,
   trigger?: () => Element<any>,
@@ -53,6 +55,21 @@ const LoginModal = (props: Props) => (
           textAlign='center'
         >
           <Grid.Column>
+            {props.onSSO && (
+              <>
+                <Grid.Row>
+                  <Button
+                    onClick={props.onSSO.bind(this)}
+                    secondary
+                    size='medium'
+                    type='button'
+                  >
+                    {i18n.t('LoginModal.logInWithSso')}
+                  </Button>
+                  <Divider />
+                </Grid.Row>
+              </>
+            )}
             <Grid.Row>
               <Input
                 autoFocus

--- a/packages/semantic-ui/src/components/LoginModal.js
+++ b/packages/semantic-ui/src/components/LoginModal.js
@@ -57,7 +57,7 @@ const LoginModal = (props: Props) => (
           <Grid.Column>
             {props.onSSO && (
               <>
-                <Grid.Row>
+                <Grid.Row className='sso-row'>
                   <Button
                     onClick={props.onSSO.bind(this)}
                     secondary
@@ -66,8 +66,8 @@ const LoginModal = (props: Props) => (
                   >
                     {i18n.t('LoginModal.logInWithSso')}
                   </Button>
-                  <Divider />
                 </Grid.Row>
+                <Divider />
               </>
             )}
             <Grid.Row>

--- a/packages/semantic-ui/src/i18n/en.json
+++ b/packages/semantic-ui/src/i18n/en.json
@@ -290,6 +290,7 @@
     "header": "Login",
     "loginErrorContent": "The username and/or password you entered is invalid. Please double check and try again.",
     "loginErrorHeader": "Invalid Credentials",
+    "logInWithSso": "Single Sign On (SSO)",
     "password": "Password"
   },
   "PhotoViewer": {

--- a/packages/storybook/src/semantic-ui/LoginModal.stories.js
+++ b/packages/storybook/src/semantic-ui/LoginModal.stories.js
@@ -32,3 +32,15 @@ export const NoCloseButton = () => (
     open={boolean('Open', true)}
   />
 );
+
+export const SSO = () => (
+  <LoginModal
+    disabled={boolean('Disabled', false)}
+    loginFailed={boolean('Login failed', false)}
+    onLogin={action('login')}
+    onPasswordChange={action('password-change')}
+    onUsernameChange={action('username-change')}
+    onSSO={action('sso')}
+    open={boolean('Open', true)}
+  />
+);


### PR DESCRIPTION
# Summary

- adds a new optional `onSSO` callback function for `LoginModal` where the user can specify what happens when the user clicks the SSO button
- adds the aforementioned SSO button if the `onSSO` prop is provided (if not, the modal looks exactly the same as before)
- adds a new example in the Storybook

# Screenshot

I'm very open to feedback about the design of this. It was a little tricky to come up with phrasing and positioning that doesn't imply some sort of connection between the SSO button and the username/password inputs.

<img width="748" alt="Screenshot 2025-01-22 at 3 06 55 PM" src="https://github.com/user-attachments/assets/de1fd559-06cf-4865-8a85-5f7b718b2c53" />
