### PR TITLE
Fix position of clear button on Input

### DIFF
--- a/packages/core-data/src/components/Input.js
+++ b/packages/core-data/src/components/Input.js
@@ -86,7 +86,7 @@ const Input = (props: Props) => {
       {clearable && (
         <button
           aria-label={i18n.t('Input.clear')}
-          className='p-2 rounded-full flex items-center justify-center absolute right-4'
+          className='p-2 rounded-full flex items-center justify-center relative left-2'
           onClick={() => props.onChange('')}
           type='button'
         >

--- a/packages/storybook/src/core-data/Input.stories.js
+++ b/packages/storybook/src/core-data/Input.stories.js
@@ -46,3 +46,19 @@ export const CustomStyled = () => {
     />
   );
 };
+
+export const InContainer = () => {
+  const [query, setQuery] = useState('');
+
+  return (
+    <div className='w-[300px]'>
+      <Input
+        className='bg-red-50 italic'
+        onChange={(val) => setQuery(val)}
+        icon='search'
+        placeholder='Search'
+        value={query}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
# Summary

This PR fixes an issue where the `position` of the clear button in the Core Data `Input` component was set to `absolute`, causing it to float to the right edge of the page, outside the component.

* change it to be relative positioned
* add a new Storybook story to handle this case, as the bug went unnoticed here because existing ones all filled the width of their pages