### PR TITLE
Fixing unmount bug with `RecordDetailHeader`

### DIFF
--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -59,11 +59,10 @@ const RecordDetailHeader = (props: Props) => {
 
   const sizeRef = React.useCallback(
     (node) => {
-      if (content !== null) {
+      if (node) {
         content.current = node;
         observer.observe(node);
       } else {
-        observer.unobserve(content.current);
         content.current = null;
       }
     },
@@ -75,6 +74,8 @@ const RecordDetailHeader = (props: Props) => {
       setShowMore(contentHeight > containerHeight || expanded);
     }
   }, [contentHeight, containerHeight]);
+
+  useEffect(() => () => observer.disconnect(), []);
 
   return (
     <div

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import RecordDetailPanel from '../../../core-data/src/components/RecordDetailPanel';
 
 export default {
@@ -241,3 +241,59 @@ export const WithCounts = () => (
     </p>
   </RecordDetailPanel>
 );
+
+export const UnmountOnClose = () => {
+  const [show, setShow] = useState(true);
+  const [content, setContent] = useState(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setContent(
+        <p>
+          Arcu imperdiet sit sit viverra id volutpat commodo.
+          {' '}
+          <span className='font-bold'>Tempor sem malesuada porttitor congue.</span>
+          {' '}
+          Nibh aenean vitae blandit vitae sapien ac varius mattis.
+          Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+          Lorem ipsum odor amet, consectetuer adipiscing elit.
+          Fringilla morbi diam vehicula nostra gravida faucibus consequat sociosqu.
+          Platea taciti ridiculus nostra feugiat hac elit quisque.
+          Magnis risus natoque sagittis finibus ridiculus aenean ac posuere.
+          Euismod ridiculus placerat dictum himenaeos odio aenean magnis magna.
+          Maximus justo curabitur purus porttitor dictum penatibus lacus. Nisl lectus finibus sollicitudin;
+          arcu adipiscing urna fermentum facilisis. Natoque blandit elit viverra penatibus facilisis.
+          Praesent habitant volutpat efficitur in lacus lacinia torquent.
+          Cras ultricies mus ante et dapibus dolor vivamus nunc.
+          Velit interdum litora lobortis ultrices sollicitudin molestie ut.
+        </p>
+      );
+    }, 200);
+  }, []);
+
+  return show && (
+  <RecordDetailPanel
+    relations={sampleData}
+    title='West Tokyo Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+    breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
+    onGoBack={() => { alert('Go back!'); }}
+    classNames={{
+      root: 'w-[380px] h-[560px]'
+    }}
+    onClose={() => { setShow(false); }}
+    detailPageUrl='#'
+  >
+    { content }
+  </RecordDetailPanel>
+  );
+};


### PR DESCRIPTION
### In this PR
Pursuant to Issue #444 , fixes an unmount bug stemming from the resize observer in the `RecordDetailHeader` component.

Note that for now I left in the Storybook component that I used to test the functionality, in case that's useful for review and testing; possibly it should be removed before merging, since it's not really necessary to include in Storybook once we're satisfied that it's working.