### PR TITLE
Replace Radix UI icon in `Checkbox` with our checkbox SVGs

### DIFF
--- a/packages/core-data/src/components/Checkbox.js
+++ b/packages/core-data/src/components/Checkbox.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import * as RadixCheckbox from '@radix-ui/react-checkbox';
 import clsx from 'clsx';
-import { CheckIcon } from '@radix-ui/react-icons';
+import Icon from './Icon';
 
 type Props = {
   /**
@@ -25,33 +25,19 @@ type Props = {
 const Checkbox = (props: Props) => (
   <RadixCheckbox.Root
     checked={props.checked}
-    className={clsx(
-      '!border-solid',
-      'border',
-      'h-4',
-      'w-4',
-      'rounded-sm',
-      'flex',
-      'items-center',
-      'justify-center',
-      { 'bg-primary': props.checked },
-      { 'hover:bg-primary': props.checked },
-      { 'bg-white': !props.checked },
-      { 'hover:bg-white': !props.checked },
-      { 'border-primary': props.checked },
-      { 'border-black': !props.checked }
-    )}
+    className='rounded-sm'
     disabled={props.disabled}
     onCheckedChange={props.onClick}
   >
-    <RadixCheckbox.Indicator
-      className='w-full h-full'
-    >
-      {props.checked && (
-        <CheckIcon
-          className='h-3.5 w-3.5 text-white'
-        />
-      )}
+    <RadixCheckbox.Indicator asChild forceMount>
+      <Icon
+        className={clsx(
+          { 'fill-primary': props.checked },
+          { 'fill-black': !props.checked },
+          { 'hover:bg-white': !props.checked },
+        )}
+        name={props.checked ? 'checkbox-filled' : 'checkbox'}
+      />
     </RadixCheckbox.Indicator>
   </RadixCheckbox.Root>
 );


### PR DESCRIPTION
# Summary

In https://github.com/performant-software/react-components/pull/363/files#diff-2a3cce7201f63050cd7c3cc94ef3679474c75b5e680d68313aa859c4e171749d, I noticed that the checkboxes in Figma were actually SVGs, rather than just a check icon with CSS styling around it. In that PR, I brought those SVGs into our `Icon` component.

This PR migrates the `Checkbox` component over to being based on the icons, too. This simplifies the styling and should fix #374.