### PR TITLE
Mouse handler callback props for `SearchResultsTable`

### DIFF
--- a/packages/core-data/src/components/SearchResultsTable.js
+++ b/packages/core-data/src/components/SearchResultsTable.js
@@ -1,5 +1,6 @@
 // @flow
 
+import clsx from 'clsx';
 import React, { useMemo, useState } from 'react';
 import Pagination from './Pagination';
 
@@ -28,7 +29,19 @@ type Props = {
   /**
    * Array of search hit objects.
    */
-  hits: Array<any>
+  hits: Array<any>,
+  /**
+   * Callback that fires when an item is clicked
+   */
+  onRowClick?: (hit: any) => void,
+  /**
+    * Callback that fires when the mouse begins to hover over an item
+    */
+  onRowMouseEnter?: (hit: any) => void,
+  /**
+    * Callback that fires when the mouse stops hovering over an item
+    */
+  onRowMouseLeave?: (hit: any) => void
 }
 
 const SearchResultsTable = (props: Props) => {
@@ -79,7 +92,19 @@ const SearchResultsTable = (props: Props) => {
           <tbody className='divide-y divide-neutral-200 border-b border-neutral-200'>
             {hitsToShow.map((hit, idx) => (
               <tr
-                className='divide-x divide-neutral-200'
+                className={clsx(
+                  'divide-x divide-neutral-200',
+                  { 'hover:bg-neutral-200 cursor-pointer': props.onRowClick }
+                )}
+                onClick={props.onRowClick
+                  ? () => props.onRowClick(hit)
+                  : undefined}
+                onMouseEnter={props.onRowMouseEnter
+                  ? () => props.onRowMouseEnter(hit)
+                  : undefined}
+                onMouseLeave={props.onRowMouseLeave
+                  ? () => props.onRowMouseLeave(hit)
+                  : undefined}
                 key={idx}
               >
                 {props.columns.map((col) => (

--- a/packages/storybook/src/core-data/SearchResultsTable.stories.js
+++ b/packages/storybook/src/core-data/SearchResultsTable.stories.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { action } from '@storybook/addon-actions';
 import React from 'react';
 import SearchResultsTable from '../../../core-data/src/components/SearchResultsTable';
 import hits from '../data/typesense/Places.json';
@@ -65,6 +66,18 @@ export const ReallyBig = () => (
     <SearchResultsTable
       columns={COLUMNS}
       hits={LOTS_OF_HITS}
+    />
+  </div>
+);
+
+export const EventHandlers = () => (
+  <div className='h-[400px] w-[1000px]'>
+    <SearchResultsTable
+      columns={COLUMNS}
+      hits={LOTS_OF_HITS}
+      onRowClick={action('click')}
+      onRowMouseEnter={action('mouseEnter')}
+      onRowMouseLeave={action('mouseLeave')}
     />
   </div>
 );


### PR DESCRIPTION
# Summary

This PR adds `onRowClick`, `onRowMouseEnter`, and `onRowMouseLeave` props to `SearchResultsTable`. If `onRowClick` is present, table rows will have a `neutral-200` background on hover.