### PR TITLE
Controlled item highlight for `SearchList` and `SearchResultsTable`

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -16,6 +16,10 @@ type Props = {
    */
   className?: string,
   /**
+   * Optional callback that determines whether to highlight an item
+   */
+  isHighlight?: (item: any) => boolean,
+  /**
    * Array of search result items
    */
   items: Array<any>,
@@ -52,6 +56,7 @@ const SearchList = (props: Props) => (
     </div>
     <ul
       className='overflow-y-auto h-full divide-y divide-solid divide-neutral-200'
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
     >
       {props.items.map((item, idx) => (
@@ -59,6 +64,7 @@ const SearchList = (props: Props) => (
           attributes={props.attributes}
           key={idx}
           item={item}
+          isHighlight={props.isHighlight && props.isHighlight(item)}
           title={typeof props.itemTitle === 'string' ? item[props.itemTitle] : props.itemTitle(item)}
           onClick={props.onItemClick}
           onPointerEnter={props.onItemPointerEnter}

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { type Element } from 'react';
+import clsx from 'clsx';
 import Icon from './Icon';
 import { type Attribute } from '../types/SearchList';
 
@@ -13,6 +14,10 @@ type SearchListItemProps = {
    * Search item object
    */
   item: any,
+  /**
+   * Boolean that determines whether to highlight the item
+   */
+  isHighlight?: boolean,
   /**
    * Callback that fires when an item is clicked
    */
@@ -60,7 +65,10 @@ const SearchListItem = (props: SearchListItemProps) => (
   <li>
     <ItemWrapper {...props}>
       <div
-        className='py-3 px-6'
+        className={clsx(
+          'py-3 px-6',
+          { 'bg-neutral-200': props.isHighlight }
+        )}
         onPointerEnter={props.onPointerEnter
           ? () => props.onPointerEnter(props.item)
           : undefined}

--- a/packages/core-data/src/components/SearchResultsTable.js
+++ b/packages/core-data/src/components/SearchResultsTable.js
@@ -31,6 +31,10 @@ type Props = {
    */
   hits: Array<any>,
   /**
+   * Optional callback that determines whether to highlight an item
+   */
+  isHighlight?: (item: any) => boolean,
+  /**
    * Callback that fires when a row is clicked
    */
   onRowClick?: (hit: any) => void,
@@ -78,6 +82,7 @@ const SearchResultsTable = (props: Props) => {
       <div className='overflow-auto'>
         <table
           className='divide-y divide-neutral-200 w-full max-h-full overflow-auto border-b border-neutral-200 grow-0'
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
           tabIndex={0}
         >
           <thead className='bg-neutral-100 sticky top-0'>
@@ -97,7 +102,8 @@ const SearchResultsTable = (props: Props) => {
               <tr
                 className={clsx(
                   'divide-x divide-neutral-200',
-                  { 'hover:bg-neutral-200 cursor-pointer': props.onRowClick }
+                  { 'hover:bg-neutral-200 cursor-pointer': props.onRowClick },
+                  { 'bg-neutral-200': props.isHighlight && props.isHighlight(hit) }
                 )}
                 onClick={props.onRowClick
                   ? () => props.onRowClick(hit)

--- a/packages/storybook/src/core-data/SearchList.stories.js
+++ b/packages/storybook/src/core-data/SearchList.stories.js
@@ -167,3 +167,32 @@ export const CustomStyles = () => (
     />
   </div>
 );
+
+export const ControlledHighlight = () => (
+  <div className='h-[600px] w-[360px]'>
+    <SearchList
+      attributes={[
+        {
+          label: 'UUID',
+          name: 'uuid',
+        },
+        {
+          label: 'Record ID',
+          name: 'record_id',
+          icon: 'person'
+        },
+        {
+          label: 'Location',
+          name: 'geometry',
+          icon: 'location',
+          render: (item) => (item.coordinates
+            ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+            : '')
+        },
+      ]}
+      items={LOTS_OF_DATA}
+      itemTitle='name'
+      isHighlight={(item) => item.id % 2 === 0}
+    />
+  </div>
+);

--- a/packages/storybook/src/core-data/SearchResultsTable.stories.js
+++ b/packages/storybook/src/core-data/SearchResultsTable.stories.js
@@ -81,3 +81,13 @@ export const EventHandlers = () => (
     />
   </div>
 );
+
+export const ControlledHighlight = () => (
+  <div className='h-80'>
+    <SearchResultsTable
+      columns={COLUMNS}
+      hits={LOTS_OF_HITS}
+      isHighlight={(item) => item.id % 2 === 0}
+    />
+  </div>
+);


### PR DESCRIPTION
# Summary

This PR adds a new `isHighlight` callback prop to `SearchList` and `SearchResultsTable`. If provided, each item will be passed through the function and will be rendered with a `bg-neutral-200` if the function returns `true`.

The appearance of a highlighted (highlit?) item is identical to the hover appearance of clickable items. `isHighlight` and `onClick` can be used together.