### PR TITLE
Set default data layers as initial selected state (CDP #52)

### DIFF
--- a/packages/core-data/src/components/LayerMenu.js
+++ b/packages/core-data/src/components/LayerMenu.js
@@ -52,13 +52,22 @@ type Props = {
  * a Peripleo map.
  */
 const LayerMenu = (props: Props) => {
-  const [selectedOverlays, setSelectedOverlays] = useState({});
-
   const {
     baseLayer,
     baseLayers,
     dataLayers
   } = props;
+
+  /**
+   * Set default data layers on initial selectedOverlays state.
+   */
+  const [selectedOverlays, setSelectedOverlays] = useState(
+    _.chain(dataLayers)
+      .filter((dl) => dl.default === true)
+      .map((dl) => [dl.name, true])
+      .object()
+      .value()
+  );
 
   /**
    * Changes the base layer to the layer with the passed name.


### PR DESCRIPTION
## In this PR

Per performant-software/core-data-places#52:
- Set data layers marked `default` (via config.json/using tina) to be visible by default

I'd attempted to do this entirely within CDP code, but because the initial `selectedOverlays` state in this component was set to `{}`, and there is a `useEffect` here that checks for that state's change and then calls the `props.onChangeOverlays` callback, the selected overlays were always getting reset back to nothing on mount. Rather than trying to divine when this component mounts and handle it externally, I figured it makes more sense to check for the `default` layers and set the initial state here.

Also just learned about `_.chain` from your CDP PR, Derek, so useful!