### PR TITLE
SearchList a11y fixes

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -50,7 +50,10 @@ const SearchList = (props: Props) => (
         ? i18n.t('Common.words.result')
         : i18n.t('Common.words.results') }
     </div>
-    <ul className='overflow-y-auto h-full divide-y divide-solid divide-neutral-200'>
+    <ul
+      className='overflow-y-auto h-full divide-y divide-solid divide-neutral-200'
+      tabIndex={0}
+    >
       {props.items.map((item, idx) => (
         <SearchListItem
           attributes={props.attributes}

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -57,38 +57,40 @@ const ItemWrapper = (props: ItemWrapperProps) => {
 };
 
 const SearchListItem = (props: SearchListItemProps) => (
-  <ItemWrapper {...props}>
-    <li
-      className='py-3 px-6'
-      onPointerEnter={props.onPointerEnter
-        ? () => props.onPointerEnter(props.item)
-        : undefined}
-      onPointerLeave={props.onPointerLeave
-        ? () => props.onPointerLeave(props.item)
-        : undefined}
-    >
-      <p className='font-bold text-neutral-800'>{props.title}</p>
-      {props.attributes && props.attributes.length > 0 && (
-        <ul className='list-none'>
-          {props.attributes.slice(0, 3).map((att) => (
-            <li
-              className='text-sm text-neutral-800 flex gap-2 items-center list-none pl-5 pt-1'
-              key={att.name}
-            >
-              <Icon
-                className='min-w-[13px]'
-                name={att.icon || 'bullet'}
-                size={13}
-              />
-              {att.render
-                ? att.render(props.item)
-                : props.item[att.name]}
-            </li>
-          ))}
-        </ul>
-      )}
-    </li>
-  </ItemWrapper>
+  <li>
+    <ItemWrapper {...props}>
+      <div
+        className='py-3 px-6'
+        onPointerEnter={props.onPointerEnter
+          ? () => props.onPointerEnter(props.item)
+          : undefined}
+        onPointerLeave={props.onPointerLeave
+          ? () => props.onPointerLeave(props.item)
+          : undefined}
+      >
+        <p className='font-bold text-neutral-800'>{props.title}</p>
+        {props.attributes && props.attributes.length > 0 && (
+          <ul className='list-none'>
+            {props.attributes.slice(0, 3).map((att) => (
+              <li
+                className='text-sm text-neutral-800 flex gap-2 items-center list-none pl-5 pt-1'
+                key={att.name}
+              >
+                <Icon
+                  className='min-w-[13px]'
+                  name={att.icon || 'bullet'}
+                  size={13}
+                />
+                {att.render
+                  ? att.render(props.item)
+                  : props.item[att.name]}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </ItemWrapper>
+  </li>
 );
 
 export default SearchListItem;


### PR DESCRIPTION
# Summary

- adds a `tabIndex` value to the scrollable element to satisfy the "Ensure elements that have scrollable content are accessible by keyboard" error
- wraps the `SearchListItem` component in an `li` and changes the existing `li` to a `div`, fixing a couple errors related to the `li` not being a direct child of the `ul` when an `onItemClick` callback was used