### PR TITLE
Adding `AccordionItemsList` component

### DIFF
--- a/packages/core-data/src/components/AccordionItemsList.js
+++ b/packages/core-data/src/components/AccordionItemsList.js
@@ -1,0 +1,126 @@
+// @flow
+
+import * as Accordion from '@radix-ui/react-accordion';
+import clsx from 'clsx';
+import React, { type Node } from 'react';
+import _ from 'underscore';
+
+type RelatedRecord = {
+  /**
+   * Optional data prop to pass other fields, e.g. if needed for rendering
+  */
+  data?: any,
+ 
+  /**
+    * The item will be rendered as a link if this prop is provided. Note this is overridden if a renderItem prop is provided
+  */
+  link?: string,
+
+  /**
+   * The primary name of the record (will display as text of the list item by default)
+   */
+  name: string,
+}
+
+type RelatedRecordsList = {  
+  /**
+   * The item count (optional)
+   */
+  count?: number | string,
+  
+  /**
+   * Icon to use in front of each list item. Defaults to bullet. Note this is overridden if a renderItem prop is provided
+   */
+  icon?: JSX.Element,
+
+  /**
+   * List of related items
+   */
+  items: Array<RelatedRecord>,
+
+  /**
+   * Optional render prop to render the title and count; defaults to `${title} (${count})`
+   */
+  renderTitle?: (title: String, count?: number | string) => JSX.Element,
+  
+  /**
+   * Optional render prop to render each item in the list
+  */
+  renderItem?: (item: RelatedRecord) => JSX.Element,
+
+  /**
+   * The title of the related model
+   */
+  title: string,
+}
+
+type Props = {
+  /**
+   * Optional list of classes to be applied to the root element
+   */
+  className?: string,
+
+  /**
+   * List of related models to render
+   */
+  relations: Array<RelatedRecordsList>
+};
+
+/**
+ * This component renders the passed list of related items in an accordion fashion.
+ */
+const AccordionItemsList = (props: Props) => (
+  <Accordion.Root
+    className={clsx(
+      'accordion-items-list',
+      props.className
+    )}
+    type='multiple'
+  >
+    { _.map(props.relations, (relation, idx) => (
+      <Accordion.Item key={idx} value={relation.title}>
+        <Accordion.Header
+          asChild
+        >
+          <h2>
+            <Accordion.Trigger className='accordion-trigger border-black/20 border border-t border-b-0 border-l-0 border-r-0 border-solid rounded-none w-full flex justify-between items-center px-3 py-3 text-sm'>
+              {
+                relation.renderTitle ? (
+                  relation.renderTitle(relation.title, relation.count)
+                ) : (
+                  <span>
+                    { relation.title }
+                    { relation.count ? <span className='ml-2'>({ relation.count })</span> : null }
+                  </span>
+                )
+              }
+            </Accordion.Trigger>
+          </h2>
+        </Accordion.Header>
+        <Accordion.Content
+          className='accordion-list-content text-sm leading-6 px-4 py-2'
+        >
+          <ul>
+            {
+              _.map(relation.items, (item, idx) => (
+                <>
+                  {
+                    relation.renderItem ? (
+                      relation.renderItem(item)
+                    ) : (
+                      <li key={idx}>
+                        { item.name }
+                      </li>
+                    )
+                  }
+                </>
+              ))
+            }
+          </ul>
+        </Accordion.Content>
+      </Accordion.Item>
+    ))}
+  </Accordion.Root>
+);
+
+export default AccordionItemsList;

