### PR TITLE
Fix pointer events in SearchList

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -58,8 +58,8 @@ const SearchList = (props: Props) => (
           item={item}
           title={typeof props.itemTitle === 'string' ? item[props.itemTitle] : props.itemTitle(item)}
           onClick={props.onItemClick}
-          onPointerEnter={() => props.onItemPointerEnter(item)}
-          onPointerLeave={() => props.onItemPointerLeave(item)}
+          onPointerEnter={props.onItemPointerEnter}
+          onPointerLeave={props.onItemPointerLeave}
         />
       ))}
     </ul>

--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -58,8 +58,8 @@ const SearchList = (props: Props) => (
           item={item}
           title={typeof props.itemTitle === 'string' ? item[props.itemTitle] : props.itemTitle(item)}
           onClick={props.onItemClick}
-          onPointerEnter={props.onItemPointerEnter}
-          onPointerLeave={props.onItemPointerLeave}
+          onPointerEnter={() => props.onItemPointerEnter(item)}
+          onPointerLeave={() => props.onItemPointerLeave(item)}
         />
       ))}
     </ul>

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -61,10 +61,10 @@ const SearchListItem = (props: SearchListItemProps) => (
     <li
       className='py-3 px-6'
       onPointerEnter={props.onPointerEnter
-        ? (item) => props.onPointerEnter(item)
+        ? () => props.onPointerEnter(props.item)
         : undefined}
       onPointerLeave={props.onPointerLeave
-        ? (item) => props.onPointerLeave(item)
+        ? () => props.onPointerLeave(props.item)
         : undefined}
     >
       <p className='font-bold text-neutral-800'>{props.title}</p>


### PR DESCRIPTION
# Summary

This PR fixes an issue with the `SearchList` `onPointer` events where the `item` wasn't being passed as an argument to the callbacks.