### PR TITLE
SearchResultsTable a11y fixes

### DIFF
--- a/packages/core-data/src/components/Pagination.js
+++ b/packages/core-data/src/components/Pagination.js
@@ -84,7 +84,7 @@ const Pagination = (props: Props) => {
     )}
     >
       <span className='font-bold'>
-        {i18n.t('SearchResultsTable.rowsPerPage')}
+        {i18n.t('Pagination.rowsPerPage')}
       </span>
       <HitsPerPage
         hitsPerPage={props.hitsPerPage}
@@ -100,6 +100,7 @@ const Pagination = (props: Props) => {
         {props.nbHits}
       </span>
       <button
+        aria-label={i18n.t('Pagination.previous')}
         className={clsx(
           'h-6',
           'w-6',
@@ -116,6 +117,7 @@ const Pagination = (props: Props) => {
         <Icon name='left' />
       </button>
       <button
+        aria-label={i18n.t('Pagination.next')}
         className={clsx(
           'h-6',
           'w-6',

--- a/packages/core-data/src/components/SearchResultsTable.js
+++ b/packages/core-data/src/components/SearchResultsTable.js
@@ -76,7 +76,10 @@ const SearchResultsTable = (props: Props) => {
   return (
     <div className='rounded-md inline-block border border-neutral-200 w-full h-full min-h-full flex flex-col'>
       <div className='overflow-auto'>
-        <table className='divide-y divide-neutral-200 w-full max-h-full overflow-auto border-b border-neutral-200 grow-0'>
+        <table
+          className='divide-y divide-neutral-200 w-full max-h-full overflow-auto border-b border-neutral-200 grow-0'
+          tabIndex={0}
+        >
           <thead className='bg-neutral-100 sticky top-0'>
             <tr className='divide-x divide-neutral-200'>
               {props.columns.map((col) => (

--- a/packages/core-data/src/i18n/en.json
+++ b/packages/core-data/src/i18n/en.json
@@ -18,7 +18,9 @@
   "Input": {
     "clear": "Clear"
   },
-  "SearchResultsTable": {
+  "Pagination": {
+    "next": "Next",
+    "previous": "Previous",
     "rowsPerPage": "Rows per page"
   }
 }


### PR DESCRIPTION
# Summary

- adds a `tabIndex` to the scrollable `<table>` element to make its children accessible via keyboard
- adds `aria-labels` to the buttons in the `Pagination` component
- for consistency, moves the pre-existing `rowsPerPage` i18n value to be under the `Pagination` object instead of the `SearchResultsTable` object since it's actually appearing in the `Pagination` component