### PR TITLE
Fix checkbox styling

### DIFF
--- a/packages/core-data/src/components/Checkbox.js
+++ b/packages/core-data/src/components/Checkbox.js
@@ -11,6 +11,10 @@ type Props = {
    */
   ariaLabel: string,
   /**
+   * (Optional) Tailwind classes for the root button component.
+   */
+  className?: string,
+  /**
    * Boolean state of the checkbox.
    */
   checked: boolean,
@@ -34,7 +38,10 @@ const Checkbox = (props: Props) => (
   <RadixCheckbox.Root
     aria-label={props.ariaLabel}
     checked={props.checked}
-    className='rounded-sm'
+    className={clsx(
+      'rounded-sm hover:bg-transparent',
+      props.className,
+    )}
     disabled={props.disabled}
     id={props.id}
     onCheckedChange={props.onClick}
@@ -44,7 +51,6 @@ const Checkbox = (props: Props) => (
         className={clsx(
           { 'fill-primary': props.checked },
           { 'fill-black': !props.checked },
-          { 'hover:bg-white': !props.checked },
         )}
         name={props.checked ? 'checkbox_filled' : 'checkbox'}
       />

--- a/packages/storybook/src/core-data/Checkbox.stories.js
+++ b/packages/storybook/src/core-data/Checkbox.stories.js
@@ -42,3 +42,27 @@ export const WithId = () => {
     </>
   );
 };
+
+export const CustomStyles = () => {
+  const [checked, setChecked] = useState(true);
+
+  return (
+    <>
+      <label htmlFor='my-checkbox'>
+        Because this label&apos;s
+        &nbsp;
+        <code>htmlFor</code>
+        &nbsp;
+        prop matches the Checkbox&apos;s ID, you can click anywhere on this label to toggle the checkbox.
+      </label>
+      <br />
+      <Checkbox
+        className='bg-red-200 hover:bg-purple-200'
+        id='my-checkbox'
+        onClick={() => setChecked(!checked)}
+        checked={checked}
+        ariaLabel='my checkbox'
+      />
+    </>
+  );
+};


### PR DESCRIPTION
# Summary

- adds a new `hover:bg-transparent` class to the Checkbox's root component to override the Peripleo CSS rule that was causing the gray background on hover
- adds a new `className` prop to allow consuming applications to style the Checkbox
- removes an extraneous `hover:bg-white` class from the SVG that was left over from the previous version of the component