### PR TITLE
Adding RecordDetailHeader component

### DIFF
--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -1,0 +1,77 @@
+// @flow
+
+import clsx from 'clsx';
+import React from 'react';
+import Icon from './Icon';
+import RecordDetailTitle from './RecordDetailTitle';
+import _ from 'underscore';
+import RecordDetailItem from './RecordDetailItem';
+
+type Props = {
+  /**
+   * Content to be rendered as the blurb
+   */
+  children?: Node,
+
+  /**
+   * Class name to apply to the main div.
+   */
+  className?: string,
+
+  /**
+   * List of detail fields to be rendered above the blurb
+   */
+  detailItems?: Array<{ text: string, icon?: string, className?: string }>,
+
+  /**
+   * The icon to display before the header.
+   */
+  icon?: string,
+
+  /**
+   * The text of the header.
+   */
+  title: string,
+
+  /**
+   * Additional classes to apply to the title element
+   */
+  titleClassName?: string
+};
+
+const RecordDetailHeader = (props: Props) => (
+  <div
+    className={clsx(
+      'flex',
+      'flex-col',
+      'gap-4',
+      'px-6',
+      'pt-6',
+      'pb-4',
+      props.className
+    )}
+  >
+    <RecordDetailTitle
+      text={props.title}
+      icon={props.icon}
+      className={props.titleClassName}
+    />
+    <ul>
+      {
+        _.map(props.detailItems, (item, idx) => (
+          <RecordDetailItem
+            text={item.text}
+            icon={item.icon}
+            className={item.className}
+            key={idx}
+          />
+        ))
+      }
+    </ul>
+    <div>
+      { props.children }
+    </div>
+  </div>
+);
+
+export default RecordDetailHeader;

--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -39,11 +39,6 @@ type Props = {
    * The text of the header.
    */
   title: string,
-
-  /**
-   * Additional classes to apply to the title element
-   */
-  titleClassName?: string
 };
 
 const RecordDetailHeader = (props: Props) => (
@@ -55,7 +50,7 @@ const RecordDetailHeader = (props: Props) => (
       'px-6',
       'pt-6',
       'pb-4',
-      props.className
+      props.classNames?.root
     )}
   >
     <RecordDetailTitle
