### PR TITLE
Prevent order overwrite in nested attributes payload (CDC #171)

### DIFF
--- a/packages/shared/src/transforms/NestedAttributesTransform.js
+++ b/packages/shared/src/transforms/NestedAttributesTransform.js
@@ -55,7 +55,7 @@ class NestedAttributesTransform {
   toPayload(record: any, collection: string) {
     return {
       [collection]: _.map(record[collection],
-        (item, index) => ({ ..._.pick(item, this.getPayloadKeys()), order: index }))
+        (item, index) => ({ order: index, ..._.pick(item, this.getPayloadKeys()) }))
     };
   }
 }


### PR DESCRIPTION
## In this PR

Per performant-software/core-data-cloud#171:
- Prevent payload `order` attribute from being overwritten by array index in nested attributes transform
  - see spread operator [overriding properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#overriding_properties)