### PR TITLE
Remove `whitespace-no-wrap` from SearchResultsTable

### DIFF
--- a/packages/core-data/src/components/SearchResultsTable.js
+++ b/packages/core-data/src/components/SearchResultsTable.js
@@ -112,7 +112,7 @@ const SearchResultsTable = (props: Props) => {
               >
                 {props.columns.map((col) => (
                   <td
-                    className='px-4 py-3 text-sm whitespace-nowrap text-gray-800 text-sm max-h-10'
+                    className='px-4 py-3 text-sm text-gray-800 text-sm max-h-10'
                     key={col.name}
                   >
                     {col.render


### PR DESCRIPTION
# Summary

This PR removes the `whitespace-no-wrap` CSS rule from the Core Data `SearchResultsTable` component, allowing the table to dynamically adjust column widths depending on the data inside it.