@@ -65,7 +60,7 @@ const RecordDetailHeader = (props: Props) => (
     />
     {
       !!props.detailItems?.length && (
-        <ul className={props.classNames.items}>
+        <ul className={props.classNames?.items}>
           {
             _.map(props.detailItems, (item, idx) => (
               <RecordDetailItem

--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -16,9 +16,9 @@ type Props = {
   children?: Node,
 
   /**
-   * Class name to apply to the main div.
+   * Class names to apply to the main div, the title element, and the list element containing the detail items.
    */
-  className?: string,
+  classNames?: { items?: string, root?: string, title?: string },
 
   /**
    * List of detail fields to be rendered above the blurb
@@ -61,26 +61,30 @@ const RecordDetailHeader = (props: Props) => (
     <RecordDetailTitle
       text={props.title}
       icon={props.icon}
-      className={props.titleClassName}
+      className={props.classNames?.title}
     />
-    <ul>
-      {
-        _.map(props.detailItems, (item, idx) => (
-          <RecordDetailItem
-            text={item.text}
-            icon={item.icon}
-            className={item.className}
-            key={idx}
-          />
-        ))
-      }
-    </ul>
+    {
+      !!props.detailItems?.length && (
+        <ul className={props.classNames.items}>
+          {
+            _.map(props.detailItems, (item, idx) => (
+              <RecordDetailItem
+                text={item.text}
+                icon={item.icon}
+                className={item.className}
+                key={idx}
+              />
+            ))
+          }
+        </ul>
+      )
+    }
     <div>
       { props.children }
     </div>
     { props.detailPageUrl && (
       <a href={props.detailPageUrl}>   
-        <Button rounded customClassName='w-full justify-center'>
+        <Button rounded className='w-full justify-center'>
           { i18n.t('RecordDetailHeader.viewDetails') }
         </Button>
       </a>

--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -3,9 +3,11 @@
 import clsx from 'clsx';
 import React from 'react';
 import Icon from './Icon';
+import Button from './Button';
 import RecordDetailTitle from './RecordDetailTitle';
 import _ from 'underscore';
 import RecordDetailItem from './RecordDetailItem';
+import i18n from '../i18n/i18n';
 
 type Props = {
   /**
@@ -22,6 +24,11 @@ type Props = {
    * List of detail fields to be rendered above the blurb
    */
   detailItems?: Array<{ text: string, icon?: string, className?: string }>,
+
+  /**
+   * If a URL for a record detail page is provided, will render a button that links to it
+   */
+  detailPageUrl?: string,
 
   /**
    * The icon to display before the header.
@@ -71,6 +78,13 @@ const RecordDetailHeader = (props: Props) => (
     <div>
       { props.children }
     </div>
+    { props.detailPageUrl && (
+      <a href={props.detailPageUrl}>   
+        <Button rounded>
+          { i18n.t('RecordDetailHeader.viewDetails') }
+        </Button>
+      </a>
+    )}
   </div>
 );
 

--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -80,7 +80,7 @@ const RecordDetailHeader = (props: Props) => (
     </div>
     { props.detailPageUrl && (
       <a href={props.detailPageUrl}>   
-        <Button rounded>
+        <Button rounded customClassName='w-full justify-center'>
           { i18n.t('RecordDetailHeader.viewDetails') }
         </Button>
       </a>

--- a/packages/core-data/src/i18n/en.json
+++ b/packages/core-data/src/i18n/en.json
@@ -4,6 +4,9 @@
       "of": "of"
     }
   },
+  "RecordDetailHeader": {
+    "viewDetails": "View Details"
+  },
   "SearchResultsTable": {
     "rowsPerPage": "Rows per page"
   }

--- a/packages/storybook/src/core-data/RecordDetailHeader.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailHeader.stories.js
@@ -1,0 +1,29 @@
+// @flow
+
+import React from 'react';
+import RecordDetailHeader from '../../../core-data/src/components/RecordDetailHeader';
+
+export default {
+  title: 'Components/Core Data/RecordDetailHeader',
+  component: RecordDetailHeader
+};
+
+export const Default = () => (
+  <RecordDetailHeader
+    title='A Very Serious and Important Event'
+    detailItems={[
+      {
+        text: 'March 11, 1986',
+        icon: 'date'
+      },
+      {
+        text: 'Princton, NJ',
+        icon: 'location'
+      }
+    ]}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailHeader>
+);

--- a/packages/storybook/src/core-data/RecordDetailHeader.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailHeader.stories.js
@@ -27,3 +27,24 @@ export const Default = () => (
     </p>
   </RecordDetailHeader>
 );
+
+export const WithLink = () => (
+  <RecordDetailHeader
+    title='A Very Serious and Important Event'
+    detailItems={[
+      {
+        text: 'March 11, 1986',
+        icon: 'date'
+      },
+      {
+        text: 'Princton, NJ',
+        icon: 'location'
+      }
+    ]}
+    detailPageUrl='#'
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailHeader>
+)


### PR DESCRIPTION
### In this PR
Adds the `RecordDetailHeader` component for use in the record detail panel. The blurb is passed as a child node and thus preserves flexibility about exactly how it is rendered, e.g. from a rich text field in Core Data. The component takes an optional url prop; if provided, it will display a `View Details` button linking to the given url.

![image](https://github.com/user-attachments/assets/9f413ef3-b30d-44e8-87cf-5151e1525da1)

(The breadcrumb navigation and functionality such as `onClose` behavior will belong to the parent panel component, and so those elements are not included here.)

Note: This should be merged after PR #355 and PR #356 