### PR TITLE
Improvements to AccordionItemsList prop structure

### DIFF
--- a/packages/core-data/src/components/AccordionItemsList.js
+++ b/packages/core-data/src/components/AccordionItemsList.js
@@ -14,9 +14,14 @@ type Props = {
   className?: string,
 
   /**
+   * If true, will display the number of items in each section after the title
+   */
+  count?: Boolean,
+
+  /**
    * List of related models to render
    */
-  relations: Array<RelatedRecordsList>
+  items: Array<RelatedRecordsList>
 };
 
 /**
@@ -30,7 +35,7 @@ const AccordionItemsList = (props: Props) => (
     )}
     type='multiple'
   >
-    { _.map(props.relations, (relation, idx) => (
+    { _.map(props.items, (relation, idx) => (
       <Accordion.Item key={idx} value={relation.title}>
         <Accordion.Header
           asChild
@@ -45,7 +50,7 @@ const AccordionItemsList = (props: Props) => (
                 ) : (
                   <span>
                     { relation.title }
-                    { relation.count ? (
+                    { props.count ? (
                       <span className='ml-2'>
                         (
                         { relation.items.length }

--- a/packages/core-data/src/components/RecordDetailPanel.js
+++ b/packages/core-data/src/components/RecordDetailPanel.js
@@ -26,6 +26,11 @@ type Props = {
   classNames?: { header?: string, items?: string, relatedRecords?: string, root?: string, title?: string },
 
   /**
+   * If true, the number of related records will be displayed for each type
+   */
+  count?: Boolean,
+
+  /**
    * List of detail fields to be rendered above the blurb
    */
   detailItems?: Array<{ text: string, icon?: string, className?: string }>,
@@ -104,7 +109,8 @@ const RecordDetailPanel = (props: Props) => (
     </div>
     <AccordionItemsList
       className={clsx('shadow-[0px_1px_4px_rgba(0,0,0,.15)]', props.classNames?.relatedRecords)}
-      relations={props.relations}
+      items={props.relations}
+      count={props.count}
     />
   </div>
 );

--- a/packages/core-data/src/types/RelatedRecord.js
+++ b/packages/core-data/src/types/RelatedRecord.js
@@ -5,9 +5,9 @@ export type RelatedRecord = {
    * Optional data prop to pass other fields, e.g. if needed for rendering
   */
   data?: any,
-  
+
   /**
-    * Optional event fired when the item is clicked. Note this will be overridden if a renderItem prop is provided in the parent list
+    * Optional event fired when item is clicked. Will be overridden if a renderItem prop is provided in the parent list
   */
   onClick?: () => void,
 

--- a/packages/core-data/src/types/RelatedRecordsList.js
+++ b/packages/core-data/src/types/RelatedRecordsList.js
@@ -2,12 +2,7 @@
 
 import type { RelatedRecord } from './RelatedRecord';
 
-export type RelatedRecordsList = {  
-  /**
-   * If true, will render the item count in parentheses after the title. Note this is overridden if a renderTitle prop is provided
-   */
-  count?: boolean,
-  
+export type RelatedRecordsList = {
   /**
    * Icon to use in front of each list item. Defaults to none. Note this is overridden if a renderItem prop is provided
    */
@@ -22,7 +17,7 @@ export type RelatedRecordsList = {
    * Optional render prop to render the title and count; defaults to `${title} (${count})`
    */
   renderTitle?: (title: String, count?: number | string) => JSX.Element,
-  
+
   /**
    * Optional render prop to render each item in the list
   */

--- a/packages/storybook/src/core-data/AccordionItemsList.stories.js
+++ b/packages/storybook/src/core-data/AccordionItemsList.stories.js
@@ -54,30 +54,6 @@ const sampleDataWithIcon = [
   }
 ];
 
-const sampleDataWithCount = [
-  {
-    title: 'Related People',
-    items: [
-      {
-        name: 'Kazuya Miyuki'
-      },
-      {
-        name: 'Eijun Sawamura'
-      }
-    ],
-    count: true
-  },
-  {
-    title: 'Related Organizations',
-    items: [
-      {
-        name: 'Seido High School Baseball Club'
-      }
-    ],
-    count: true
-  }
-];
-
 const sampleDataWithClickEvent = [
   {
     title: 'Related People',
@@ -105,24 +81,25 @@ const sampleDataWithClickEvent = [
 
 export const Default = () => (
   <AccordionItemsList
-    relations={sampleData}
+    items={sampleData}
   />
 );
 
 export const WithIcons = () => (
   <AccordionItemsList
-    relations={sampleDataWithIcon}
+    items={sampleDataWithIcon}
   />
 );
 
 export const WithCount = () => (
   <AccordionItemsList
-    relations={sampleDataWithCount}
+    items={sampleData}
+    count
   />
 );
 
 export const WithClickEvent = () => (
   <AccordionItemsList
-    relations={sampleDataWithClickEvent}
+    items={sampleDataWithClickEvent}
   />
 );

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -204,3 +204,30 @@ export const FixedWidthAndHeight = () => (
     </p>
   </RecordDetailPanel>
 );
+
+export const WithCounts = () => (
+  <RecordDetailPanel
+    relations={sampleData}
+    title='West Tokyo Qualifiers Quarterfinal'
+    count
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo.
+      {' '}
+      <span className='font-bold'>Tempor sem malesuada porttitor congue.</span>
+      {' '}
+      Nibh aenean vitae blandit vitae sapien ac varius mattis.
+      Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+);


### PR DESCRIPTION
### In this PR
Pursuant to Issue #373 , this PR does two things:
- Moves the `count` prop to the top level of the component rather than being set per item type;
- Renames the `relations` prop to the more generic `items`.