### PR TITLE
Adding the record detail panel

### DIFF
--- a/packages/core-data/src/components/AccordionItemsList.js
+++ b/packages/core-data/src/components/AccordionItemsList.js
@@ -5,55 +5,7 @@ import clsx from 'clsx';
 import React, { type Node } from 'react';
 import _ from 'underscore';
 import Icon from './Icon';
-
-type RelatedRecord = {
-  /**
-   * Optional data prop to pass other fields, e.g. if needed for rendering
-  */
-  data?: any,
- 
-  /**
-    * Optional event fired when the item is clicked. Note this will be overridden if a renderItem prop is provided in the parent list
-  */
-  onClick?: () => void,
-
-  /**
-   * The primary name of the record (will display as text of the list item by default)
-   */
-  name: string,
-}
-
-type RelatedRecordsList = {  
-  /**
-   * The item count (optional)
-   */
-  count?: boolean,
-  
-  /**
-   * Icon to use in front of each list item. Defaults to none. Note this is overridden if a renderItem prop is provided
-   */
-  icon?: JSX.Element,
-
-  /**
-   * List of related items
-   */
-  items: Array<RelatedRecord>,
-
-  /**
-   * Optional render prop to render the title and count; defaults to `${title} (${count})`
-   */
-  renderTitle?: (title: String, count?: number | string) => JSX.Element,
-  
-  /**
-   * Optional render prop to render each item in the list
-  */
-  renderItem?: (item: RelatedRecord) => JSX.Element,
-
-  /**
-   * The title of the related model
-   */
-  title: string,
-}
+import type { RelatedRecordsList } from '../types/RelatedRecordsList';
 
 type Props = {
   /**

--- a/packages/core-data/src/components/RecordDetailPanel.js
+++ b/packages/core-data/src/components/RecordDetailPanel.js
@@ -11,6 +11,7 @@ import RecordDetailHeader from './RecordDetailHeader';
 import type { RelatedRecordsList } from '../types/RelatedRecordsList';
 import i18n from '../i18n/i18n';
 import _ from 'underscore';
+import RecordDetailBreadcrumbs from './RecordDetailBreadcrumbs';
 
 type Props = {
   /**
@@ -69,34 +70,44 @@ const RecordDetailPanel = (props: Props) => (
     className={clsx(
       'relative',
       'shadow-[0px_5px_12px_0px_rgba(0,0,0,.10)]',
+      'overflow-y-auto',
       props.classNames?.root
     )}
   >
-    { props.onClose && (
-      <Icon
-        name='close'
-        size='24'
-        onClick={props.onClose}
-        className='absolute top-6 right-6'
-      />
-    )}
-    <RecordDetailHeader
-      title={props.title}
-      icon={props.icon}
-      classNames={
-        { 
-          root: clsx('sticky', 'inset-0', 'shadow-[0px_1px_4px_0px_rgba(0,0,0,.15)]', props.classNames?.header), 
-          title: clsx(props.classNames?.title, { 'pr-6': props.onClose }), //make sure there's space for the close icon
-          items: props.classNames?.items 
+    <div className='sticky inset-0 shadow-[0px_1px_4px_0px_rgba(0,0,0,.15)] bg-white z-[5]'>
+      { props.onClose && (
+        <div onClick={props.onClose} className='absolute top-6 right-6 z-10 cursor-pointer'>
+          <Icon
+            name='close'
+            size={24}
+          />
+        </div>
+      )}
+      { (props.breadcrumbs || props.onGoBack) && (
+        <RecordDetailBreadcrumbs
+          history={props.breadcrumbs || []}
+          onGoBack={props.onGoBack}
+          className='absolute top-6 left-6 pr-6 max-w-[calc(100%_-4.5em)] z-10'
+        />
+      ) }
+      <RecordDetailHeader
+        title={props.title}
+        icon={props.icon}
+        classNames={
+          { 
+            root: clsx({'pt-16': props.breadcrumbs || props.onGoBack}, props.classNames?.header), 
+            title: clsx(props.classNames?.title, { 'pr-6': props.onClose }), //make sure there's space for the close icon
+            items: props.classNames?.items 
+          }
         }
-      }
-      detailItems={props.detailItems}
-      detailPageUrl={props.detailPageUrl}
-    >
-      { props.children }
-    </RecordDetailHeader>
+        detailItems={props.detailItems}
+        detailPageUrl={props.detailPageUrl}
+      >
+        { props.children }
+      </RecordDetailHeader>
+    </div>
     <AccordionItemsList
-      className={clsx('overflow-auto', props.classNames?.relatedRecords)}
+      className={clsx('shadow-[0px_1px_4px_rgba(0,0,0,.15)]', props.classNames?.relatedRecords)}
       relations={props.relations}
     />
   </div>

--- a/packages/core-data/src/components/RecordDetailPanel.js
+++ b/packages/core-data/src/components/RecordDetailPanel.js
@@ -1,0 +1,105 @@
+// @flow
+
+import clsx from 'clsx';
+import React from 'react';
+import Icon from './Icon';
+import Button from './Button';
+import RecordDetailTitle from './RecordDetailTitle';
+import RecordDetailItem from './RecordDetailItem';
+import AccordionItemsList from './AccordionItemsList';
+import RecordDetailHeader from './RecordDetailHeader';
+import type { RelatedRecordsList } from '../types/RelatedRecordsList';
+import i18n from '../i18n/i18n';
+import _ from 'underscore';
+
+type Props = {
+  /**
+   * A list of navigation breadcrumbs to be rendered above the title
+   */
+  breadcrumbs?: Array<string>,
+
+  /**
+   * Content to be rendered as the blurb
+   */
+  children?: Node,
+
+  /**
+   * Class names to apply to the root div, the header box, the title element, the list element containing the detail items, and the accordion list containing related records
+   */
+  classNames?: { header?: string, items?: string, relatedRecords?: string, root?: string, title?: string },
+
+  /**
+   * List of detail fields to be rendered above the blurb
+   */
+  detailItems?: Array<{ text: string, icon?: string, className?: string }>,
+
+  /**
+   * If a URL for a record detail page is provided, will render a button that links to it
+   */
+  detailPageUrl?: string,
+
+  /**
+   * The icon to display before the header.
+   */
+  icon?: string,
+
+  /**
+   * A function called when the `close` icon is clicked
+   */
+  onClose?: () => void,
+
+  /**
+   * A function called when the back arrow is clicked
+   */
+  onGoBack?: () => void,
+
+  /**
+   * An array of lists of related records for different model types
+   */
+  relations?: Array<RelatedRecordsList>,
+
+  /**
+   * The text of the header.
+   */
+  title: string,
+};
+
+const RecordDetailPanel = (props: Props) => (
+  <div
+    className={clsx(
+      'relative',
+      'shadow-[0px_5px_12px_0px_rgba(0,0,0,.10)]',
+      props.classNames?.root
+    )}
+  >
+    { props.onClose && (
+      <Icon
+        name='close'
+        size='24'
+        onClick={props.onClose}
+        className='absolute top-6 right-6'
+      />
+    )}
+    <RecordDetailHeader
+      title={props.title}
+      icon={props.icon}
+      classNames={
+        { 
+          root: clsx('sticky', 'inset-0', 'shadow-[0px_1px_4px_0px_rgba(0,0,0,.15)]', props.classNames?.header), 
+          title: clsx(props.classNames?.title, { 'pr-6': props.onClose }), //make sure there's space for the close icon
+          items: props.classNames?.items 
+        }
+      }
+      detailItems={props.detailItems}
+      detailPageUrl={props.detailPageUrl}
+    >
+      { props.children }
+    </RecordDetailHeader>
+    <AccordionItemsList
+      className={clsx('overflow-auto', props.classNames?.relatedRecords)}
+      relations={props.relations}
+    />
+  </div>
+);
+
+export default RecordDetailPanel;

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -31,6 +31,7 @@ export { default as PlaceDetails } from './components/PlaceDetails';
 export { default as PlaceLayersSelector } from './components/PlaceLayersSelector';
 export { default as PlaceMarkers } from './components/PlaceMarkers';
 export { default as SearchResultsList } from './components/SearchResultsList';
