### PR TITLE
Slider a11y fixes

### DIFF
--- a/packages/core-data/src/components/Input.js
+++ b/packages/core-data/src/components/Input.js
@@ -7,6 +7,10 @@ import i18n from '../i18n/i18n';
 
 type Props = {
   /**
+   * (Optional) aria-label attribute for the input if not already contained in a label element
+   */
+  ariaLabel?: string,
+  /**
    * (Optional) Extra styles for the input
    */
   className?: string,
@@ -71,6 +75,7 @@ const Input = (props: Props) => {
         />
       )}
       <input
+        aria-label={props.ariaLabel}
         className='grow bg-transparent focus:outline-none w-full'
         placeholder={props.placeholder}
         onBlur={(e) => props.onBlur(e.target.value)}

--- a/packages/core-data/src/components/Slider.js
+++ b/packages/core-data/src/components/Slider.js
@@ -7,6 +7,7 @@ import { clsx } from 'clsx';
 import React, { useCallback, useEffect, useState } from 'react';
 import Input from './Input';
 import Icon from './Icon';
+import i18n from '../i18n/i18n';
 
 type MarkerProps = {
   className?: string,
@@ -271,6 +272,7 @@ const Slider = (props: Props) => {
         className='flex justify-between w-full py-4'
       >
         <Input
+          ariaLabel={i18n.t('Slider.start')}
           className={clsx(
             'rounded-md !w-20',
             props.classNames.input
@@ -281,6 +283,7 @@ const Slider = (props: Props) => {
           value={props.value[0]}
         />
         <Input
+          ariaLabel={i18n.t('Slider.end')}
           className={clsx(
             'rounded-md !w-20',
             props.classNames.input

--- a/packages/core-data/src/i18n/en.json
+++ b/packages/core-data/src/i18n/en.json
@@ -20,5 +20,9 @@
   },
   "SearchResultsTable": {
     "rowsPerPage": "Rows per page"
+  },
+  "Slider": {
+    "end": "End",
+    "start": "Start"
   }
 }


### PR DESCRIPTION
# Summary

* adds `aria-label` attributes to the input elements in Slider
* updates the `Input` component to accept a new, optional `ariaLabel` prop, whose value is applied as `aria-label` to the `<input>` element