### PR TITLE
Adding breadcrumb component for record detail panel

### DIFF
--- a/packages/core-data/src/components/RecordDetailBreadcrumbs.js
+++ b/packages/core-data/src/components/RecordDetailBreadcrumbs.js
@@ -45,8 +45,8 @@ const RecordDetailBreadcrumbs = (props: Props) => (
               'text-[13px]',
               'overflow-hidden',
               'text-nowrap',
-              { 'font-semibold underline' : idx == 0 },
-              { 'shrink-0' : idx == props.history.length - 1 },
+              { 'font-semibold' : idx === 0 },
+              { 'shrink-0' : idx === props.history.length - 1 },
               { 'text-ellipsis' : idx < props.history.length - 1 }
             )}
           >

--- a/packages/core-data/src/components/RecordDetailBreadcrumbs.js
+++ b/packages/core-data/src/components/RecordDetailBreadcrumbs.js
@@ -1,0 +1,61 @@
+// @flow
+
+import clsx from 'clsx';
+import React from 'react';
+import Icon from './Icon';
+import _ from 'underscore'
+
+type Props = {
+  /**
+   * Classes applied to the containing div
+   */
+  className?: string,
+
+  /**
+   * Array of crumbs to display, with the most recent last
+   */
+  history: Array<string>,
+
+  /**
+   * Function fired on clicking the back arrow
+   */
+  onGoBack?: () => void
+};
+
+const RecordDetailBreadcrumbs = (props: Props) => (
+  <div
+    className={clsx(
+      'flex',
+      'flex-row',
+      'items-center',
+      'gap-1.5',
+      props.className  
+    )}
+  >
+    { props.onGoBack && (
+      <div onClick={props.onGoBack} className='cursor-pointer'>
+        <Icon name='left_arrow' size={16} />
+      </div>
+    )}
+    {
+      _.map(props.history, (item, idx) => {
+        return (
+          <span
+            className={clsx(
+              'text-[13px]',
+              'overflow-hidden',
+              'text-nowrap',
+              { 'font-semibold underline' : idx == 0 },
+              { 'shrink-0' : idx == props.history.length - 1 },
+              { 'text-ellipsis' : idx < props.history.length - 1 }
+            )}
+          >
+            { `${ idx != 0 ? ' / ' : ''}${item}` }
+          </span>
+        )
+      })
+    }
+  </div>
+);
+
+export default RecordDetailBreadcrumbs;

--- a/packages/storybook/src/core-data/RecordDetailBreadcrumbs.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailBreadcrumbs.stories.js
@@ -1,0 +1,29 @@
+// @flow
+
+import React from 'react';
+import RecordDetailBreadcrumbs from '../../../core-data/src/components/RecordDetailBreadcrumbs';
+
+export default {
+  title: 'Components/Core Data/RecordDetailBreadcrumbs',
+  component: RecordDetailBreadcrumbs
+};
+
+export const Default = () => (
+  <RecordDetailBreadcrumbs
+    history={['First record', 'Second record', 'Third record']}
+  />
+);
+
+export const WithBackArrow = () => (
+  <RecordDetailBreadcrumbs
+    history={['First record', 'Second record', 'Third record']}
+    onGoBack={() => { alert('Go Back!') }}
+  />
+)
+
+export const NarrowWidth = () => (
+  <RecordDetailBreadcrumbs
+    history={['First record', 'Second record', 'Third record']}
+    className='w-60'
+  />
+);


### PR DESCRIPTION
### In this PR
Adds a breadcrumb navigation component for use in the record detail modal, which optionally accepts a function to be called when the back arrow is clicked.
![image](https://github.com/user-attachments/assets/25adb234-f4c1-411d-88e9-155741540440)
