### PR TITLE
Add Typesense environment variables to workflow

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Install and Build 🔧
+        env:
+          VITE_TYPESENSE_COLLECTION: ${{ secrets.VITE_TYPESENSE_COLLECTION }}
+          VITE_TYPESENSE_URL: ${{ secrets.VITE_TYPESENSE_URL }}
+          VITE_TYPESENSE_SEARCH_KEY: ${{ secrets.VITE_TYPESENSE_SEARCH_KEY }}
         run: | # Install npm packages and build the Storybook files
           yarn install
           yarn build-storybook


### PR DESCRIPTION
# Summary

This PR adds a few lines to `storybook.yml` that should allow the build process in the workflow to read the environment variables stored in the repo.