### PR TITLE
SearchResultsTable overflow behavior

### DIFF
--- a/packages/core-data/src/components/Pagination.js
+++ b/packages/core-data/src/components/Pagination.js
@@ -13,7 +13,14 @@ import clsx from 'clsx';
 import HitsPerPage from './HitsPerPage';
 import i18n from '../i18n/i18n';
 
-const Pagination = () => {
+type Props = {
+  /**
+   * (Optional) Class name to append to the list of the Pagination container
+   */
+  className?: string
+}
+
+const Pagination = (props: Props) => {
   const { refine } = usePagination();
   const { results } = useInstantSearch();
 
@@ -48,7 +55,19 @@ const Pagination = () => {
   const onPreviousPage = () => refine(results.page - 1);
 
   return (
-    <div className='w-full h-10 bg-white flex justify-end items-center gap-4 text-sm px-4'>
+    <div className={clsx(
+      'w-full',
+      'h-10',
+      'bg-white',
+      'flex',
+      'justify-end',
+      'items-center',
+      'gap-4',
+      'text-sm',
+      'px-4',
+      props.className
+    )}
+    >
       <span className='font-bold'>
         {i18n.t('SearchResultsTable.rowsPerPage')}
       </span>

--- a/packages/core-data/src/components/SearchResultsTable.js
+++ b/packages/core-data/src/components/SearchResultsTable.js
@@ -32,35 +32,42 @@ const SearchResultsTable = (props: Props) => {
   const { results } = useInstantSearch();
 
   return (
-    <div className='rounded-md overflow-hidden inline-block border border-neutral-200 w-full'>
-      <table className='divide-y divide-neutral-200 w-full border-b border-neutral-200'>
-        <thead className='bg-neutral-100'>
-          <tr className='divide-x divide-neutral-200'>
-            {props.columns.map((col) => (
-              <th className='px-4 py-3 text-left text-sm font-bold text-gray-800'>
-                {col.label}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className='divide-y divide-neutral-200 border-b border-neutral-200'>
-          {results.hits.map((item, idx) => (
-            <tr
-              className='divide-x divide-neutral-200'
-              key={idx}
-            >
+    <div className='rounded-md inline-block border border-neutral-200 w-full h-full min-h-full flex flex-col'>
+      <div className='overflow-auto'>
+        <table className='divide-y divide-neutral-200 w-full max-h-full overflow-auto border-b border-neutral-200 grow-0'>
+          <thead className='bg-neutral-100 sticky top-0'>
+            <tr className='divide-x divide-neutral-200'>
               {props.columns.map((col) => (
-                <td className='px-4 py-3 text-sm whitespace-nowrap text-gray-800 text-sm'>
-                  {col.render
-                    ? col.render(item)
-                    : item[col.name]}
-                </td>
+                <th className='px-4 py-3 text-left text-sm font-bold text-gray-800 max-h-10'>
+                  {col.label}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
-      <Pagination />
+          </thead>
+          <tbody className='divide-y divide-neutral-200 border-b border-neutral-200'>
+            {results.hits.map((item, idx) => (
+              <tr
+                className='divide-x divide-neutral-200'
+                key={idx}
+              >
+                {props.columns.map((col) => (
+                  <td className='px-4 py-3 text-sm whitespace-nowrap text-gray-800 text-sm max-h-10'>
+                    {col.render
+                      ? col.render(item)
+                      : item[col.name]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {/* this empty div keeps the Pagination bar at the bottom, even
+          when there aren't enough results to fill the table */}
+      <div className='grow' />
+      <Pagination
+        className='sticky bottom-0 grow-0 w-full min-w-full'
+      />
     </div>
   );
 };

--- a/packages/storybook/src/core-data/SearchResultsTable.stories.js
+++ b/packages/storybook/src/core-data/SearchResultsTable.stories.js
@@ -12,25 +12,81 @@ export default {
 
 export const Default = () => (
   <InstantSearchProvider>
-    <SearchResultsTable
-      columns={[
-        {
-          label: 'UUID',
-          name: 'uuid'
-        },
-        {
-          label: 'Name',
-          name: 'name'
-        },
-        {
-          label: 'Location',
-          name: 'geometry',
-          render: (item) => (item.coordinates
-            ? `${item.coordinates[0]}, ${item.coordinates[1]}`
-            : '')
-        }
-      ]}
-      hits={hits}
-    />
+    <div className='h-80'>
+      <SearchResultsTable
+        columns={[
+          {
+            label: 'UUID',
+            name: 'uuid'
+          },
+          {
+            label: 'Name',
+            name: 'name'
+          },
+          {
+            label: 'Location',
+            name: 'geometry',
+            render: (item) => (item.coordinates
+              ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+              : '')
+          }
+        ]}
+        hits={hits}
+      />
+    </div>
+  </InstantSearchProvider>
+);
+
+export const Narrow = () => (
+  <InstantSearchProvider>
+    <div className='h-80 w-[400px]'>
+      <SearchResultsTable
+        columns={[
+          {
+            label: 'UUID',
+            name: 'uuid'
+          },
+          {
+            label: 'Name',
+            name: 'name'
+          },
+          {
+            label: 'Location',
+            name: 'geometry',
+            render: (item) => (item.coordinates
+              ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+              : '')
+          }
+        ]}
+        hits={hits}
+      />
+    </div>
+  </InstantSearchProvider>
+);
+
+export const ReallyBig = () => (
+  <InstantSearchProvider>
+    <div className='h-[80vh] w-[1000px]'>
+      <SearchResultsTable
+        columns={[
+          {
+            label: 'UUID',
+            name: 'uuid'
+          },
+          {
+            label: 'Name',
+            name: 'name'
+          },
+          {
+            label: 'Location',
+            name: 'geometry',
+            render: (item) => (item.coordinates
+              ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+              : '')
+          }
+        ]}
+        hits={hits}
+      />
+    </div>
   </InstantSearchProvider>
 );


### PR DESCRIPTION
# Summary

This PR addresses Chelsea's feedback from #348 with the following changes:

* the component will now fill the height and width of its parent container
* the table itself scrolls horizontally and/or vertically if it doesn't fit in the width of its parent
* the header row is sticky-positioned to the top
* the pagination row is sticky-positioned to the bottom

## Video


https://github.com/user-attachments/assets/961aec23-0bf8-4308-bf7c-9bea9c0671d1

