### PR TITLE
Core Data Places `Slider` component

### DIFF
--- a/packages/core-data/src/components/Input.js
+++ b/packages/core-data/src/components/Input.js
@@ -23,6 +23,12 @@ type Props = {
    * @param {string} value
    * @returns
    */
+  onBlur: (value: string) => any,
+  /**
+   * Callback function telling the component what to do when the user changes the value.
+   * @param {string} value
+   * @returns
+   */
   onChange: (value: string) => any,
   /**
    * (Optional) The name of the icon to show on the left side of the component.
@@ -66,6 +72,7 @@ const Input = (props: Props) => {
       <input
         className='grow bg-transparent focus:outline-none'
         placeholder={props.placeholder}
+        onBlur={(e) => props.onBlur(e.target.value)}
         onChange={(e) => props.onChange(e.target.value)}
         type='text'
         value={props.value || ''}

--- a/packages/core-data/src/components/Input.js
+++ b/packages/core-data/src/components/Input.js
@@ -70,12 +70,12 @@ const Input = (props: Props) => {
         />
       )}
       <input
-        className='grow bg-transparent focus:outline-none'
+        className='grow bg-transparent focus:outline-none w-full'
         placeholder={props.placeholder}
         onBlur={(e) => props.onBlur(e.target.value)}
         onChange={(e) => props.onChange(e.target.value)}
         type='text'
-        value={props.value || ''}
+        value={typeof props.value === 'undefined' ? '' : props.value}
       />
       {clearable && (
         <button

--- a/packages/core-data/src/components/Slider.js
+++ b/packages/core-data/src/components/Slider.js
@@ -6,6 +6,7 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import { clsx } from 'clsx';
 import React, { useCallback, useEffect, useState } from 'react';
 import Input from './Input';
+import Icon from './Icon';
 
 type MarkerProps = {
   className?: string,
@@ -125,6 +126,16 @@ type Props = {
   classNames: ClassNames,
 
   /**
+   * Icon to show in the header
+   */
+  icon?: string,
+
+  /**
+   * Label to show in the header
+   */
+  label?: string,
+
+  /**
    * The maximum facet value.
    */
   max?: number,
@@ -192,6 +203,26 @@ const Slider = (props: Props) => {
 
   return (
     <div className='p-4'>
+      {(props.icon || props.label) && (
+      <div
+        className='flex gap-2 items-center justify-center w-full'
+      >
+        {props.icon && (
+        <Icon
+          className='fill-neutral-800'
+          name={props.icon}
+          size={16}
+        />
+        )}
+        {props.label && (
+        <span
+          className='text-neutral-800 grow font-semibold text-lg'
+        >
+          {props.label}
+        </span>
+        )}
+      </div>
+      )}
       <div
         className='flex justify-between items-center pt-4'
       >

--- a/packages/core-data/src/components/Slider.js
+++ b/packages/core-data/src/components/Slider.js
@@ -178,14 +178,17 @@ const Slider = (props: Props) => {
       newVals.reverse();
     }
 
+    // Set first value to min if lower than min
     if (typeof props.min !== 'undefined' && newVals[0] <= props.min) {
       newVals[0] = props.min;
     }
 
+    // Set second value to max if higher than max
     if (typeof props.max !== 'undefined' && newVals[1] >= props.max) {
       newVals[1] = props.max;
     }
 
+    // keep a separation of at least 1 between values
     if (newVals[0] === newVals[1]) {
       if (props.max && newVals[1] < props.max) {
         newVals[1] += 1;

--- a/packages/core-data/src/components/Slider.js
+++ b/packages/core-data/src/components/Slider.js
@@ -1,0 +1,233 @@
+// @flow
+
+import { useTimer } from '@performant-software/shared-components';
+import * as RadixSlider from '@radix-ui/react-slider';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { clsx } from 'clsx';
+import React, { useEffect, useState } from 'react';
+import Input from './Input';
+
+type MarkerProps = {
+  className?: string,
+  position: 'top' | 'bottom' | 'left' | 'right',
+  value: number
+};
+
+const SliderMarker = (props: MarkerProps) => {
+  const [initialized, setInitialized] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const { clearTimer, setTimer } = useTimer();
+
+  /**
+   * If initialized, sets the "open" state to "true".
+   */
+  useEffect(() => {
+    if (!initialized) {
+      return;
+    }
+
+    // Set the open state to "true"
+    setOpen(true);
+
+    // Clear existing timers
+    clearTimer();
+
+    // Set a new timer
+    setTimer(() => setOpen(false));
+  }, [props.value]);
+
+  /**
+   * Sets the initialized state.
+   */
+  useEffect(() => {
+    if (!initialized) {
+      setInitialized(true);
+    }
+  }, [props.value]);
+
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root
+        open={open}
+      >
+        <Tooltip.Trigger
+          asChild
+        >
+          <RadixSlider.Thumb
+            className={clsx(
+              'block h-5 w-5 rounded-full bg-gray-600',
+              'focus:outline-none focus-visible:ring focus-visible:ring-black focus-visible:ring-opacity-30',
+              props.className
+            )}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setOpen(false)}
+            onMouseEnter={() => setOpen(true)}
+            onMouseLeave={() => setOpen(false)}
+          />
+        </Tooltip.Trigger>
+        <Tooltip.Content
+          side={props.position}
+          sideOffset={5}
+        >
+          <div
+            className='bg-white p-2 text-black rounded-md shadow-md shadow-gray-1000'
+          >
+            { props.value }
+          </div>
+          <Tooltip.Arrow
+            className='fill-white'
+          />
+        </Tooltip.Content>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+};
+
+SliderMarker.defaultProps = {
+  position: 'top'
+};
+
+type Action = {
+  /**
+   * Class name to apply to the button element.
+   */
+  className?: string,
+
+  /**
+   * (Optional) icon to render inside the button element.
+   */
+  icon?: JSX.Element,
+
+  /**
+   * Button label.
+   */
+  label: string,
+
+  /**
+   * Callback fired when the button is clicked.
+   */
+  onClick: () => void
+};
+
+type ClassNames = {
+  button: string,
+  range: string,
+  root: string,
+  thumb: string,
+  track: string,
+  zoom: string
+};
+
+type Props = {
+  /**
+   * Custom Tailwind CSS class names.
+   */
+  classNames: ClassNames,
+
+  /**
+   * The maximum facet value.
+   */
+  max?: number,
+
+  /**
+   * The minimum facet value.
+   */
+  min?: number,
+
+  /**
+   * Callback fired when the range is changed.
+   */
+  onValueChange: (value: [number, number]) => void,
+
+  /**
+   * Callback fired when the range is done changing.
+   */
+  onValueCommit?: (value: [number, number]) => void,
+
+  /**
+   * Position of the value tooltip marker.
+   */
+  position?: 'top' | 'bottom' | 'left' | 'right',
+
+  /**
+   * Value for controlled input.
+   */
+  value: [number, number]
+};
+
+const Slider = (props: Props) => (
+  <>
+    <div
+      className='flex justify-between items-center pt-4'
+    >
+      <RadixSlider.Root
+        className={clsx(
+          'relative flex flex-grow h-5 touch-none items-center w-full',
+          props.classNames.root
+        )}
+        max={props.max}
+        min={props.min}
+        minStepsBetweenThumbs={1}
+        onValueChange={props.onValueChange}
+        onValueCommit={props.onValueCommit}
+        step={1}
+        value={props.value}
+      >
+        <RadixSlider.Track
+          className={clsx(
+            'relative h-1 w-full grow bg-gray-100',
+            props.classNames.track
+          )}
+        >
+          <RadixSlider.Range
+            className={clsx(
+              'absolute h-full bg-gray-600',
+              props.classNames.range
+            )}
+          />
+        </RadixSlider.Track>
+        <SliderMarker
+          className={props.classNames.thumb}
+          position={props.position}
+          value={props.value[0]}
+        />
+        <SliderMarker
+          className={props.classNames.thumb}
+          position={props.position}
+          value={props.value[1]}
+        />
+      </RadixSlider.Root>
+    </div>
+    <div
+      className='flex justify-between w-full px-12'
+    >
+      <Input
+        className='rounded-md'
+        clearable={false}
+        onBlur={props.onValueCommit ? ((val) => props.onValueCommit([val, props.value[1]])) : undefined}
+        onChange={(val) => props.onValueChange([val, props.value[1]])}
+        value={props.value[0]}
+      />
+      <Input
+        className='rounded-md'
+        clearable={false}
+        onBlur={props.onValueCommit ? (val) => props.onValueCommit([props.value[0], val]) : undefined}
+        onChange={(val) => props.onValueChange([props.value[0], val])}
+        value={props.value[1]}
+      />
+    </div>
+  </>
+);
+
+Slider.defaultProps = {
+  classNames: {},
+  value: []
+};
+
+export default Slider;
+
+export type {
+  Action,
+  ClassNames
+};

--- a/packages/storybook/src/core-data/Slider.stories.js
+++ b/packages/storybook/src/core-data/Slider.stories.js
@@ -21,6 +21,39 @@ export const Default = () => {
   );
 };
 
+export const WithLabel = () => {
+  const [value, setValue] = useState([1500, 2010]);
+
+  return (
+    <div className='w-[300px] border border-black rounded-md'>
+      <Slider
+        min={1500}
+        max={2010}
+        label='Lifespan'
+        onValueChange={setValue}
+        value={value}
+      />
+    </div>
+  );
+};
+
+export const WithLabelAndIcon = () => {
+  const [value, setValue] = useState([1500, 2010]);
+
+  return (
+    <div className='w-[300px] border border-black rounded-md'>
+      <Slider
+        min={1500}
+        max={2010}
+        icon='person'
+        label='Lifespan'
+        onValueChange={setValue}
+        value={value}
+      />
+    </div>
+  );
+};
+
 export const CustomStyles = () => {
   const [value, setValue] = useState([1500, 2010]);
   const [committedValue, setCommittedValue] = useState([1500, 2010]);
@@ -63,5 +96,20 @@ export const TooltipPosition = () => {
       position='right'
       value={value}
     />
+  );
+};
+
+export const NarrowContainer = () => {
+  const [value, setValue] = useState([1500, 2010]);
+
+  return (
+    <div className='w-[300px] border border-black rounded-md'>
+      <Slider
+        min={1500}
+        max={2010}
+        onValueChange={setValue}
+        value={value}
+      />
+    </div>
   );
 };

--- a/packages/storybook/src/core-data/Slider.stories.js
+++ b/packages/storybook/src/core-data/Slider.stories.js
@@ -1,0 +1,67 @@
+// @flow
+
+import React, { useState } from 'react';
+import Slider from '../../../core-data/src/components/Slider';
+
+export default {
+  title: 'Components/Core Data/Slider',
+  component: Slider
+};
+
+export const Default = () => {
+  const [value, setValue] = useState([1500, 2010]);
+
+  return (
+    <Slider
+      min={1500}
+      max={2010}
+      onValueChange={setValue}
+      value={value}
+    />
+  );
+};
+
+export const CustomStyles = () => {
+  const [value, setValue] = useState([1500, 2010]);
+  const [committedValue, setCommittedValue] = useState([1500, 2010]);
+
+  return (
+    <div
+      className='bg-gray-1000 text-white fill-white py-7 rounded-md'
+    >
+      <p>
+        committed values:
+        {committedValue[0]}
+        ,
+        {committedValue[1]}
+      </p>
+      <Slider
+        classNames={{
+          button: 'px-4',
+          range: 'bg-white',
+          thumb: 'bg-white',
+          track: 'bg-gray-400'
+        }}
+        min={1500}
+        max={2010}
+        onValueChange={setValue}
+        onValueCommit={setCommittedValue}
+        value={value}
+      />
+    </div>
+  );
+};
+
+export const TooltipPosition = () => {
+  const [value, setValue] = useState([1500, 2010]);
+
+  return (
+    <Slider
+      min={1500}
+      max={2010}
+      onValueChange={setValue}
+      position='right'
+      value={value}
+    />
+  );
+};


### PR DESCRIPTION
# Summary

This PR adds the Slider component to the Core Data package.

It's very similar to the existing `RangeSlider`, and the main difference is the input fields that allow the user to type in a value. This required handling some edge cases, as shown in the recording below.

* when a value is out of range, we reset it to the nearest in-range value (i.e. min or max)
* when the user enters a value that changes the order of the two range values (e.g. going from `[0, 100]` to `[101, 100]`), we reverse the range array so the lower value comes first (this keeps the behavior consistent with the fact that you could already reverse the range array by dragging a slider past the other slider)
* when both values are equal, we add or remove 1 from one of the values in a way that's consistent with the range constraints

## Screen Recording

https://github.com/user-attachments/assets/c22e18ad-f92b-4797-b652-50aa757359fc