### PR TITLE
Add `itemTitle` prop for SearchList

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -13,7 +13,11 @@ type Props = {
   /**
    * Array of search result items
    */
-  items: Array<any>
+  items: Array<any>,
+  /**
+   * Field name or callback function to return the title of an item
+   */
+  itemTitle: string | (item: any) => string
 };
 
 const SearchList = (props: Props) => (
@@ -26,10 +30,10 @@ const SearchList = (props: Props) => (
     <ul className='overflow-y-auto h-full divide-y divide-solid'>
       {props.items.map((item, idx) => (
         <SearchListItem
-          key={idx}
-          title={item.name}
           attributes={props.attributes}
+          key={idx}
           item={item}
+          title={typeof props.itemTitle === 'string' ? item[props.itemTitle] : props.itemTitle(item)}
         />
       ))}
     </ul>

--- a/packages/storybook/src/core-data/SearchList.stories.js
+++ b/packages/storybook/src/core-data/SearchList.stories.js
@@ -47,6 +47,35 @@ export const Default = () => (
         },
       ]}
       items={LOTS_OF_DATA}
+      itemTitle='name'
+    />
+  </div>
+);
+
+export const TitleCallback = () => (
+  <div className='h-[600px] w-[360px]'>
+    <SearchList
+      attributes={[
+        {
+          label: 'UUID',
+          name: 'uuid',
+        },
+        {
+          label: 'Record ID',
+          name: 'record_id',
+          icon: 'person'
+        },
+        {
+          label: 'Location',
+          name: 'geometry',
+          icon: 'location',
+          render: (item) => (item.coordinates
+            ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+            : '')
+        },
+      ]}
+      items={LOTS_OF_DATA}
+      itemTitle={(item) => `This record's name is "${item.name}"`}
     />
   </div>
 );


### PR DESCRIPTION
# Summary

This PR adds a new prop called `itemTitle` to the `SearchList` component that allows the consuming application to configure how item titles are rendered.

It can be a string or a function. If it's a string, the title will be rendered by accessing that property on the item (`item[props.itemTitle]`). If it's a function, it will be run with the item as an argument (`props.itemTitle(item)`).