### PR TITLE
Core Data Places `SelectRecordPanel`

### DIFF
--- a/packages/core-data/src/components/SelectRecordPanel.js
+++ b/packages/core-data/src/components/SelectRecordPanel.js
@@ -21,9 +21,9 @@ type Props = {
   items: Array<any>,
 
   /**
-   * Name of the related modal
+   * Label to show at the top of the list
    */
-  modelName: string,
+  label?: string,
 
   /**
    * Callback fired when a record is clicked.
@@ -46,10 +46,7 @@ type Props = {
   title: string
 };
 
-/**
- * This component renders a list of search results returned from a Core Data Typesense index.
- */
-const SearchResultsList = (props: Props) => (
+const SelectRecordPanel = (props: Props) => (
   <div className='h-full bg-white'>
     <div className='flex items-center gap-2 w-full p-6'>
       {props.headerIcon && (
@@ -60,6 +57,7 @@ const SearchResultsList = (props: Props) => (
       )}
       <p className='font-bold text-xl grow'>{props.title}</p>
       <button
+        aria-label={i18n.t('Common.words.close')}
         className='flex items-center justify-center rounded-full hover:brightness-50 p-2'
         onClick={props.onClose}
         type='button'
@@ -70,11 +68,11 @@ const SearchResultsList = (props: Props) => (
         />
       </button>
     </div>
-    <p className='font-bold pt-2 pb-4 px-6 border-b text-lg'>
-      {i18n.t('Common.words.Select')}
-      &nbsp;
-      {props.modelName}
-    </p>
+    {props.label && (
+      <p className='font-bold pt-2 pb-4 px-6 border-b text-lg'>
+        {props.label}
+      </p>
+    )}
     <ul className='w-full h-full divide-y divide-solid'>
       {props.items.map((item, idx) => (
         <li
@@ -102,4 +100,4 @@ const SearchResultsList = (props: Props) => (
   </div>
 );
 
-export default SearchResultsList;
+export default SelectRecordPanel;

--- a/packages/core-data/src/components/SelectRecordPanel.js
+++ b/packages/core-data/src/components/SelectRecordPanel.js
@@ -31,6 +31,11 @@ type Props = {
   onClick: (item: any) => void,
 
   /**
+   * Callback fired when the close button is clicked.
+   */
+  onClose: () => void,
+
+  /**
    * Callback to get an item's name for the list.
    */
   renderItemName: (item: any) => string,
@@ -45,37 +50,48 @@ type Props = {
  * This component renders a list of search results returned from a Core Data Typesense index.
  */
 const SearchResultsList = (props: Props) => (
-  <div className='h-full bg-white'>
-    <div className='flex items-center gap-2 w-full'>
+  <div className='h-full bg-white font-inter'>
+    <div className='flex items-center gap-2 w-full p-6'>
       {props.headerIcon && (
         <Icon
           name={props.headerIcon}
           size={24}
         />
       )}
-      <h2 className='font-bold text-xl'>{props.title}</h2>
+      <p className='font-bold text-xl grow'>{props.title}</p>
+      <button
+        className='flex items-center justify-center rounded-full hover:brightness-50 p-2'
+        onClick={props.onClose}
+        type='button'
+      >
+        <Icon
+          name='close'
+          size={24}
+        />
+      </button>
     </div>
-    <h2 className='font-bold'>
+    <p className='font-bold pt-2 pb-4 px-6 border-b text-lg'>
       {i18n.t('Common.words.Select')}
       &nbsp;
       {props.modelName}
-    </h2>
-    <ul className='w-full h-full'>
-      {props.items.map((item) => (
+    </p>
+    <ul className='w-full h-full divide-y divide-solid'>
+      {props.items.map((item, idx) => (
         <li
-          className='hover:brightness-50 w-full'
+          className='hover:bg-neutral-100 w-full'
+          key={idx}
         >
           <button
-            className='flex items-center gap-2 py-2 px-6'
+            className='flex items-center gap-2 py-2 px-6 w-full min-h-[50px]'
             onClick={() => props.onClick(item)}
             type='button'
           >
             <Icon
               name={props.itemIcon || 'bullet'}
-              size={24}
+              size={14}
             />
             <span
-              className='font-semibold'
+              className='font-semibold text-left text-sm'
             >
               {props.renderItemName(item)}
             </span>

--- a/packages/core-data/src/components/SelectRecordPanel.js
+++ b/packages/core-data/src/components/SelectRecordPanel.js
@@ -50,7 +50,7 @@ type Props = {
  * This component renders a list of search results returned from a Core Data Typesense index.
  */
 const SearchResultsList = (props: Props) => (
-  <div className='h-full bg-white font-inter'>
+  <div className='h-full bg-white'>
     <div className='flex items-center gap-2 w-full p-6'>
       {props.headerIcon && (
         <Icon

--- a/packages/core-data/src/components/SelectRecordPanel.js
+++ b/packages/core-data/src/components/SelectRecordPanel.js
@@ -1,0 +1,89 @@
+// @flow
+
+import React from 'react';
+import i18n from '../i18n/i18n';
+import Icon from './Icon';
+
+type Props = {
+  /**
+   * Icon to show in the header
+   */
+  headerIcon?: string,
+
+  /**
+   * Icon to show next to each item in the list
+   */
+  itemIcon?: string,
+
+  /**
+   * An array of items.
+   */
+  items: Array<any>,
+
+  /**
+   * Name of the related modal
+   */
+  modelName: string,
+
+  /**
+   * Callback fired when a record is clicked.
+   */
+  onClick: (item: any) => void,
+
+  /**
+   * Callback to get an item's name for the list.
+   */
+  renderItemName: (item: any) => string,
+
+  /**
+   * Title of the parent record.
+   */
+  title: string
+};
+
+/**
+ * This component renders a list of search results returned from a Core Data Typesense index.
+ */
+const SearchResultsList = (props: Props) => (
+  <div className='h-full bg-white'>
+    <div className='flex items-center gap-2 w-full'>
+      {props.headerIcon && (
+        <Icon
+          name={props.headerIcon}
+          size={24}
+        />
+      )}
+      <h2 className='font-bold text-xl'>{props.title}</h2>
+    </div>
+    <h2 className='font-bold'>
+      {i18n.t('Common.words.Select')}
+      &nbsp;
+      {props.modelName}
+    </h2>
+    <ul className='w-full h-full'>
+      {props.items.map((item) => (
+        <li
+          className='hover:brightness-50 w-full'
+        >
+          <button
+            className='flex items-center gap-2 py-2 px-6'
+            onClick={() => props.onClick(item)}
+            type='button'
+          >
+            <Icon
+              name={props.itemIcon || 'bullet'}
+              size={24}
+            />
+            <span
+              className='font-semibold'
+            >
+              {props.renderItemName(item)}
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default SearchResultsList;

--- a/packages/core-data/src/i18n/en.json
+++ b/packages/core-data/src/i18n/en.json
@@ -1,9 +1,9 @@
 {
   "Common": {
     "words": {
+      "close": "Close",
       "of": "of",
-      "results": "results",
-      "Select": "Select"
+      "results": "results"
     }
   },
   "RecordDetailHeader": {

--- a/packages/core-data/src/i18n/en.json
+++ b/packages/core-data/src/i18n/en.json
@@ -2,7 +2,8 @@
   "Common": {
     "words": {
       "of": "of",
-      "results": "results"
+      "results": "results",
+      "Select": "Select"
     }
   },
   "RecordDetailHeader": {

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -8,6 +8,7 @@ const config = {
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-actions',
+    '@storybook/addon-backgrounds',
     '@storybook/addon-docs',
     '@storybook/addon-knobs',
     '@storybook/addon-links'

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -64,6 +64,19 @@ export const parameters = {
       )
     }
   },
+  backgrounds: {
+    values: [
+      {
+        name: 'light',
+        value: '#ffffff'
+      },
+      {
+        name: 'dark',
+        value: '#555555'
+      }
+    ],
+    default: 'light'
+  },
   options: {
     storySort: {
       order: ['Overview', 'Components']

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -21,6 +21,7 @@
     "@peripleo/peripleo": "^0.4.2",
     "@storybook/addon-a11y": "^7.6.17",
     "@storybook/addon-actions": "^7.6.17",
+    "@storybook/addon-backgrounds": "^7.6.17",
     "@storybook/addon-docs": "^7.6.17",
     "@storybook/addon-knobs": "^7.0.2",
     "@storybook/addon-links": "^7.6.17",

--- a/packages/storybook/src/core-data/SelectRecordPanel.stories.js
+++ b/packages/storybook/src/core-data/SelectRecordPanel.stories.js
@@ -7,17 +7,25 @@ import data from '../data/Companies.json';
 
 export default {
   title: 'Components/Core Data/SelectRecordPanel',
-  component: SelectRecordPanel
+  component: SelectRecordPanel,
+  parameters: {
+    backgrounds: {
+      default: 'dark'
+    }
+  }
 };
 
 export const Default = () => (
-  <SelectRecordPanel
-    items={data}
-    modelName='Organization'
-    onClick={action('click')}
-    renderItemName={(item) => item.company}
-    itemIcon='occupation'
-    headerIcon='location'
-    title='Cincinnati'
-  />
+  <div className='w-[360px] h-[600px]'>
+    <SelectRecordPanel
+      items={data}
+      modelName='Organization'
+      onClick={action('click')}
+      onClose={action('click')}
+      renderItemName={(item) => item.company}
+      itemIcon='occupation'
+      headerIcon='location'
+      title='Cincinnati, Ohio'
+    />
+  </div>
 );

--- a/packages/storybook/src/core-data/SelectRecordPanel.stories.js
+++ b/packages/storybook/src/core-data/SelectRecordPanel.stories.js
@@ -1,0 +1,23 @@
+// @flow
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import SelectRecordPanel from '../../../core-data/src/components/SelectRecordPanel';
+import data from '../data/Companies.json';
+
+export default {
+  title: 'Components/Core Data/SelectRecordPanel',
+  component: SelectRecordPanel
+};
+
+export const Default = () => (
+  <SelectRecordPanel
+    items={data}
+    modelName='Organization'
+    onClick={action('click')}
+    renderItemName={(item) => item.company}
+    itemIcon='occupation'
+    headerIcon='location'
+    title='Cincinnati'
+  />
+);

--- a/packages/storybook/src/core-data/SelectRecordPanel.stories.js
+++ b/packages/storybook/src/core-data/SelectRecordPanel.stories.js
@@ -19,7 +19,21 @@ export const Default = () => (
   <div className='w-[360px] h-[600px]'>
     <SelectRecordPanel
       items={data}
-      modelName='Organization'
+      onClick={action('click')}
+      onClose={action('click')}
+      renderItemName={(item) => item.company}
+      itemIcon='occupation'
+      headerIcon='location'
+      title='Cincinnati, Ohio'
+      label='Select organization'
+    />
+  </div>
+);
+
+export const NoLabel = () => (
+  <div className='w-[360px] h-[600px]'>
+    <SelectRecordPanel
+      items={data}
       onClick={action('click')}
       onClose={action('click')}
       renderItemName={(item) => item.company}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4116,6 +4116,15 @@
     polished "^4.2.2"
     uuid "^9.0.0"
 
+"@storybook/addon-backgrounds@^7.6.17":
+  version "7.6.20"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.6.20.tgz#a84758c07b236181f2d67966a7c159d0b3bc1abb"
+  integrity sha512-a7ukoaXT42vpKsMxkseIeO3GqL0Zst2IxpCTq5dSlXiADrcemSF/8/oNpNW9C4L6F1Zdt+WDtECXslEm017FvQ==
+  dependencies:
+    "@storybook/global" "^5.0.0"
+    memoizerific "^1.11.3"
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-docs@^7.6.17":
   version "7.6.17"
   resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-7.6.17.tgz#ea62be2da8b31df2c80a47cac4c30f66af4d2fbf"


### PR DESCRIPTION
# Summary

This PR includes the `SelectRecordPanel` component from #336. It expands to the height and width of its parent and accepts a list of items with a `renderTitle` callback to get the names to display in the list.

This PR also adds the Storybook background addon and configures a dark mode, which makes it easier to showcase components that have white backgrounds and no borders, like this one. It doesn't affect existing stories but allows us to use a darker background on a per-story basis.

## Screenshot

<img width="382" alt="Screenshot 2025-02-11 at 4 52 55 PM" src="https://github.com/user-attachments/assets/8f8601a6-c4e0-4c90-bac0-4d1126a3e90c" />
