### PR TITLE
Add `aria-label` to Clear button in Input component

### DIFF
--- a/packages/core-data/src/components/Input.js
+++ b/packages/core-data/src/components/Input.js
@@ -3,6 +3,7 @@
 import clsx from 'clsx';
 import React from 'react';
 import Icon from './Icon';
+import i18n from '../i18n/i18n';
 
 type Props = {
   /**
@@ -79,6 +80,7 @@ const Input = (props: Props) => {
       />
       {clearable && (
         <button
+          aria-label={i18n.t('Input.clear')}
           className='p-2 rounded-full flex items-center justify-center absolute right-4'
           onClick={() => props.onChange('')}
           type='button'

--- a/packages/core-data/src/i18n/en.json
+++ b/packages/core-data/src/i18n/en.json
@@ -12,6 +12,9 @@
   "Combobox": {
     "select": "Select"
   },
+  "Input": {
+    "clear": "Clear"
+  },
   "SearchResultsTable": {
     "rowsPerPage": "Rows per page"
   }


### PR DESCRIPTION
# Summary

This PR adds a new `aria-label` for the Input component's clear button, fixing the only a11y issue Storybook picked up for this component.