### PR TITLE
`id` prop for `Checkbox`

### DIFF
--- a/packages/core-data/src/components/Checkbox.js
+++ b/packages/core-data/src/components/Checkbox.js
@@ -17,6 +17,10 @@ type Props = {
    */
   checked: boolean,
   /**
+   * HTML ID to apply to the checkbox
+   */
+  id?: string,
+  /**
    * (Optional) Whether to disable the checkbox.
    */
   disabled?: boolean
@@ -27,6 +31,7 @@ const Checkbox = (props: Props) => (
     checked={props.checked}
     className='rounded-sm'
     disabled={props.disabled}
+    id={props.id}
     onCheckedChange={props.onClick}
   >
     <RadixCheckbox.Indicator asChild forceMount>

--- a/packages/storybook/src/core-data/Checkbox.stories.js
+++ b/packages/storybook/src/core-data/Checkbox.stories.js
@@ -18,3 +18,25 @@ export const Default = () => {
     />
   );
 };
+
+export const WithId = () => {
+  const [checked, setChecked] = useState(true);
+
+  return (
+    <>
+      <label htmlFor='my-checkbox'>
+        Because this label&apos;s
+        &nbsp;
+        <code>htmlFor</code>
+        &nbsp;
+        prop matches the Checkbox&apos;s ID, you can click anywhere on this label to toggle the checkbox.
+      </label>
+      <br />
+      <Checkbox
+        id='my-checkbox'
+        onClick={() => setChecked(!checked)}
+        checked={checked}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
# Summary

This PR adds a new `id` prop to the `Checkbox` component that's passed down to the `RadixCheckbox.Root` component. It also adds an example to the Storybook with a really long `label` element attached via `htmlFor`.