### PR TITLE
Adding record detail item component

### DIFF
--- a/packages/core-data/src/components/RecordDetailItem.js
+++ b/packages/core-data/src/components/RecordDetailItem.js
@@ -1,0 +1,43 @@
+// @flow
+
+import clsx from 'clsx';
+import React from 'react';
+import Icon from './Icon';
+
+type Props = {
+  /**
+   * Class name to apply to the list element.
+   */
+  className?: string,
+
+  /**
+   * The icon to display before the header.
+   */
+  icon?: string,
+
+  /**
+   * The text of the item.
+   */
+  text: string,
+};
+
+const RecordDetailItem = (props: Props) => (
+  <li
+    className={clsx(
+      'flex',
+      'flex-row',
+      'gap-2',
+      'py-1.5',
+      'items-center',
+      'text-[13px]',
+      'font-light',
+      'leading-[120%]',
+      props.className
+    )}
+  >
+    { props.icon && <Icon name={props.icon} size={14} /> }
+    <span>{ props.text }</span>
+  </li>
+);
+
+export default RecordDetailItem;

--- a/packages/storybook/src/core-data/RecordDetailItem.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailItem.stories.js
@@ -1,0 +1,16 @@
+// @flow
+
+import React from 'react';
+import RecordDetailItem from '../../../core-data/src/components/RecordDetailItem';
+
+export default {
+  title: 'Components/Core Data/RecordDetailItem',
+  component: RecordDetailItem
+};
+
+export const Default = () => (
+  <RecordDetailItem
+    text='March 11, 1986'
+    icon='date'
+  />
+);


### PR DESCRIPTION
### In this PR
Adds a utility component for rendering the values of Core Data fields on the record detail panel, including optional icons. See https://www.figma.com/design/5AWa1c3pJeVXwEeVPbRqZj/Place-Components-2.0?node-id=84-1209&m=dev

![image](https://github.com/user-attachments/assets/4c0e8194-3c01-4b5f-a893-13efef7b58ca)

Note: Should be merged after PR #353 