### PR TITLE
Fix SearchList highlight/hover behavior

### DIFF
--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -65,7 +65,7 @@ const SearchListItem = (props: SearchListItemProps) => (
   <li
     className={clsx(
       { 'bg-neutral-200': props.isHighlight },
-      { 'hover:bg-neutral-200': props.onClick }
+      { 'hover:bg-neutral-200': !!props.onClick }
     )}
   >
     <ItemWrapper {...props}>

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -49,7 +49,7 @@ const ItemWrapper = (props: ItemWrapperProps) => {
   if (props.onClick) {
     return (
       <button
-        className='w-full border-0 text-left hover:bg-neutral-200'
+        className='w-full border-0 text-left hover:bg-transparent'
         onClick={() => props.onClick(props.item)}
         type='button'
       >
@@ -63,7 +63,10 @@ const ItemWrapper = (props: ItemWrapperProps) => {
 
 const SearchListItem = (props: SearchListItemProps) => (
   <li
-    className={clsx({ 'bg-neutral-200': props.isHighlight })}
+    className={clsx(
+      { 'bg-neutral-200': props.isHighlight },
+      { 'hover:bg-neutral-200': props.onClick }
+    )}
   >
     <ItemWrapper {...props}>
       <div

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -49,7 +49,7 @@ const ItemWrapper = (props: ItemWrapperProps) => {
   if (props.onClick) {
     return (
       <button
-        className='w-full border-0 text-left'
+        className='w-full border-0 text-left hover:bg-neutral-200'
         onClick={() => props.onClick(props.item)}
         type='button'
       >
@@ -62,13 +62,12 @@ const ItemWrapper = (props: ItemWrapperProps) => {
 };
 
 const SearchListItem = (props: SearchListItemProps) => (
-  <li>
+  <li
+    className={clsx({ 'bg-neutral-200': props.isHighlight })}
+  >
     <ItemWrapper {...props}>
       <div
-        className={clsx(
-          'py-3 px-6',
-          { 'bg-neutral-200': props.isHighlight }
-        )}
+        className='py-3 px-6'
         onPointerEnter={props.onPointerEnter
           ? () => props.onPointerEnter(props.item)
           : undefined}

--- a/packages/storybook/src/core-data/SearchList.stories.js
+++ b/packages/storybook/src/core-data/SearchList.stories.js
@@ -196,3 +196,33 @@ export const ControlledHighlight = () => (
     />
   </div>
 );
+
+export const ControlledHighlightWithOnClick = () => (
+  <div className='h-[600px] w-[360px]'>
+    <SearchList
+      attributes={[
+        {
+          label: 'UUID',
+          name: 'uuid',
+        },
+        {
+          label: 'Record ID',
+          name: 'record_id',
+          icon: 'person'
+        },
+        {
+          label: 'Location',
+          name: 'geometry',
+          icon: 'location',
+          render: (item) => (item.coordinates
+            ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+            : '')
+        },
+      ]}
+      items={LOTS_OF_DATA}
+      itemTitle='name'
+      isHighlight={(item) => item.id % 2 === 0}
+      onItemClick={action('click')}
+    />
+  </div>
+);


### PR DESCRIPTION
# Summary

This PR fixes a couple issues with the SearchList component:

* makes the button hover background consistent with the highlight background (`bg-neutral-200` - originally they were subtly different shades of gray)
* moves the `bg-neutral-200` class for highlighted and hovered items to the top-level `li` element instead of the inner `div`, so any extra styles applied to elements inside the component won't interfere with the background color (https://github.com/performant-software/react-components/issues/439 was caused by some padding added to `button` elements by one of CDP's stylesheets)