### PR TITLE
Fixing bug in button behavior with `className` prop

### DIFF
--- a/packages/core-data/src/components/Button.js
+++ b/packages/core-data/src/components/Button.js
@@ -7,7 +7,7 @@ type Props = {
   /**
    * Class name to apply to the root button element.
    */
-  customClassName?: string,
+  className?: string,
 
   /**
    * Child elements to append to the button.
@@ -37,6 +37,7 @@ type Props = {
 
 const Button = (props: Props) => (
   <button
+    {...props}
     className={clsx(
       'flex',
       'items-center',
@@ -48,10 +49,9 @@ const Button = (props: Props) => (
       { 'border border-solid border-gray-200': !props.primary },
       { 'bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary },
       { 'rounded-md': props.rounded },
-      props.customClassName
+      props.className
     )}
     type='button'
-    {...props}
   >
     { props.children }
   </button>

--- a/packages/storybook/src/core-data/Button.stories.js
+++ b/packages/storybook/src/core-data/Button.stories.js
@@ -72,7 +72,7 @@ export const IconOnly = () => (
 
 export const customClasses = () => (
   <Button
-    customClassName='bg-blue-500 text-white'
+    className='bg-blue-500 text-white'
   >
     This is blue
   </Button>


### PR DESCRIPTION
### In this PR
Changes the name of the `className` prop on `CoreData/src/Button.js` to 'customClassName`, to avoid conflict with native attribute, fixing previous behavior where supplying a value for `className` would end up overriding the existing styling. Also added a story showcasing the use of the prop.

![image](https://github.com/user-attachments/assets/545f100a-a6d1-4178-8902-bc31dbbd5932)

Note: This might not be the ideal fix, since obviously there might be instances of the `<Button>` component in various codebases that are using the `className` prop; but I don't believe that this change will actually change how those buttons are rendering, since as far as I can tell currently the value of `className` is simply replacing the default styling of the button rather than being appended to it, and that behavior should continue.