--- a/packages/core-data/src/components/AccordionItemsList.js
+++ b/packages/core-data/src/components/AccordionItemsList.js
@@ -30,7 +30,7 @@ type RelatedRecordsList = {
   count?: boolean,
   
   /**
-   * Icon to use in front of each list item. Defaults to bullet. Note this is overridden if a renderItem prop is provided
+   * Icon to use in front of each list item. Defaults to none. Note this is overridden if a renderItem prop is provided
    */
   icon?: JSX.Element,
 

--- a/packages/core-data/src/components/AccordionItemsList.js
+++ b/packages/core-data/src/components/AccordionItemsList.js
@@ -85,8 +85,7 @@ const AccordionItemsList = (props: Props) => (
         >
           <h2>
             <Accordion.Trigger
-              className='accordion-list-trigger border-black/20 border border-t border-b-0 border-l-0 border-r-0 border-solid 
-                          rounded-none w-full flex justify-between items-center p-4 text-[15px] font-bold leading-[120%]'
+              className='accordion-list-trigger border-neutral-100 border border-t border-b-0 border-l-0 border-r-0 border-solid rounded-none w-full flex justify-between items-center p-4 text-[15px] font-bold leading-[120%]'
             >
               {
                 relation.renderTitle ? (
@@ -107,13 +106,7 @@ const AccordionItemsList = (props: Props) => (
           </h2>
         </Accordion.Header>
         <Accordion.Content
-          className={clsx(
-              'accordion-list-content',
-              'text-[13px]',
-              'font-semibold',
-              'leading-[120%]'
-            )
-          }
+          className='accordion-list-content text-[13px] font-semibold leading-[120%]'
         >
           <ul>
             {
@@ -133,12 +126,12 @@ const AccordionItemsList = (props: Props) => (
                         )}
                       >                           
                         {
-                          relation.icon ? (
+                          relation.icon && (
                             <Icon
                               name={relation.icon}
                               size={14}
                             />
-                          ) : null
+                          )
                         }
                         <span>
                           { item.name }                        

--- a/packages/core-data/src/components/AccordionItemsList.js
+++ b/packages/core-data/src/components/AccordionItemsList.js
@@ -4,6 +4,7 @@ import * as Accordion from '@radix-ui/react-accordion';
 import clsx from 'clsx';
 import React, { type Node } from 'react';
 import _ from 'underscore';
+import Icon from './Icon';
 
 type RelatedRecord = {
   /**
@@ -12,9 +13,9 @@ type RelatedRecord = {
   data?: any,
  
   /**
-    * The item will be rendered as a link if this prop is provided. Note this is overridden if a renderItem prop is provided
+    * Optional event fired when the item is clicked. Note this will be overridden if a renderItem prop is provided in the parent list
   */
-  link?: string,
+  onClick?: () => void,
 
   /**
    * The primary name of the record (will display as text of the list item by default)
@@ -26,7 +27,7 @@ type RelatedRecordsList = {
   /**
    * The item count (optional)
    */
-  count?: number | string,
+  count?: boolean,
   
   /**
    * Icon to use in front of each list item. Defaults to bullet. Note this is overridden if a renderItem prop is provided
@@ -83,22 +84,36 @@ const AccordionItemsList = (props: Props) => (
           asChild
         >
           <h2>
-            <Accordion.Trigger className='accordion-trigger border-black/20 border border-t border-b-0 border-l-0 border-r-0 border-solid rounded-none w-full flex justify-between items-center px-3 py-3 text-sm'>
+            <Accordion.Trigger
+              className='accordion-list-trigger border-black/20 border border-t border-b-0 border-l-0 border-r-0 border-solid 
+                          rounded-none w-full flex justify-between items-center p-4 text-[15px] font-bold leading-[120%]'
+            >
               {
                 relation.renderTitle ? (
                   relation.renderTitle(relation.title, relation.count)
                 ) : (
                   <span>
                     { relation.title }
-                    { relation.count ? <span className='ml-2'>({ relation.count })</span> : null }
+                    { relation.count ? <span className='ml-2'>({ relation.items.length })</span> : null }
                   </span>
                 )
               }
+              <Icon
+                className='accordion-list-chevron'
+                name='right'
+                size={18}
+              />
             </Accordion.Trigger>
           </h2>
         </Accordion.Header>
         <Accordion.Content
-          className='accordion-list-content text-sm leading-6 px-4 py-2'
+          className={clsx(
+              'accordion-list-content',
+              'text-[13px]',
+              'font-semibold',
+              'leading-[120%]'
+            )
+          }
         >
           <ul>
             {
@@ -108,8 +123,26 @@ const AccordionItemsList = (props: Props) => (
                     relation.renderItem ? (
                       relation.renderItem(item)
                     ) : (
-                      <li key={idx}>
-                        { item.name }
+                      <li key={idx} onClick={item.onClick} className={
+                        clsx(
+                          'flex flex-row gap-2 items-baseline px-6 py-2',
+                          { 
+                            'hover:bg-neutral-100' : item.onClick,
+                            'cursor-pointer': item.onClick
+                          }
+                        )}
+                      >                           
+                        {
+                          relation.icon ? (
+                            <Icon
+                              name={relation.icon}
+                              size={14}
+                            />
+                          ) : null
+                        }
+                        <span>
+                          { item.name }                        
+                        </span>
                       </li>
                     )
                   }

--- a/packages/core-data/src/index.css
+++ b/packages/core-data/src/index.css
@@ -2,6 +2,7 @@
 @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=DM+Serif+Display:ital@0;1&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 
 /* Component styles */
+@import './styles/AccordionItemsList.css';
 @import './styles/FacetList.css';
 @import './styles/FacetTimeline.css';
 @import './styles/LoadAnimation.css';

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -1,55 +1,56 @@
 // @flow
 
 // CSS
-import './index.css';
+import "./index.css";
 
 // Components
-export { default as Checkbox } from './components/Checkbox';
-export { default as CoreDataContextProvider } from './components/CoreDataContextProvider';
-export { default as EventDetails } from './components/EventDetails';
-export { default as EventsList } from './components/EventsList';
-export { default as FacetList } from './components/FacetList';
-export { default as FacetLists } from './components/FacetLists';
-export { default as FacetListsGrouped } from './components/FacetListsGrouped';
-export { default as FacetSlider } from './components/FacetSlider';
-export { default as FacetStateContextProvider } from './components/FacetStateContextProvider';
-export { default as FacetTimeline } from './components/FacetTimeline';
-export { default as HeaderImage } from './components/HeaderImage';
-export { default as HitsPerPage } from './components/HitsPerPage';
-export { default as Input } from './components/Input';
-export { default as KeyValueList } from './components/KeyValueList';
-export { default as LayerMenu } from './components/LayerMenu';
-export { default as LoadAnimation } from './components/LoadAnimation';
-export { default as MediaGallery } from './components/MediaGallery';
-export { default as Modal } from './components/Modal';
-export { default as OverlayLayers } from './components/OverlayLayers';
-export { default as Pagination } from './components/Pagination';
-export { default as PersistentSearchStateContextProvider } from './components/PersistentSearchStateContextProvider';
-export { default as Pill } from './components/Pill';
-export { default as PlaceDetails } from './components/PlaceDetails';
-export { default as PlaceLayersSelector } from './components/PlaceLayersSelector';
-export { default as PlaceMarkers } from './components/PlaceMarkers';
-export { default as SearchResultsList } from './components/SearchResultsList';
-export { default as RefinementListProxy } from './components/RefinementListProxy';
-export { default as RelatedEvents } from './components/RelatedEvents';
-export { default as RelatedItem } from './components/RelatedItem';
-export { default as RelatedItems } from './components/RelatedItems';
-export { default as RelatedItemsList } from './components/RelatedItemsList';
-export { default as RelatedList } from './components/RelatedList';
-export { default as RelatedMedia } from './components/RelatedMedia';
-export { default as RelatedOrganizations } from './components/RelatedOrganizations';
-export { default as RelatedPeople } from './components/RelatedPeople';
-export { default as RelatedPlaces } from './components/RelatedPlaces';
-export { default as RelatedPlacesLayer } from './components/RelatedPlacesLayer';
-export { default as RelatedSources } from './components/RelatedSources';
-export { default as RelatedTaxonomies } from './components/RelatedTaxonomies';
-export { default as SearchResultsLayer } from './components/SearchResultsLayer';
-export { default as SearchResultsTable } from './components/SearchResultsTable';
+export { default as AccordionItemsList } from "./components/AccordionItemsList";
+export { default as Checkbox } from "./components/Checkbox";
+export { default as CoreDataContextProvider } from "./components/CoreDataContextProvider";
+export { default as EventDetails } from "./components/EventDetails";
+export { default as EventsList } from "./components/EventsList";
+export { default as FacetList } from "./components/FacetList";
+export { default as FacetLists } from "./components/FacetLists";
+export { default as FacetListsGrouped } from "./components/FacetListsGrouped";
+export { default as FacetSlider } from "./components/FacetSlider";
+export { default as FacetStateContextProvider } from "./components/FacetStateContextProvider";
+export { default as FacetTimeline } from "./components/FacetTimeline";
+export { default as HeaderImage } from "./components/HeaderImage";
+export { default as HitsPerPage } from "./components/HitsPerPage";
+export { default as Input } from "./components/Input";
+export { default as KeyValueList } from "./components/KeyValueList";
+export { default as LayerMenu } from "./components/LayerMenu";
+export { default as LoadAnimation } from "./components/LoadAnimation";
+export { default as MediaGallery } from "./components/MediaGallery";
+export { default as Modal } from "./components/Modal";
+export { default as OverlayLayers } from "./components/OverlayLayers";
+export { default as Pagination } from "./components/Pagination";
+export { default as PersistentSearchStateContextProvider } from "./components/PersistentSearchStateContextProvider";
+export { default as Pill } from "./components/Pill";
+export { default as PlaceDetails } from "./components/PlaceDetails";
+export { default as PlaceLayersSelector } from "./components/PlaceLayersSelector";
+export { default as PlaceMarkers } from "./components/PlaceMarkers";
+export { default as SearchResultsList } from "./components/SearchResultsList";
+export { default as RefinementListProxy } from "./components/RefinementListProxy";
+export { default as RelatedEvents } from "./components/RelatedEvents";
+export { default as RelatedItem } from "./components/RelatedItem";
+export { default as RelatedItems } from "./components/RelatedItems";
+export { default as RelatedItemsList } from "./components/RelatedItemsList";
+export { default as RelatedList } from "./components/RelatedList";
+export { default as RelatedMedia } from "./components/RelatedMedia";
+export { default as RelatedOrganizations } from "./components/RelatedOrganizations";
+export { default as RelatedPeople } from "./components/RelatedPeople";
+export { default as RelatedPlaces } from "./components/RelatedPlaces";
+export { default as RelatedPlacesLayer } from "./components/RelatedPlacesLayer";
+export { default as RelatedSources } from "./components/RelatedSources";
+export { default as RelatedTaxonomies } from "./components/RelatedTaxonomies";
+export { default as SearchResultsLayer } from "./components/SearchResultsLayer";
+export { default as SearchResultsTable } from "./components/SearchResultsTable";
 
 // Contexts
-export { default as CoreDataContext } from './context/CoreData';
-export { default as FacetStateContext } from './context/FacetStateContext';
-export { default as PersistentSearchStateContext } from './context/PersistentSearchState';
+export { default as CoreDataContext } from "./context/CoreData";
+export { default as FacetStateContext } from "./context/FacetStateContext";
+export { default as PersistentSearchStateContext } from "./context/PersistentSearchState";
 
 // Hooks
 export {
@@ -60,29 +61,29 @@ export {
   useOrganizationsService,
   usePeopleService,
   usePlacesService,
-  useWorksService
-} from './hooks/CoreData';
-export { default as useProgressiveSearch } from './hooks/ProgressiveSearch';
+  useWorksService,
+} from "./hooks/CoreData";
+export { default as useProgressiveSearch } from "./hooks/ProgressiveSearch";
 export {
   useCachedHits,
   useGeoSearch,
   useGeoSearchToggle,
   useSearchBox,
-  useSearchCompleted
-} from './hooks/Typesense';
+  useSearchCompleted,
+} from "./hooks/Typesense";
 
 // Services
-export { default as EventsService } from './services/Events';
-export { default as InstancesService } from './services/Instances';
-export { default as ItemsService } from './services/Items';
-export { default as OrganizationsService } from './services/Organizations';
-export { default as PeopleService } from './services/People';
-export { default as PlacesService } from './services/Places';
-export { default as WorksService } from './services/Works';
+export { default as EventsService } from "./services/Events";
+export { default as InstancesService } from "./services/Instances";
+export { default as ItemsService } from "./services/Items";
+export { default as OrganizationsService } from "./services/Organizations";
+export { default as PeopleService } from "./services/People";
+export { default as PlacesService } from "./services/Places";
+export { default as WorksService } from "./services/Works";
 
 // Utilities
-export { default as Api } from './utils/Api';
-export { default as CoreData } from './utils/CoreData';
-export { default as Event } from './utils/Event';
-export { default as Peripleo } from './utils/Peripleo';
-export { default as Typesense } from './utils/Typesense';
+export { default as Api } from "./utils/Api";
+export { default as CoreData } from "./utils/CoreData";
+export { default as Event } from "./utils/Event";
+export { default as Peripleo } from "./utils/Peripleo";
+export { default as Typesense } from "./utils/Typesense";

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -61,7 +61,7 @@ export {
   useOrganizationsService,
   usePeopleService,
   usePlacesService,
-  useWorksService,
+  useWorksService
 } from './hooks/CoreData';
 export { default as useProgressiveSearch } from './hooks/ProgressiveSearch';
 export {
@@ -69,7 +69,7 @@ export {
   useGeoSearch,
   useGeoSearchToggle,
   useSearchBox,
-  useSearchCompleted,
+  useSearchCompleted
 } from './hooks/Typesense';
 
 // Services

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -1,56 +1,56 @@
 // @flow
 
 // CSS
-import "./index.css";
+import './index.css';
 
 // Components
-export { default as AccordionItemsList } from "./components/AccordionItemsList";
-export { default as Checkbox } from "./components/Checkbox";
-export { default as CoreDataContextProvider } from "./components/CoreDataContextProvider";
-export { default as EventDetails } from "./components/EventDetails";
-export { default as EventsList } from "./components/EventsList";
-export { default as FacetList } from "./components/FacetList";
-export { default as FacetLists } from "./components/FacetLists";
-export { default as FacetListsGrouped } from "./components/FacetListsGrouped";
-export { default as FacetSlider } from "./components/FacetSlider";
-export { default as FacetStateContextProvider } from "./components/FacetStateContextProvider";
-export { default as FacetTimeline } from "./components/FacetTimeline";
-export { default as HeaderImage } from "./components/HeaderImage";
-export { default as HitsPerPage } from "./components/HitsPerPage";
-export { default as Input } from "./components/Input";
-export { default as KeyValueList } from "./components/KeyValueList";
-export { default as LayerMenu } from "./components/LayerMenu";
-export { default as LoadAnimation } from "./components/LoadAnimation";
-export { default as MediaGallery } from "./components/MediaGallery";
-export { default as Modal } from "./components/Modal";
-export { default as OverlayLayers } from "./components/OverlayLayers";
-export { default as Pagination } from "./components/Pagination";
-export { default as PersistentSearchStateContextProvider } from "./components/PersistentSearchStateContextProvider";
-export { default as Pill } from "./components/Pill";
-export { default as PlaceDetails } from "./components/PlaceDetails";
-export { default as PlaceLayersSelector } from "./components/PlaceLayersSelector";
-export { default as PlaceMarkers } from "./components/PlaceMarkers";
-export { default as SearchResultsList } from "./components/SearchResultsList";
-export { default as RefinementListProxy } from "./components/RefinementListProxy";
-export { default as RelatedEvents } from "./components/RelatedEvents";
-export { default as RelatedItem } from "./components/RelatedItem";
-export { default as RelatedItems } from "./components/RelatedItems";
-export { default as RelatedItemsList } from "./components/RelatedItemsList";
-export { default as RelatedList } from "./components/RelatedList";
-export { default as RelatedMedia } from "./components/RelatedMedia";
-export { default as RelatedOrganizations } from "./components/RelatedOrganizations";
-export { default as RelatedPeople } from "./components/RelatedPeople";
-export { default as RelatedPlaces } from "./components/RelatedPlaces";
-export { default as RelatedPlacesLayer } from "./components/RelatedPlacesLayer";
-export { default as RelatedSources } from "./components/RelatedSources";
-export { default as RelatedTaxonomies } from "./components/RelatedTaxonomies";
-export { default as SearchResultsLayer } from "./components/SearchResultsLayer";
-export { default as SearchResultsTable } from "./components/SearchResultsTable";
+export { default as AccordionItemsList } from './components/AccordionItemsList';
+export { default as Checkbox } from './components/Checkbox';
+export { default as CoreDataContextProvider } from './components/CoreDataContextProvider';
+export { default as EventDetails } from './components/EventDetails';
+export { default as EventsList } from './components/EventsList';
+export { default as FacetList } from './components/FacetList';
+export { default as FacetLists } from './components/FacetLists';
+export { default as FacetListsGrouped } from './components/FacetListsGrouped';
+export { default as FacetSlider } from './components/FacetSlider';
+export { default as FacetStateContextProvider } from './components/FacetStateContextProvider';
+export { default as FacetTimeline } from './components/FacetTimeline';
+export { default as HeaderImage } from './components/HeaderImage';
+export { default as HitsPerPage } from './components/HitsPerPage';
+export { default as Input } from './components/Input';
+export { default as KeyValueList } from './components/KeyValueList';
+export { default as LayerMenu } from './components/LayerMenu';
+export { default as LoadAnimation } from './components/LoadAnimation';
+export { default as MediaGallery } from './components/MediaGallery';
+export { default as Modal } from './components/Modal';
+export { default as OverlayLayers } from './components/OverlayLayers';
+export { default as Pagination } from './components/Pagination';
+export { default as PersistentSearchStateContextProvider } from './components/PersistentSearchStateContextProvider';
+export { default as Pill } from './components/Pill';
+export { default as PlaceDetails } from './components/PlaceDetails';
+export { default as PlaceLayersSelector } from './components/PlaceLayersSelector';
+export { default as PlaceMarkers } from './components/PlaceMarkers';
+export { default as SearchResultsList } from './components/SearchResultsList';
+export { default as RefinementListProxy } from './components/RefinementListProxy';
+export { default as RelatedEvents } from './components/RelatedEvents';
+export { default as RelatedItem } from './components/RelatedItem';
+export { default as RelatedItems } from './components/RelatedItems';
+export { default as RelatedItemsList } from './components/RelatedItemsList';
+export { default as RelatedList } from './components/RelatedList';
+export { default as RelatedMedia } from './components/RelatedMedia';
+export { default as RelatedOrganizations } from './components/RelatedOrganizations';
+export { default as RelatedPeople } from './components/RelatedPeople';
+export { default as RelatedPlaces } from './components/RelatedPlaces';
+export { default as RelatedPlacesLayer } from './components/RelatedPlacesLayer';
+export { default as RelatedSources } from './components/RelatedSources';
+export { default as RelatedTaxonomies } from './components/RelatedTaxonomies';
+export { default as SearchResultsLayer } from './components/SearchResultsLayer';
+export { default as SearchResultsTable } from './components/SearchResultsTable';
 
 // Contexts
-export { default as CoreDataContext } from "./context/CoreData";
-export { default as FacetStateContext } from "./context/FacetStateContext";
-export { default as PersistentSearchStateContext } from "./context/PersistentSearchState";
+export { default as CoreDataContext } from './context/CoreData';
+export { default as FacetStateContext } from './context/FacetStateContext';
+export { default as PersistentSearchStateContext } from './context/PersistentSearchState';
 
 // Hooks
 export {
@@ -62,28 +62,28 @@ export {
   usePeopleService,
   usePlacesService,
   useWorksService,
-} from "./hooks/CoreData";
-export { default as useProgressiveSearch } from "./hooks/ProgressiveSearch";
+} from './hooks/CoreData';
+export { default as useProgressiveSearch } from './hooks/ProgressiveSearch';
 export {
   useCachedHits,
   useGeoSearch,
   useGeoSearchToggle,
   useSearchBox,
   useSearchCompleted,
-} from "./hooks/Typesense";
+} from './hooks/Typesense';
 
 // Services
-export { default as EventsService } from "./services/Events";
-export { default as InstancesService } from "./services/Instances";
-export { default as ItemsService } from "./services/Items";
-export { default as OrganizationsService } from "./services/Organizations";
-export { default as PeopleService } from "./services/People";
-export { default as PlacesService } from "./services/Places";
-export { default as WorksService } from "./services/Works";
+export { default as EventsService } from './services/Events';
+export { default as InstancesService } from './services/Instances';
+export { default as ItemsService } from './services/Items';
+export { default as OrganizationsService } from './services/Organizations';
+export { default as PeopleService } from './services/People';
+export { default as PlacesService } from './services/Places';
+export { default as WorksService } from './services/Works';
 
 // Utilities
-export { default as Api } from "./utils/Api";
-export { default as CoreData } from "./utils/CoreData";
-export { default as Event } from "./utils/Event";
-export { default as Peripleo } from "./utils/Peripleo";
-export { default as Typesense } from "./utils/Typesense";
+export { default as Api } from './utils/Api';
+export { default as CoreData } from './utils/CoreData';
+export { default as Event } from './utils/Event';
+export { default as Peripleo } from './utils/Peripleo';
+export { default as Typesense } from './utils/Typesense';

--- a/packages/core-data/src/styles/AccordionItemsList.css
+++ b/packages/core-data/src/styles/AccordionItemsList.css
@@ -1,0 +1,42 @@
+/* .accordion-items-list .accordion-chevron {
+  transition: transform 300ms cubic-bezier(0.87, 0, 0.13, 1);
+}
+
+.accordion-items-list .accordion-trigger[data-state='open'] > .accordion-chevron {
+  transform: rotate(180deg);
+} */
+
+.accordion-items-list .accordion-list-content {
+  overflow: hidden;
+}
+
+.accordion-items-list .accordion-list-content[data-state="closed"] {
+  visibility: hidden;
+  height: 0;
+}
+
+.accordion-items-list .accordion-list-content[data-state='open'] {
+  animation: slideDown 300ms cubic-bezier(0.87, 0, 0.13, 1);
+}
+
+.accordion-items-list .accordion-list-content[data-state='closed'] {
+  animation: slideUp 300ms cubic-bezier(0.87, 0, 0.13, 1);
+}
+
+@keyframes slideDown {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--radix-accordion-content-height);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    height: var(--radix-accordion-content-height);
+  }
+  to {
+    height: 0;
+  }
+}

--- a/packages/core-data/src/styles/AccordionItemsList.css
+++ b/packages/core-data/src/styles/AccordionItemsList.css
@@ -1,10 +1,10 @@
-/* .accordion-items-list .accordion-chevron {
+.accordion-items-list .accordion-list-chevron {
   transition: transform 300ms cubic-bezier(0.87, 0, 0.13, 1);
 }
 
-.accordion-items-list .accordion-trigger[data-state='open'] > .accordion-chevron {
-  transform: rotate(180deg);
-} */
+.accordion-items-list .accordion-list-trigger[data-state='open'] > .accordion-list-chevron {
+  transform: rotate(90deg);
+}
 
 .accordion-items-list .accordion-list-content {
   overflow: hidden;

--- a/packages/storybook/src/core-data/AccordionItemsList.stories.js
+++ b/packages/storybook/src/core-data/AccordionItemsList.stories.js
@@ -30,8 +30,99 @@ const sampleData = [
     }
 ]
 
+const sampleDataWithIcon = [
+    {
+        title: 'Related People',
+        items: [
+            {
+                name: 'Gon Freecs'
+            },
+            {
+                name: 'Killua Zoldyck'
+            }
+        ],
+        icon: 'person'
+    },
+    {
+        title: 'Related Organizations',
+        items: [
+            {
+                name: 'Hunters Association'
+            }
+        ],
+        icon: 'occupation'
+    }
+]
+
+const sampleDataWithCount = [
+  {
+      title: 'Related People',
+      items: [
+          {
+              name: 'Gon Freecs'
+          },
+          {
+              name: 'Killua Zoldyck'
+          }
+      ],
+      count: true
+  },
+  {
+      title: 'Related Organizations',
+      items: [
+          {
+              name: 'Hunters Association'
+          }
+      ],
+      count: true
+  }
+]
+
+const sampleDataWithClickEvent = [
+  {
+      title: 'Related People',
+      items: [
+          {
+              name: 'Gon Freecs',
+              onClick: () => { alert('Gon!') }
+          },
+          {
+              name: 'Killua Zoldyck'
+          }
+      ],
+      count: true
+  },
+  {
+      title: 'Related Organizations',
+      items: [
+          {
+              name: 'Hunters Association'
+          }
+      ],
+      count: true
+  }
+]
+
 export const Default = () => (
   <AccordionItemsList
     relations={sampleData}
   />
 );
+
+export const WithIcons = () => (
+  <AccordionItemsList
+    relations={sampleDataWithIcon}
+  />
+)
+
+export const WithCount = () => (
+  <AccordionItemsList
+    relations={sampleDataWithCount}
+  />
+)
+
+export const WithClickEvent = () => (
+  <AccordionItemsList
+    relations={sampleDataWithClickEvent}
+  />
+)

--- a/packages/storybook/src/core-data/AccordionItemsList.stories.js
+++ b/packages/storybook/src/core-data/AccordionItemsList.stories.js
@@ -13,10 +13,10 @@ const sampleData = [
         title: 'Related People',
         items: [
             {
-                name: 'Gon Freecs'
+                name: 'Kazuya Miyuki'
             },
             {
-                name: 'Killua Zoldyck'
+                name: 'Eijun Sawamura'
             }
         ]
     },
@@ -24,7 +24,7 @@ const sampleData = [
         title: 'Related Organizations',
         items: [
             {
-                name: 'Hunters Association'
+                name: 'Seido High School Baseball Club'
             }
         ]
     }
@@ -35,10 +35,10 @@ const sampleDataWithIcon = [
         title: 'Related People',
         items: [
             {
-                name: 'Gon Freecs'
+                name: 'Kazuya Miyuki'
             },
             {
-                name: 'Killua Zoldyck'
+                name: 'Eijun Sawamura'
             }
         ],
         icon: 'person'
@@ -47,7 +47,7 @@ const sampleDataWithIcon = [
         title: 'Related Organizations',
         items: [
             {
-                name: 'Hunters Association'
+                name: 'Seido High School Baseball Club'
             }
         ],
         icon: 'occupation'
@@ -59,10 +59,10 @@ const sampleDataWithCount = [
       title: 'Related People',
       items: [
           {
-              name: 'Gon Freecs'
+              name: 'Kazuya Miyuki'
           },
           {
-              name: 'Killua Zoldyck'
+              name: 'Eijun Sawamura'
           }
       ],
       count: true
@@ -71,7 +71,7 @@ const sampleDataWithCount = [
       title: 'Related Organizations',
       items: [
           {
-              name: 'Hunters Association'
+              name: 'Seido High School Baseball Club'
           }
       ],
       count: true
@@ -83,11 +83,11 @@ const sampleDataWithClickEvent = [
       title: 'Related People',
       items: [
           {
-              name: 'Gon Freecs',
-              onClick: () => { alert('Gon!') }
+              name: 'Kazuya Miyuki',
+              onClick: () => { alert('Kazuya Miyuki!') }
           },
           {
-              name: 'Killua Zoldyck'
+              name: 'Eijun Sawamura'
           }
       ],
       count: true
@@ -96,7 +96,7 @@ const sampleDataWithClickEvent = [
       title: 'Related Organizations',
       items: [
           {
-              name: 'Hunters Association'
+              name: 'Seido High School Baseball Club'
           }
       ],
       count: true

--- a/packages/storybook/src/core-data/AccordionItemsList.stories.js
+++ b/packages/storybook/src/core-data/AccordionItemsList.stories.js
@@ -1,0 +1,37 @@
+// @flow
+
+import React from 'react';
+import AccordionItemsList from '../../../core-data/src/components/AccordionItemsList';
+
+export default {
+  title: 'Components/Core Data/AccordionItemsList',
+  component: AccordionItemsList
+};
+
+const sampleData = [
+    {
+        title: 'Related People',
+        items: [
+            {
+                name: 'Gon Freecs'
+            },
+            {
+                name: 'Killua Zoldyck'
+            }
+        ]
+    },
+    {
+        title: 'Related Organizations',
+        items: [
+            {
+                name: 'Hunters Association'
+            }
+        ]
+    }
+]
+
+export const Default = () => (
+  <AccordionItemsList
+    relations={sampleData}
+  />
+);


### PR DESCRIPTION
### In this PR
Adds an accordion list component for displaying related record information in the record detail panel. See Figma: https://www.figma.com/design/5AWa1c3pJeVXwEeVPbRqZj/Place-Components-2.0?node-id=15-102&p=f&t=WW23fRNeoikc9Poz-0

![image](https://github.com/user-attachments/assets/645e4b0c-4fa9-4016-81c1-5ac3995c9b03)


### Notes
I wasn't sure how granular to get in terms of what components we're exporting; it would be possible to factor out e.g. the `<Accordion.Item>` part as its own component, but since it needs to be inside an `<Accordion.Root>` tag in any case it felt neater to me to just have the whole accordion list as one entity. But I'm open to other thoughts about how to structure it.