### PR TITLE
CDP #33 - Core data models

### DIFF
--- a/packages/core-data/src/components/FacetTimeline.js
+++ b/packages/core-data/src/components/FacetTimeline.js
@@ -56,9 +56,24 @@ type Props = {
   onLoad?: (events: Array<EventType>) => void,
 
   /**
-   * Typesense `useRange` hook.
+   * The absolute min/max values for the timeline range.
    */
-  useRange: ({ attribute: string }) => ({ refine: (range: [number, number]) => void }) => void,
+  range: {
+    max: number,
+    min: number
+  },
+
+  /**
+   * Callback fired when the slider value(s) are changed.
+   *
+   * @param any
+   */
+  refine: (number | [number, number]) => void,
+
+  /**
+   * The current value of the slider.
+   */
+  start: [number, number],
 
   /**
    * Zoom level increment.
@@ -66,10 +81,8 @@ type Props = {
   zoom?: number
 };
 
-const FACET_EVENT_RANGE = 'event_range_facet';
-
 const FacetTimeline = (props: Props) => {
-  const { range = {}, refine, start = [] } = props.useRange({ attribute: FACET_EVENT_RANGE });
+  const { range = {}, refine, start = [] } = props;
 
   const from = Math.max(range.min, Number.isFinite(start[0]) ? start[0] : range.min);
   const to = Math.min(range.max, Number.isFinite(start[1]) ? start[1] : range.max);

--- a/packages/core-data/src/components/HeaderImage.js
+++ b/packages/core-data/src/components/HeaderImage.js
@@ -1,0 +1,35 @@
+// @flow
+
+import React from 'react';
+import { Image } from 'lucide-react';
+
+type Props = {
+  alt?: string,
+  src: string
+};
+
+const HeaderImage = (props: Props) => (
+  <div
+    className='relative w-full h-[200px] flex-grow-0 flex-shrink-0 bg-muted/20 z-0'
+  >
+    <div
+      className='absolute top-0 left-0 w-full h-full flex justify-center items-center'
+    >
+      <Image
+        className='h-20 w-20 text-gray-400'
+        strokeWidth={1}
+      />
+    </div>
+    <div
+      className='absolute top-0 left-0 w-full h-full flex justify-center items-center'
+    >
+      <img
+        alt={props.alt}
+        className='object-cover h-full w-full'
+        src={props.src}
+      />
+    </div>
+  </div>
+);
+
+export default HeaderImage;

--- a/packages/core-data/src/components/KeyValueList.js
+++ b/packages/core-data/src/components/KeyValueList.js
@@ -1,0 +1,39 @@
+// @flow
+
+import React from 'react';
+import _ from 'underscore';
+
+type Item = {
+  label: string,
+  value: string
+};
+
+type Props = {
+  items: Array<Item>
+};
+
+const KeyValueList = (props: Props) => (
+  <ol
+    className='text-sm mt-4 leading-6 overflow-hidden'
+  >
+    { _.map(props.items, ({ label, value }) => (
+      <li
+        key={label}
+        className='mb-2'
+      >
+        <div
+          className='text-muted'
+        >
+          { label }
+        </div>
+        <div
+          className='font-medium overflow-hidden text-ellipsis'
+        >
+          { value }
+        </div>
+      </li>
+    ))}
+  </ol>
+);
+
+export default KeyValueList;

--- a/packages/core-data/src/components/PlaceDetails.js
+++ b/packages/core-data/src/components/PlaceDetails.js
@@ -1,8 +1,9 @@
 // @flow
 
-import { Image } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import _ from 'underscore';
+import HeaderImage from './HeaderImage';
+import KeyValueList from './KeyValueList';
 import { useLoader, usePlacesService } from '../hooks/CoreData';
 
 type Props = {
@@ -20,7 +21,10 @@ type Props = {
 };
 
 /**
- * This component renders a detail view for the passed Core Data place record.
+ * This component renders a detail view for the passed Core Data place record. This component is deprecated, as it is
+ * just a composition of other components, and will be removed in a future release.
+ *
+ * @deprecated
  */
 const PlaceDetails = (props: Props) => {
   const PlacesService = usePlacesService();
@@ -71,27 +75,10 @@ const PlaceDetails = (props: Props) => {
   return (
     <>
       { image && (
-        <div
-          className='relative w-full h-[200px] flex-grow-0 flex-shrink-0 bg-muted/20 z-0'
-        >
-          <div
-            className='absolute top-0 left-0 w-full h-full flex justify-center items-center'
-          >
-            <Image
-              className='h-20 w-20 text-gray-400'
-              strokeWidth={1}
-            />
-          </div>
-          <div
-            className='absolute top-0 left-0 w-full h-full flex justify-center items-center'
-          >
-            <img
-              className='object-cover h-full w-full'
-              src={image.content_iiif_url}
-              alt={image.name}
-            />
-          </div>
-        </div>
+        <HeaderImage
+          alt={image.name}
+          src={image.content_iiif_url}
+        />
       )}
       { place && (
         <div
@@ -102,27 +89,11 @@ const PlaceDetails = (props: Props) => {
           >
             { place.name }
           </h1>
-          <ol
-            className='text-sm mt-4 leading-6 overflow-hidden'
-          >
-            { _.map(userDefined, ({ label, value }) => (
-              <li
-                key={label}
-                className='mb-2'
-              >
-                <div
-                  className='text-muted'
-                >
-                  { label }
-                </div>
-                <div
-                  className='font-medium overflow-hidden text-ellipsis'
-                >
-                  { value }
-                </div>
-              </li>
-            ))}
-          </ol>
+          { userDefined && (
+            <KeyValueList
+              items={userDefined}
+            />
+          )}
         </div>
       )}
     </>

--- a/packages/core-data/src/components/SearchResultsLayer.js
+++ b/packages/core-data/src/components/SearchResultsLayer.js
@@ -29,10 +29,9 @@ type Props = {
   fitBoundingBox?: boolean,
 
   /**
-   * If `true`, polygons will be shown (when available) on the map
-   * instead of points.
+   * Path to the geometry attribute for each result.
    */
-  showPolygons?: boolean
+  geometry: string,
 }
 
 /**
@@ -50,10 +49,9 @@ const SearchResultsLayer = (props: Props) => {
    *
    * @type {unknown}
    */
-  const data = useMemo(
-    () => !_.isEmpty(hits) && TypesenseUtils.toFeatureCollection(hits, props.showPolygons),
-    [hits, props.showPolygons]
-  );
+  const data = useMemo(() => (
+    !_.isEmpty(hits) && TypesenseUtils.toFeatureCollection(hits, props.geometry)
+  ), [hits, props.geometry]);
 
   /**
    * Here we'll implement our own fitting of the bounding box once the search has completed and the map has loaded,

--- a/packages/core-data/src/hooks/CoreData.js
+++ b/packages/core-data/src/hooks/CoreData.js
@@ -11,6 +11,7 @@ import CoreDataContext from '../context/CoreData';
 import EventsService from '../services/Events';
 import InstancesService from '../services/Instances';
 import ItemsService from '../services/Items';
+import OrganizationsService from '../services/Organizations';
 import PeopleService from '../services/People';
 import PlacesService from '../services/Places';
 import WorksService from '../services/Works';
@@ -130,6 +131,16 @@ export const useInstancesService = () => {
 export const useItemsService = () => {
   const { baseUrl, projectIds } = useContext(CoreDataContext);
   return new ItemsService(baseUrl, projectIds);
+};
+
+/**
+ * Hook to initialize the organizations service.
+ *
+ * @returns {Items}
+ */
+export const useOrganizationsService = () => {
+  const { baseUrl, projectIds } = useContext(CoreDataContext);
+  return new OrganizationsService(baseUrl, projectIds);
 };
 
 /**

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -69,6 +69,7 @@ export {
 export { default as EventsService } from './services/Events';
 export { default as InstancesService } from './services/Instances';
 export { default as ItemsService } from './services/Items';
+export { default as OrganizationsService } from './services/Organizations';
 export { default as PeopleService } from './services/People';
 export { default as PlacesService } from './services/Places';
 export { default as WorksService } from './services/Works';

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -13,6 +13,8 @@ export { default as FacetListsGrouped } from './components/FacetListsGrouped';
 export { default as FacetSlider } from './components/FacetSlider';
 export { default as FacetStateContextProvider } from './components/FacetStateContextProvider';
 export { default as FacetTimeline } from './components/FacetTimeline';
+export { default as HeaderImage } from './components/HeaderImage';
+export { default as KeyValueList } from './components/KeyValueList';
 export { default as LayerMenu } from './components/LayerMenu';
 export { default as LoadAnimation } from './components/LoadAnimation';
 export { default as MediaGallery } from './components/MediaGallery';

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -51,6 +51,7 @@ export {
   useInstancesService,
   useItemsService,
   useLoader,
+  useOrganizationsService,
   usePeopleService,
   usePlacesService,
   useWorksService

--- a/packages/core-data/src/services/Organizations.js
+++ b/packages/core-data/src/services/Organizations.js
@@ -1,0 +1,19 @@
+// @flow
+
+import BaseService from './BaseService';
+
+/**
+ * Class responsible for making API calls to the Core Data `organizations` API endpoint.
+ */
+class Organizations extends BaseService {
+  /**
+   * Returns the organizations route name.
+   *
+   * @returns {string}
+   */
+  getRoute() {
+    return 'organizations';
+  }
+}
+
+export default Organizations;

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -198,13 +198,20 @@ const toFeature = (result: any, geometry: any) => {
  *
  * @returns {FeatureCollection<Geometry, Properties>}
  */
-const toFeatureCollection = (results: Array<any>, path: string) => (
-  featureCollection(
-    _.flatten(
-      _.map(results, (result) => _.map(getNestedValue(result, path), (geometry) => toFeature(result, geometry)))
-    )
-  )
-);
+const toFeatureCollection = (results: Array<any>, path: string) => {
+  const features = [];
+
+  _.each(results, (result) => {
+    const geometries = getNestedValue(result, path);
+    _.each(geometries, (geometry) => {
+      if (geometry) {
+        features.push(toFeature(result, geometry));
+      }
+    });
+  });
+
+  return featureCollection(features);
+};
 
 export default {
   createCachedHits,

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { Map as MapUtils } from '@performant-software/geospatial';
 import { feature, featureCollection, point } from '@turf/turf';
 import { history } from 'instantsearch.js/es/lib/routers';
 import TypesenseInstantsearchAdapter from 'typesense-instantsearch-adapter';
@@ -144,16 +143,6 @@ const getRelationshipId = (attribute: string) => {
 };
 
 /**
- * Necessary normalization steps to make the TypeSense result work
- * for visualization. Currently, these include:
- *
- * - Removing places without coordinates
- */
-const normalizeResults = (results: Array<TypesenseSearchResult>) => (
-  results.filter((h) => MapUtils.validateCoordinates(h.coordinates))
-);
-
-/**
  * Returns the passed Typesense search result as a GeoJSON feature.
  *
  * @param result
@@ -205,7 +194,6 @@ export default {
   createTypesenseAdapter,
   getFieldId,
   getRelationshipId,
-  normalizeResults,
   toFeature,
   toFeatureCollection
 };

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -202,7 +202,12 @@ const toFeatureCollection = (results: Array<any>, path: string) => {
   const features = [];
 
   _.each(results, (result) => {
-    const geometries = getNestedValue(result, path);
+    let geometries = getNestedValue(result, path);
+
+    if (!_.isArray(geometries)) {
+      geometries = [geometries];
+    }
+
     _.each(geometries, (geometry) => {
       if (geometry) {
         features.push(toFeature(result, geometry));

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -182,7 +182,7 @@ const toFeature = (result: any, geometry: any) => {
     uuid: result.uuid,
     record_id: result.record_id,
     name: result.name,
-    names: result.names.map((toponym: string) => ({ toponym })),
+    names: result.names?.map((toponym: string) => ({ toponym })),
     type: result.type
   };
 

--- a/packages/geospatial/src/components/LocationMarkers.js
+++ b/packages/geospatial/src/components/LocationMarkers.js
@@ -99,16 +99,6 @@ const LocationMarkers = (props: Props) => {
    */
   const data = useMemo(() => (_.isEmpty(props.data) ? null : props.data), [props.data]);
 
-  const cluster = useMemo(() => {
-    if (!props.cluster) {
-      return false;
-    }
-
-    console.log(data);
-
-    return true;
-  }, [data, props.cluster]);
-
   /**
    * Sets the bounding box on the map.
    */
@@ -135,7 +125,7 @@ const LocationMarkers = (props: Props) => {
         />
       )}
       <GeoJSONLayer
-        cluster={cluster}
+        cluster={props.cluster}
         clusterMaxZoom={props.clusterMaxZoom}
         clusterMinPoints={props.clusterMinPoints}
         clusterProperties={props.clusterProperties}

--- a/packages/geospatial/src/components/LocationMarkers.js
+++ b/packages/geospatial/src/components/LocationMarkers.js
@@ -99,6 +99,16 @@ const LocationMarkers = (props: Props) => {
    */
   const data = useMemo(() => (_.isEmpty(props.data) ? null : props.data), [props.data]);
 
+  const cluster = useMemo(() => {
+    if (!props.cluster) {
+      return false;
+    }
+
+    console.log(data);
+
+    return true;
+  }, [data, props.cluster]);
+
   /**
    * Sets the bounding box on the map.
    */
@@ -125,7 +135,7 @@ const LocationMarkers = (props: Props) => {
         />
       )}
       <GeoJSONLayer
-        cluster={props.cluster}
+        cluster={cluster}
         clusterMaxZoom={props.clusterMaxZoom}
         clusterMinPoints={props.clusterMinPoints}
         clusterProperties={props.clusterProperties}

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -45,6 +45,7 @@ export { default as Numbers } from './utils/Numbers';
 export { default as ObjectJs } from './utils/Object';
 export { default as String } from './utils/String';
 export { default as Timer } from './utils/Timer';
+export { default as UserDefinedFields } from './utils/UserDefinedFields';
 
 // Types
 export type { CitationsStyleProps } from './hooks/CitationStyles';

--- a/packages/shared/src/utils/UserDefinedFields.js
+++ b/packages/shared/src/utils/UserDefinedFields.js
@@ -1,0 +1,16 @@
+// @flow
+
+const DataTypes = {
+  boolean: 'Boolean',
+  date: 'Date',
+  fuzzyDate: 'FuzzyDate',
+  number: 'Number',
+  richText: 'RichText',
+  select: 'Select',
+  string: 'String',
+  text: 'Text'
+};
+
+export default {
+  DataTypes
+};

--- a/packages/storybook/src/core-data/FacetTimeline.stories.js
+++ b/packages/storybook/src/core-data/FacetTimeline.stories.js
@@ -20,14 +20,6 @@ const range = {
 
 const refine = () => {};
 
-// const useRange = () => ({
-//   range: {
-//     min: 1768,
-//     max: 1777
-//   },
-//   refine: () => {}
-// });
-
 export const Default = withCoreDataContextProvider(() => (
   <FacetTimeline
     range={range}

--- a/packages/storybook/src/core-data/FacetTimeline.stories.js
+++ b/packages/storybook/src/core-data/FacetTimeline.stories.js
@@ -13,17 +13,25 @@ export default {
   component: FacetTimeline
 };
 
-const useRange = () => ({
-  range: {
-    min: 1768,
-    max: 1777
-  },
-  refine: () => {}
-});
+const range = {
+  min: 1768,
+  max: 1777
+};
+
+const refine = () => {};
+
+// const useRange = () => ({
+//   range: {
+//     min: 1768,
+//     max: 1777
+//   },
+//   refine: () => {}
+// });
 
 export const Default = withCoreDataContextProvider(() => (
   <FacetTimeline
-    useRange={useRange}
+    range={range}
+    refine={refine}
     zoom={10}
   />
 ));
@@ -38,7 +46,8 @@ export const Styled = withCoreDataContextProvider(() => (
       track: 'bg-gray-400',
       zoom: 'text-white'
     }}
-    useRange={useRange}
+    range={range}
+    refine={refine}
     zoom={10}
   />
 ));
@@ -50,7 +59,8 @@ export const EventModal = withCoreDataContextProvider(() => {
     <>
       <FacetTimeline
         onClick={(event) => setSelectedEvent(event)}
-        useRange={useRange}
+        range={range}
+        refine={refine}
         zoom={10}
       />
       { selectedEvent && (
@@ -90,7 +100,8 @@ export const ListView = withCoreDataContextProvider(() => {
           onClick: () => setListView(true)
         }]}
         onLoad={setEvents}
-        useRange={useRange}
+        range={range}
+        refine={refine}
         zoom={10}
       />
       { listView && (
@@ -127,7 +138,8 @@ export const ListView = withCoreDataContextProvider(() => {
 export const Description = withCoreDataContextProvider(() => (
   <FacetTimeline
     description
-    useRange={useRange}
+    range={range}
+    refine={refine}
     zoom={10}
   />
 ));

--- a/packages/storybook/src/core-data/HeaderImage.stories.js
+++ b/packages/storybook/src/core-data/HeaderImage.stories.js
@@ -1,0 +1,16 @@
+// @flow
+
+import React from 'react';
+import HeaderImage from '../../../core-data/src/components/HeaderImage';
+import testImage from '../assets/test-image.jpg';
+
+export default {
+  title: 'Components/Core Data/HeaderImage',
+  component: HeaderImage
+};
+
+export const Default = () => (
+  <HeaderImage
+    src={testImage}
+  />
+);

--- a/packages/storybook/src/core-data/KeyValueList.stories.js
+++ b/packages/storybook/src/core-data/KeyValueList.stories.js
@@ -1,0 +1,21 @@
+// @flow
+
+import React from 'react';
+import KeyValueList from '../../../core-data/src/components/KeyValueList';
+
+export default {
+  title: 'Components/Core Data/KeyValueList',
+  component: KeyValueList
+};
+
+export const Default = () => (
+  <KeyValueList
+    items={[{
+      label: 'Test',
+      value: 'abc'
+    }, {
+      label: 'Another',
+      value: '123'
+    }]}
+  />
+);

--- a/packages/user-defined-fields/src/constants/DataTypes.js
+++ b/packages/user-defined-fields/src/constants/DataTypes.js
@@ -1,15 +1,8 @@
 // @flow
 
-const DataTypes = {
-  boolean: 'Boolean',
-  date: 'Date',
-  fuzzyDate: 'FuzzyDate',
-  number: 'Number',
-  richText: 'RichText',
-  select: 'Select',
-  string: 'String',
-  text: 'Text'
-};
+import { UserDefinedFields as UserDefinedFieldsUtils } from '@performant-software/shared-components';
+
+const { DataTypes } = UserDefinedFieldsUtils;
 
 export {
   DataTypes


### PR DESCRIPTION
This pull request updates the `core-data` package to work with any type of model, as opposed to just place records. These changes include:

- Removes the `useRange` prop from FacetTimeline in place of the `range`, `refine`, and `start` props
- Deprecates the `PlaceDetails` component and adds the `HeaderImage` and `KeyValueList` components
- Updates the `SearchResultsLayer` component to accept a `geometry` prop, which will be the path to the data that should be rendered on the map
  - `coordinates`
  - `<uuid>.geometry`
- Adds the missing `OrganizationsService` class
- Moves the user-defined fields `DataTypes` to the `shared` package; Adds a re-export in `user-defined-fields`
  - This will allow handling of user-defined fields without the need to import the whole package, which has `semantic-components` as a dependency