### PR TITLE
Set Inter as the default font for Core Data components

### DIFF
--- a/packages/core-data/tailwind.config.js
+++ b/packages/core-data/tailwind.config.js
@@ -19,7 +19,7 @@ export default {
         secondary: colors.neutral['200']
       },
       fontFamily: {
-        inter: [
+        sans: [
           'Inter',
           ...fontFamily.sans
         ]


### PR DESCRIPTION
# Summary

This PR renames the `inter` font family in the Tailwind config to `sans`, which will make it the default font across all Tailwind-based components in `core-data`.

Storybook is still importing some Semantic UI styles that override Tailwind, but I can see in the dev tools that the components would be displaying Inter if not for that. So I expect this PR to fix the font issue for consuming applications, if not for Storybook.