### PR TITLE
Configurable text color for Pill component

### DIFF
--- a/packages/core-data/src/components/Icon.js
+++ b/packages/core-data/src/components/Icon.js
@@ -7,18 +7,22 @@ import Icons from '../icons/icons.svg';
 type Props = {
   className?: string,
   name: string,
-  size: number
+  size: number,
+  style?: any
 };
 
 const DEFAULT_SIZE = 16;
 
-const Icon = ({ className, name, size = DEFAULT_SIZE }: Props) => (
+const Icon = ({
+  className, name, style, size = DEFAULT_SIZE
+}: Props) => (
   <svg
     className={clsx('icon', className)}
     width={size}
     height={size}
     viewBox={`0 0 ${DEFAULT_SIZE} ${DEFAULT_SIZE}`}
     preserveAspectRatio='none'
+    style={style}
   >
     <use
       xlinkHref={`${Icons}#icon-${name}`}

--- a/packages/core-data/src/components/Pill.js
+++ b/packages/core-data/src/components/Pill.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import clsx from 'clsx';
-import Icon from '../components/Icon';
+import Icon from './Icon';
 
 type Props = {
   /**
@@ -15,9 +15,13 @@ type Props = {
    */
   onRemove?: (data) => any,
   /**
-   * (Optional) Background color for the pill.
+   * (Optional) Background color for the pill (CSS value, not Tailwind).
    */
-  primary?: string
+  primary?: string,
+  /**
+   * (Optional) Text color for the pill (CSS value, not Tailwind).
+   */
+  textColor?: string
 }
 
 const Pill = (props: Props) => (
@@ -37,7 +41,7 @@ const Pill = (props: Props) => (
       { 'pr-2.5': !props.onRemove },
       { 'bg-primary': !props.primary }
     )}
-    style={{ backgroundColor: props.primary }}
+    style={{ backgroundColor: props.primary, color: props.textColor }}
   >
     <span>{props.label}</span>
     {props.onRemove && (
@@ -49,6 +53,7 @@ const Pill = (props: Props) => (
       <Icon
         name='close'
         size={14}
+        style={{ fill: props.textColor }}
       />
     </button>
     )}

--- a/packages/storybook/src/core-data/Pill.stories.js
+++ b/packages/storybook/src/core-data/Pill.stories.js
@@ -22,10 +22,11 @@ export const OnRemove = () => (
   />
 );
 
-export const CustomColor = () => (
+export const CustomColors = () => (
   <Pill
     label='Chip Text'
     onRemove={action('click')}
     primary='#fc94af'
+    textColor='#000000'
   />
 );


### PR DESCRIPTION
# Summary

This PR addresses #346 by adding a new `textColor` prop to the Pill component. The icon is also passed a `fill` value matching the text color.

## Screenshot

The top one is the default and the bottom one has been given custom colors for both text and background.

<img width="170" alt="Screenshot 2025-02-06 at 3 08 57 PM" src="https://github.com/user-attachments/assets/f62baced-c8f6-4eff-b420-7c35fe6bdf57" />
