### PR TITLE
Outline entire Input component on focus

### DIFF
--- a/packages/core-data/src/components/Input.js
+++ b/packages/core-data/src/components/Input.js
@@ -53,6 +53,7 @@ const Input = (props: Props) => {
         'rounded-[50px]',
         'text-md',
         'fill-neutral-800',
+        'focus-within:border-primary',
         props.className
       )}
     >
@@ -63,7 +64,7 @@ const Input = (props: Props) => {
         />
       )}
       <input
-        className='grow bg-transparent'
+        className='grow bg-transparent focus:outline-none group'
         placeholder={props.placeholder}
         onChange={(e) => props.onChange(e.target.value)}
         type='text'

--- a/packages/core-data/src/components/Input.js
+++ b/packages/core-data/src/components/Input.js
@@ -64,7 +64,7 @@ const Input = (props: Props) => {
         />
       )}
       <input
-        className='grow bg-transparent focus:outline-none group'
+        className='grow bg-transparent focus:outline-none'
         placeholder={props.placeholder}
         onChange={(e) => props.onChange(e.target.value)}
         type='text'


### PR DESCRIPTION
# Summary

This PR addresses the bullet points in #347 by moving the focus outline to the entire component instead of just the interior `input` element, and setting the outline color to `primary`.

## Video


https://github.com/user-attachments/assets/b3a26b4f-446a-48bc-8797-ee167f12a9c2

