### PR TITLE
Core Data Places `SearchList` component

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -1,21 +1,38 @@
 // @flow
 
 import React from 'react';
-import { useInstantSearch } from 'react-instantsearch';
 import { type Attribute } from '../types/SearchList';
+import SearchListItem from './SearchListItem';
+import i18n from '../i18n/i18n';
 
 type Props = {
-  attributes: Attribute[]
+  /**
+   * Attributes to display (only the first three will be shown)
+   */
+  attributes: Attribute[],
+  /**
+   * Array of search result items
+   */
+  items: Array<any>
 };
 
-const SearchList = (props: Props) => {
-  const { results } = useInstantSearch();
-
-  return (
-    <div>
-      {results.length}
+const SearchList = (props: Props) => (
+  <div className='h-full'>
+    <div className='text-sm italic bg-white sticky top-0 py-2.5 px-6 shadow-sm'>
+      {props.items.length}
+        &nbsp;
+      {i18n.t('Common.words.results')}
     </div>
-  );
-};
+    <ul className='overflow-y-auto h-full divide-y divide-solid'>
+      {props.items.map((item) => (
+        <SearchListItem
+          title={item.name}
+          attributes={props.attributes}
+          item={item}
+        />
+      ))}
+    </ul>
+  </div>
+);
 
 export default SearchList;

--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -24,8 +24,9 @@ const SearchList = (props: Props) => (
       {i18n.t('Common.words.results')}
     </div>
     <ul className='overflow-y-auto h-full divide-y divide-solid'>
-      {props.items.map((item) => (
+      {props.items.map((item, idx) => (
         <SearchListItem
+          key={idx}
           title={item.name}
           attributes={props.attributes}
           item={item}

--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -1,0 +1,21 @@
+// @flow
+
+import React from 'react';
+import { useInstantSearch } from 'react-instantsearch';
+import { type Attribute } from '../types/SearchList';
+
+type Props = {
+  attributes: Attribute[]
+};
+
+const SearchList = (props: Props) => {
+  const { results } = useInstantSearch();
+
+  return (
+    <div>
+      {results.length}
+    </div>
+  );
+};
+
+export default SearchList;

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -1,0 +1,37 @@
+// @flow
+
+import React from 'react';
+import Icon from './Icon';
+import { type Attribute } from '../types/SearchList';
+
+type Props = {
+  /**
+   * Title of the record
+   */
+  title: string,
+  /**
+   * Attributes to display
+   */
+  attributes: Attribute[],
+  item: any
+};
+
+const ListItem = (props: Props) => (
+  <li>
+    <p>{props.title}</p>
+    {props.attributes.length > 0 && (
+      <ul>
+        {props.attributes.map((att) => (
+          <li key={att.name}>
+            <Icon name={att.icon || 'bullet'} />
+            {att.render
+              ? att.render(props.item)
+              : props.item[att.name]}
+          </li>
+        ))}
+      </ul>
+    )}
+  </li>
+);
+
+export default ListItem;

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -13,17 +13,27 @@ type Props = {
    * Attributes to display
    */
   attributes: Attribute[],
+  /**
+   * Search item object
+   */
   item: any
 };
 
 const ListItem = (props: Props) => (
-  <li>
-    <p>{props.title}</p>
+  <li className='py-3 px-6'>
+    <p className='font-bold text-neutral-800'>{props.title}</p>
     {props.attributes.length > 0 && (
-      <ul>
+      <ul className='list-none'>
         {props.attributes.map((att) => (
-          <li key={att.name}>
-            <Icon name={att.icon || 'bullet'} />
+          <li
+            className='text-sm text-neutral-800 flex gap-2 items-center list-none pl-5 pt-1'
+            key={att.name}
+          >
+            <Icon
+              className='min-w-[13px]'
+              name={att.icon || 'bullet'}
+              size={13}
+            />
             {att.render
               ? att.render(props.item)
               : props.item[att.name]}

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -10,7 +10,7 @@ type Props = {
    */
   title: string,
   /**
-   * Attributes to display
+   * Attributes to display (only the first three are shown)
    */
   attributes: Attribute[],
   /**
@@ -24,7 +24,7 @@ const ListItem = (props: Props) => (
     <p className='font-bold text-neutral-800'>{props.title}</p>
     {props.attributes.length > 0 && (
       <ul className='list-none'>
-        {props.attributes.map((att) => (
+        {props.attributes.slice(0, 3).map((att) => (
           <li
             className='text-sm text-neutral-800 flex gap-2 items-center list-none pl-5 pt-1'
             key={att.name}

--- a/packages/core-data/src/i18n/en.json
+++ b/packages/core-data/src/i18n/en.json
@@ -1,7 +1,8 @@
 {
   "Common": {
     "words": {
-      "of": "of"
+      "of": "of",
+      "results": "results"
     }
   },
   "RecordDetailHeader": {

--- a/packages/core-data/src/types/SearchList.js
+++ b/packages/core-data/src/types/SearchList.js
@@ -1,0 +1,8 @@
+// @flow
+
+export type Attribute = {
+  icon?: string,
+  label: string,
+  name: string,
+  render?: (item: any) => any
+}

--- a/packages/storybook/src/core-data/SearchList.stories.js
+++ b/packages/storybook/src/core-data/SearchList.stories.js
@@ -1,8 +1,23 @@
 // @flow
 
 import React from 'react';
-import InstantSearchProvider from '../components/InstantSearchProvider';
 import SearchList from '../../../core-data/src/components/SearchList';
+import data from '../data/typesense/Places.json';
+
+const LOTS_OF_DATA = [
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data
+];
+
+LOTS_OF_DATA[0].name = "I'm a really long name to showcase how this component handles really long names.";
 
 export default {
   title: 'Components/Core Data/SearchList',
@@ -10,7 +25,28 @@ export default {
 };
 
 export const Default = () => (
-  <InstantSearchProvider>
-    <SearchList attributes={[]} />
-  </InstantSearchProvider>
+  <div className='h-[600px] w-[360px]'>
+    <SearchList
+      attributes={[
+        {
+          label: 'UUID',
+          name: 'uuid',
+        },
+        {
+          label: 'Record ID',
+          name: 'record_id',
+          icon: 'person'
+        },
+        {
+          label: 'Location',
+          name: 'geometry',
+          icon: 'location',
+          render: (item) => (item.coordinates
+            ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+            : '')
+        },
+      ]}
+      items={LOTS_OF_DATA}
+    />
+  </div>
 );

--- a/packages/storybook/src/core-data/SearchList.stories.js
+++ b/packages/storybook/src/core-data/SearchList.stories.js
@@ -1,0 +1,16 @@
+// @flow
+
+import React from 'react';
+import InstantSearchProvider from '../components/InstantSearchProvider';
+import SearchList from '../../../core-data/src/components/SearchList';
+
+export default {
+  title: 'Components/Core Data/SearchList',
+  component: SearchList
+};
+
+export const Default = () => (
+  <InstantSearchProvider>
+    <SearchList attributes={[]} />
+  </InstantSearchProvider>
+);


### PR DESCRIPTION
# Summary

This PR adds the SearchList component from #335 

The component takes a list of items and a list of attributes to show. Attributes can be given an `icon` property. If left off, a bullet point will be shown as the icon.

The search list will expand to fit the height and width of its container, but the interior `ul` will scroll on the Y axis for overflow.

## Screenshot

<img width="380" alt="Screenshot 2025-02-11 at 1 37 33 PM" src="https://github.com/user-attachments/assets/7bc0834e-143a-4ad4-b096-75c799c6fcd7" />