+export { default as RecordDetailPanel } from './components/RecordDetailPanel';
 export { default as RefinementListProxy } from './components/RefinementListProxy';
 export { default as RelatedEvents } from './components/RelatedEvents';
 export { default as RelatedItem } from './components/RelatedItem';

--- a/packages/core-data/src/types/RelatedRecord.js
+++ b/packages/core-data/src/types/RelatedRecord.js
@@ -1,0 +1,18 @@
+// @flow
+
+export type RelatedRecord = {
+  /**
+   * Optional data prop to pass other fields, e.g. if needed for rendering
+  */
+  data?: any,
+  
+  /**
+    * Optional event fired when the item is clicked. Note this will be overridden if a renderItem prop is provided in the parent list
+  */
+  onClick?: () => void,
+
+  /**
+   * The primary name of the record (will display as text of the list item by default)
+   */
+  name: string,
+}

--- a/packages/core-data/src/types/RelatedRecordsList.js
+++ b/packages/core-data/src/types/RelatedRecordsList.js
@@ -1,0 +1,35 @@
+// @flow
+
+import type { RelatedRecord } from './RelatedRecord';
+
+export type RelatedRecordsList = {  
+  /**
+   * If true, will render the item count in parentheses after the title. Note this is overridden if a renderTitle prop is provided
+   */
+  count?: boolean,
+  
+  /**
+   * Icon to use in front of each list item. Defaults to none. Note this is overridden if a renderItem prop is provided
+   */
+  icon?: JSX.Element,
+
+  /**
+   * List of related items
+   */
+  items: Array<RelatedRecord>,
+
+  /**
+   * Optional render prop to render the title and count; defaults to `${title} (${count})`
+   */
+  renderTitle?: (title: String, count?: number | string) => JSX.Element,
+  
+  /**
+   * Optional render prop to render each item in the list
+  */
+  renderItem?: (item: RelatedRecord) => JSX.Element,
+
+  /**
+   * The title of the related model
+   */
+  title: string,
+}

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -164,10 +164,11 @@ export const FixedWidthAndHeight = () => (
     breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
     onGoBack={() => { alert('Go back!'); }}
     classNames={{
-        root: 'w-[380px] h-[450px]'
+        root: 'w-[380px] h-[500px]'
       }
     } 
     onClose={() => { alert('Close!') }}
+    detailPageUrl='#'
   >
     <p>
       Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -40,7 +40,7 @@ const sampleData = [
 export const Default = () => (
   <RecordDetailPanel
     relations={sampleData}
-    title='West Tokyo Regional Qualifiers Quarterfinal'
+    title='West Tokyo Qualifiers Quarterfinal'
     detailItems={[
       {
         text: 'July 27',
@@ -62,7 +62,7 @@ export const WithViewDetail = () => (
   <RecordDetailPanel
     relations={sampleData}
     detailPageUrl='#'
-    title='West Tokyo Regional Qualifiers Quarterfinal'
+    title='West Tokyo Qualifiers Quarterfinal'
     detailItems={[
       {
         text: 'July 27',
@@ -83,7 +83,7 @@ export const WithViewDetail = () => (
 export const WithIcon = () => (
   <RecordDetailPanel
     relations={sampleData}
-    title='West Tokyo Regional Qualifiers Quarterfinal'
+    title='West Tokyo Qualifiers Quarterfinal'
     detailItems={[
       {
         text: 'July 27',
@@ -105,7 +105,7 @@ export const WithIcon = () => (
 export const WithClose = () => (
   <RecordDetailPanel
     relations={sampleData}
-    title='West Tokyo Regional Qualifiers Quarterfinal'
+    title='West Tokyo Qualifiers Quarterfinal'
     detailItems={[
       {
         text: 'July 27',
@@ -127,7 +127,7 @@ export const WithClose = () => (
 export const WithBreadcrumbs = () => (
   <RecordDetailPanel
     relations={sampleData}
-    title='West Tokyo Regional Qualifiers Quarterfinal'
+    title='West Tokyo Qualifiers Quarterfinal'
     detailItems={[
       {
         text: 'July 27',
@@ -138,6 +138,8 @@ export const WithBreadcrumbs = () => (
         icon: 'location'
       }
     ]}
+    breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
+    onGoBack={() => { alert('Go back!'); }}
   >
     <p>
       Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
@@ -145,10 +147,10 @@ export const WithBreadcrumbs = () => (
   </RecordDetailPanel>
 )
 
-export const FixedWidth = () => (
+export const FixedWidthAndHeight = () => (
   <RecordDetailPanel
     relations={sampleData}
-    title='West Tokyo Regional Qualifiers Quarterfinal'
+    title='West Tokyo Qualifiers Quarterfinal'
     detailItems={[
       {
         text: 'July 27',
@@ -159,10 +161,13 @@ export const FixedWidth = () => (
         icon: 'location'
       }
     ]}
+    breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
+    onGoBack={() => { alert('Go back!'); }}
     classNames={{
-        root: 'w-[380px]'
+        root: 'w-[380px] h-[450px]'
       }
     } 
+    onClose={() => { alert('Close!') }}
   >
     <p>
       Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -1,0 +1,171 @@
+// @flow
+
+import React from 'react';
+import RecordDetailPanel from '../../../core-data/src/components/RecordDetailPanel';
+
+export default {
+  title: 'Components/Core Data/RecordDetailPanel',
+  component: RecordDetailPanel
+};
+
+const sampleData = [
+    {
+        title: 'Related People',
+        items: [
+            {
+                name: 'Kazuya Miyuki'
+            },
+            {
+                name: 'Eijun Sawamura'
+            }
+        ],
+        icon: 'person',
+        count: true
+    },
+    {
+        title: 'Related Organizations',
+        items: [
+            {
+              name: 'Seido High School Baseball Club'
+            },
+            {
+              name: 'Yakushi High School Baseball Club'
+            }
+        ],
+        icon: 'occupation',
+        count: true
+    }
+]
+
+export const Default = () => (
+  <RecordDetailPanel
+    relations={sampleData}
+    title='West Tokyo Regional Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+);
+
+export const WithViewDetail = () => (
+  <RecordDetailPanel
+    relations={sampleData}
+    detailPageUrl='#'
+    title='West Tokyo Regional Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+)
+
+export const WithIcon = () => (
+  <RecordDetailPanel
+    relations={sampleData}
+    title='West Tokyo Regional Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+    icon='participants'
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+)
+
+export const WithClose = () => (
+  <RecordDetailPanel
+    relations={sampleData}
+    title='West Tokyo Regional Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+    onClose={() => { alert('Closed!') }}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>  
+  </RecordDetailPanel>
+)
+
+export const WithBreadcrumbs = () => (
+  <RecordDetailPanel
+    relations={sampleData}
+    title='West Tokyo Regional Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+)
+
+export const FixedWidth = () => (
+  <RecordDetailPanel
+    relations={sampleData}
+    title='West Tokyo Regional Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+    classNames={{
+        root: 'w-[380px]'
+      }
+    } 
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo. <span className='font-bold'>Tempor sem malesuada porttitor congue.</span> Nibh aenean vitae blandit vitae sapien ac varius mattis. Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+)


### PR DESCRIPTION
### In this PR
Adds the record detail panel component as an export to the `core-data` library. See https://www.figma.com/design/5AWa1c3pJeVXwEeVPbRqZj/Place-Components-2.0?node-id=85-3981&m=dev

Note: Should be merged after PR #359 .

![image](https://github.com/user-attachments/assets/4cd6a6ec-b285-43ae-a568-023db7072ef4)
