### PR TITLE
Fixing unpredictable icon resizing

### DIFF
--- a/packages/core-data/src/components/Icon.js
+++ b/packages/core-data/src/components/Icon.js
@@ -127,7 +127,7 @@ const Icon = ({
       xmlns='http://www.w3.org/2000/svg'
       id={name}
       style={style}
-      className={clsx('icon', className)}
+      className={clsx('icon', 'flex-shrink-0', className)}
     >
       <ThisIcon />
     </svg>


### PR DESCRIPTION
### In this PR
Addresses Issue #429 by adding the `flex-shrink-0` class to the `Icon` component so that it isn't squished when e.g. the title of a record detail panel is extra long. 
![image](https://github.com/user-attachments/assets/5e6630b8-54d4-4db6-b76e-21defd41e4c1)

