### PR TITLE
Adds line limit and Show More button to `RecordPanelHeader`

### DIFF
--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -87,9 +87,7 @@ const RecordDetailHeader = (props: Props) => {
       <div
         ref={content}
         className={clsx(
-          { 'max-h-[120px]': !expanded },
-          { 'overflow-hidden': !expanded },
-          { 'text-ellipsis': !expanded }
+          { 'line-clamp-6': !expanded }
         )}
       >
         { props.children }

--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -1,7 +1,7 @@
 // @flow
 
 import clsx from 'clsx';
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import _ from 'underscore';
 import Button from './Button';
 import RecordDetailTitle from './RecordDetailTitle';
@@ -40,24 +40,35 @@ type Props = {
   title: string,
 };
 
-const RecordDetailHeader = (props: Props) => (
-  <div
-    className={clsx(
-      'flex',
-      'flex-col',
-      'gap-4',
-      'px-6',
-      'pt-6',
-      'pb-4',
-      props.classNames?.root
-    )}
-  >
-    <RecordDetailTitle
-      text={props.title}
-      icon={props.icon}
-      className={props.classNames?.title}
-    />
-    {
+const RecordDetailHeader = (props: Props) => {
+  const [expanded, setExpanded] = useState(false);
+  const [showMore, setShowMore] = useState(false);
+  const content = useRef(null);
+
+  useEffect(() => {
+    if (content.current) {
+      setShowMore(content.current.scrollHeight > content.current.clientHeight);
+    }
+  }, [content]);
+
+  return (
+    <div
+      className={clsx(
+        'flex',
+        'flex-col',
+        'gap-4',
+        'px-6',
+        'pt-6',
+        'pb-4',
+        props.classNames?.root
+      )}
+    >
+      <RecordDetailTitle
+        text={props.title}
+        icon={props.icon}
+        className={props.classNames?.title}
+      />
+      {
       !!props.detailItems?.length && (
         <ul className={props.classNames?.items}>
           {
@@ -73,17 +84,30 @@ const RecordDetailHeader = (props: Props) => (
         </ul>
       )
     }
-    <div>
-      { props.children }
-    </div>
-    { props.detailPageUrl && (
+      <div
+        ref={content}
+        className={clsx(
+          { 'max-h-[120px]': !expanded },
+          { 'overflow-hidden': !expanded },
+          { 'text-ellipsis': !expanded }
+        )}
+      >
+        { props.children }
+      </div>
+      { showMore && (
+      <Button rounded className='w-full justify-center' onClick={() => { setExpanded((current) => (!current)); }}>
+        { expanded ? i18n.t('RecordDetailHeader.showLess') : i18n.t('RecordDetailHeader.showMore') }
+      </Button>
+      )}
+      { props.detailPageUrl && (
       <a href={props.detailPageUrl}>
         <Button rounded className='w-full justify-center'>
           { i18n.t('RecordDetailHeader.viewDetails') }
         </Button>
       </a>
-    )}
-  </div>
-);
+      )}
+    </div>
+  );
+};
 
 export default RecordDetailHeader;

--- a/packages/core-data/src/i18n/en.json
+++ b/packages/core-data/src/i18n/en.json
@@ -7,6 +7,8 @@
     }
   },
   "RecordDetailHeader": {
+    "showLess": "Show Less",
+    "showMore": "Show More",
     "viewDetails": "View Details"
   },
   "Combobox": {

--- a/packages/storybook/src/core-data/RecordDetailHeader.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailHeader.stories.js
@@ -58,3 +58,50 @@ export const WithLink = () => (
     </p>
   </RecordDetailHeader>
 );
+
+export const NarrowWidth = () => (
+  <RecordDetailHeader
+    title='A Very Serious and Important Event'
+    detailItems={[
+      {
+        text: 'March 11, 1986',
+        icon: 'date'
+      },
+      {
+        text: 'Princton, NJ',
+        icon: 'location'
+      }
+    ]}
+    classNames={{
+      root: 'w-[380px]'
+    }}
+    detailPageUrl='#'
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo.
+      {' '}
+      <span className='font-bold'>Tempor sem malesuada porttitor congue.</span>
+      {' '}
+      Nibh aenean vitae blandit vitae sapien ac varius mattis.
+      Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+      Lorem ipsum odor amet, consectetuer adipiscing elit.
+      Fringilla morbi diam vehicula nostra gravida faucibus consequat sociosqu.
+      Platea taciti ridiculus nostra feugiat hac elit quisque.
+      Magnis risus natoque sagittis finibus ridiculus aenean ac posuere.
+      Dapibus taciti phasellus pulvinar ut ac nascetur tortor.
+      Inceptos viverra fames donec eu imperdiet. Tempus parturient justo curae parturient arcu.
+      Risus molestie lobortis, hendrerit consectetur curae eros.
+    </p>
+    <p>
+      Per orci torquent, nascetur tellus diam arcu pulvinar.
+      Euismod ridiculus placerat dictum himenaeos odio aenean magnis magna.
+      Maximus justo curabitur purus porttitor dictum penatibus lacus. Nisl lectus finibus sollicitudin;
+      arcu adipiscing urna fermentum facilisis. Natoque blandit elit viverra penatibus facilisis.
+      Praesent habitant volutpat efficitur in lacus lacinia torquent.
+      Cras ultricies mus ante et dapibus dolor vivamus nunc.
+      Velit interdum litora lobortis ultrices sollicitudin molestie ut.
+      Fusce per est; ullamcorper montes pellentesque purus.
+      Ullamcorper mauris fermentum cursus sollicitudin ex id conubia dui nisi.
+    </p>
+  </RecordDetailHeader>
+);

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -189,7 +189,7 @@ export const FixedWidthAndHeight = () => (
     breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
     onGoBack={() => { alert('Go back!'); }}
     classNames={{
-      root: 'w-[380px] h-[500px]'
+      root: 'w-[380px] h-[560px]'
     }}
     onClose={() => { alert('Close!'); }}
     detailPageUrl='#'
@@ -201,6 +201,16 @@ export const FixedWidthAndHeight = () => (
       {' '}
       Nibh aenean vitae blandit vitae sapien ac varius mattis.
       Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+      Lorem ipsum odor amet, consectetuer adipiscing elit.
+      Fringilla morbi diam vehicula nostra gravida faucibus consequat sociosqu.
+      Platea taciti ridiculus nostra feugiat hac elit quisque.
+      Magnis risus natoque sagittis finibus ridiculus aenean ac posuere.
+      Euismod ridiculus placerat dictum himenaeos odio aenean magnis magna.
+      Maximus justo curabitur purus porttitor dictum penatibus lacus. Nisl lectus finibus sollicitudin;
+      arcu adipiscing urna fermentum facilisis. Natoque blandit elit viverra penatibus facilisis.
+      Praesent habitant volutpat efficitur in lacus lacinia torquent.
+      Cras ultricies mus ante et dapibus dolor vivamus nunc.
+      Velit interdum litora lobortis ultrices sollicitudin molestie ut.
     </p>
   </RecordDetailPanel>
 );


### PR DESCRIPTION
### In this PR
Limits the height of the text content in the `RecordPanelHeader` component to six lines and displays a `Show More` button in the case that this limit is exceeded, which expands the container to show the full text content. 
![image](https://github.com/user-attachments/assets/0260e8d6-c7f9-44c4-9d98-be212a36a287)
![image](https://github.com/user-attachments/assets/ea5875bf-d00c-4d3e-a332-83470528f76e)

### Notes
- I chose six lines a bit arbitrarily based on what looked reasonable to me, but of course open to tweaks.