### PR TITLE
Add `ariaLabel` prop to Checkbox component

### DIFF
--- a/packages/core-data/src/components/Checkbox.js
+++ b/packages/core-data/src/components/Checkbox.js
@@ -7,27 +7,32 @@ import Icon from './Icon';
 
 type Props = {
   /**
-   * Callback that determines what to do when the checkbox is clicked.
-   * @param {boolean} arg
-   * @returns
+   * Label to show in the aria-label property for screen readers.
    */
-  onClick: (arg: boolean) => any,
+  ariaLabel: string,
   /**
    * Boolean state of the checkbox.
    */
   checked: boolean,
   /**
+   * (Optional) Whether to disable the checkbox.
+   */
+  disabled?: boolean,
+  /**
    * HTML ID to apply to the checkbox
    */
   id?: string,
   /**
-   * (Optional) Whether to disable the checkbox.
+   * Callback that determines what to do when the checkbox is clicked.
+   * @param {boolean} arg
+   * @returns
    */
-  disabled?: boolean
+  onClick: (arg: boolean) => any
 }
 
 const Checkbox = (props: Props) => (
   <RadixCheckbox.Root
+    aria-label={props.ariaLabel}
     checked={props.checked}
     className='rounded-sm'
     disabled={props.disabled}

--- a/packages/storybook/src/core-data/Checkbox.stories.js
+++ b/packages/storybook/src/core-data/Checkbox.stories.js
@@ -15,6 +15,7 @@ export const Default = () => {
     <Checkbox
       onClick={() => setChecked(!checked)}
       checked={checked}
+      ariaLabel='my checkbox'
     />
   );
 };
@@ -36,6 +37,7 @@ export const WithId = () => {
         id='my-checkbox'
         onClick={() => setChecked(!checked)}
         checked={checked}
+        ariaLabel='my checkbox'
       />
     </>
   );


### PR DESCRIPTION
# Summary

This PR adds a new, required `ariaLabel` prop to the Core Data `Checkbox` component. The `aria-label` will be provided to the `<button>` that Radix UI uses internally to render the checkbox.

(I tried to rebuild the component with a native `<input>` element as per https://github.com/performant-software/react-components/issues/396#issuecomment-2663333271 but it was too complicated that way)