### PR TITLE
Update `Icon` component to return `null` if no icon matched

### DIFF
--- a/packages/core-data/src/components/Checkbox.js
+++ b/packages/core-data/src/components/Checkbox.js
@@ -46,7 +46,7 @@ const Checkbox = (props: Props) => (
           { 'fill-black': !props.checked },
           { 'hover:bg-white': !props.checked },
         )}
-        name={props.checked ? 'checkbox-filled' : 'checkbox'}
+        name={props.checked ? 'checkbox_filled' : 'checkbox'}
       />
     </RadixCheckbox.Indicator>
   </RadixCheckbox.Root>

--- a/packages/core-data/src/components/Combobox.js
+++ b/packages/core-data/src/components/Combobox.js
@@ -159,7 +159,7 @@ const Combobox = (props: Props) => {
               >
                 <Icon
                   name={isSelected(option)
-                    ? 'checkbox-filled'
+                    ? 'checkbox_filled'
                     : 'checkbox'}
                 />
                 {option.label}

--- a/packages/core-data/src/components/Icon.js
+++ b/packages/core-data/src/components/Icon.js
@@ -111,10 +111,10 @@ const Icon = ({
       ThisIcon = ZoomOutIcon;
       break;
     default:
-      ThisIcon = InfoIcon;
+      ThisIcon = null;
   }
 
-  return (
+  return ThisIcon ? (
     <svg
       width={size}
       height={size}
@@ -127,7 +127,7 @@ const Icon = ({
     >
       <ThisIcon />
     </svg>
-  );
+  ) : null;
 };
 
 export default Icon;


### PR DESCRIPTION
### In this PR
Addresses Issue #412 by changing the default behavior of the `Icon` component to return `null` if no existing icon name is matched.