### PR TITLE
CDP #68 - Bounding box

### DIFF
--- a/packages/core-data/src/components/PersistentSearchStateContextProvider.js
+++ b/packages/core-data/src/components/PersistentSearchStateContextProvider.js
@@ -13,13 +13,7 @@ type Props = {
 
 const PersistentSearchStateContextProvider = (props: Props) => {
   const { geoSearch, infiniteHits, searchBox } = props;
-
-  const {
-    cachedHits,
-    observe,
-    unobserve,
-    searching
-  } = useProgressiveSearch(infiniteHits);
+  const { cachedHits, observe, unobserve } = useProgressiveSearch(infiniteHits);
 
   /**
    * Memoizes the context value.
@@ -37,9 +31,8 @@ const PersistentSearchStateContextProvider = (props: Props) => {
     geoSearch,
     searchBox,
     observe,
-    unobserve,
-    searching
-  }), [cachedHits, geoSearch, searchBox, observe, unobserve, searching]);
+    unobserve
+  }), [cachedHits, geoSearch, searchBox, observe, unobserve]);
 
   return (
     <PersistentSearchStateContext.Provider

--- a/packages/core-data/src/components/PersistentSearchStateContextProvider.js
+++ b/packages/core-data/src/components/PersistentSearchStateContextProvider.js
@@ -13,7 +13,12 @@ type Props = {
 
 const PersistentSearchStateContextProvider = (props: Props) => {
   const { geoSearch, infiniteHits, searchBox } = props;
-  const { cachedHits, observe, unobserve } = useProgressiveSearch(infiniteHits);
+  const {
+    cachedHits,
+    observe,
+    unobserve,
+    searching
+  } = useProgressiveSearch(infiniteHits);
 
   /**
    * Memoizes the context value.
@@ -31,8 +36,9 @@ const PersistentSearchStateContextProvider = (props: Props) => {
     geoSearch,
     searchBox,
     observe,
-    unobserve
-  }), [cachedHits, geoSearch, searchBox, observe, unobserve]);
+    unobserve,
+    searching
+  }), [cachedHits, geoSearch, searchBox, observe, unobserve, searching]);
 
   return (
     <PersistentSearchStateContext.Provider

--- a/packages/core-data/src/components/PersistentSearchStateContextProvider.js
+++ b/packages/core-data/src/components/PersistentSearchStateContextProvider.js
@@ -13,7 +13,13 @@ type Props = {
 
 const PersistentSearchStateContextProvider = (props: Props) => {
   const { geoSearch, infiniteHits, searchBox } = props;
-  const { cachedHits, observe, unobserve } = useProgressiveSearch(infiniteHits);
+
+  const {
+    cachedHits,
+    observe,
+    unobserve,
+    searching
+  } = useProgressiveSearch(infiniteHits);
 
   /**
    * Memoizes the context value.
@@ -31,8 +37,9 @@ const PersistentSearchStateContextProvider = (props: Props) => {
     geoSearch,
     searchBox,
     observe,
-    unobserve
-  }), [cachedHits, geoSearch, searchBox, observe, unobserve]);
+    unobserve,
+    searching
+  }), [cachedHits, geoSearch, searchBox, observe, unobserve, searching]);
 
   return (
     <PersistentSearchStateContext.Provider

--- a/packages/core-data/src/components/SearchResultsLayer.js
+++ b/packages/core-data/src/components/SearchResultsLayer.js
@@ -5,7 +5,7 @@ import { useMap } from '@peripleo/maplibre';
 import React, { useEffect, useMemo, useState } from 'react';
 import _ from 'underscore';
 import TypesenseUtils from '../utils/Typesense';
-import { useCachedHits } from '../hooks/Typesense';
+import { useCachedHits, useSearching } from '../hooks/Typesense';
 
 type Props = {
   /**
@@ -32,17 +32,17 @@ type Props = {
    * Path to the geometry attribute for each result.
    */
   geometry: string,
-}
+};
 
 /**
  * This component renders a map layer for the search results from a Typesense search index.
  */
 const SearchResultsLayer = (props: Props) => {
   const [mapLoaded, setMapLoaded] = useState(false);
-  const [searchCompleted, setSearchCompleted] = useState(false);
 
   const hits = useCachedHits();
   const map = useMap();
+  const isSearching = useSearching();
 
   /**
    * Memo-ize the Typesense hits as a feature collection.
@@ -60,7 +60,7 @@ const SearchResultsLayer = (props: Props) => {
   const boundingBoxDependencies = [
     data,
     mapLoaded,
-    searchCompleted,
+    isSearching,
     props.boundingBoxData,
     props.boundingBoxOptions,
     props.buffer,
@@ -68,16 +68,13 @@ const SearchResultsLayer = (props: Props) => {
   ];
 
   useEffect(() => {
-    if (props.fitBoundingBox && data && mapLoaded && searchCompleted) {
+    if (props.fitBoundingBox && data && mapLoaded && !isSearching) {
       // Set the bounding box on the map
       const bbox = MapUtils.getBoundingBox(data, props.buffer);
 
       if (bbox) {
         map.fitBounds(bbox, props.boundingBoxOptions, props.boundingBoxData);
       }
-
-      // Reset search completed
-      setSearchCompleted(false);
     }
   }, boundingBoxDependencies);
 

--- a/packages/core-data/src/components/SearchResultsLayer.js
+++ b/packages/core-data/src/components/SearchResultsLayer.js
@@ -2,10 +2,10 @@
 
 import { LocationMarkers, Map as MapUtils } from '@performant-software/geospatial';
 import { useMap } from '@peripleo/maplibre';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import _ from 'underscore';
 import TypesenseUtils from '../utils/Typesense';
-import { useCachedHits, useSearching } from '../hooks/Typesense';
+import { useCachedHits, useSearchCompleted } from '../hooks/Typesense';
 
 type Props = {
   /**
@@ -42,7 +42,6 @@ const SearchResultsLayer = (props: Props) => {
 
   const hits = useCachedHits();
   const map = useMap();
-  const isSearching = useSearching();
 
   /**
    * Memo-ize the Typesense hits as a feature collection.
@@ -53,30 +52,46 @@ const SearchResultsLayer = (props: Props) => {
     !_.isEmpty(hits) && TypesenseUtils.toFeatureCollection(hits, props.geometry)
   ), [hits, props.geometry]);
 
+  const fitBounds = useCallback(() => {
+    // Set the bounding box on the map
+    const bbox = MapUtils.getBoundingBox(data, props.buffer);
+
+    if (bbox) {
+      map.fitBounds(bbox, props.boundingBoxOptions, props.boundingBoxData);
+    }
+  }, [data, map, props.boundingBoxData, props.boundingBoxOptions, props.buffer]);
+
+  useEffect(() => {
+    if (mapLoaded && props.fitBoundingBox) {
+      fitBounds();
+    }
+  }, [props.boundingBoxData, props.boundingBoxOptions, props.buffer, props.fitBoundingBox, mapLoaded]);
+
+  useSearchCompleted(() => fitBounds(), [fitBounds]);
+
   /**
    * Here we'll implement our own fitting of the bounding box once the search has completed and the map has loaded,
    * rather than using the default implementation in LocationMarker that will change when the "data" prop changes.
    */
-  const boundingBoxDependencies = [
-    data,
-    isSearching,
-    mapLoaded,
-    props.boundingBoxData,
-    props.boundingBoxOptions,
-    props.buffer,
-    props.fitBoundingBox
-  ];
-
-  useEffect(() => {
-    if (props.fitBoundingBox && data && mapLoaded && !isSearching) {
-      // Set the bounding box on the map
-      const bbox = MapUtils.getBoundingBox(data, props.buffer);
-
-      if (bbox) {
-        map.fitBounds(bbox, props.boundingBoxOptions, props.boundingBoxData);
-      }
-    }
-  }, boundingBoxDependencies);
+  // const boundingBoxDependencies = [
+  //   data,
+  //   mapLoaded,
+  //   props.boundingBoxData,
+  //   props.boundingBoxOptions,
+  //   props.buffer,
+  //   props.fitBoundingBox
+  // ];
+  //
+  // useEffect(() => {
+  //   if (props.fitBoundingBox && data && mapLoaded) {
+  //     // Set the bounding box on the map
+  //     const bbox = MapUtils.getBoundingBox(data, props.buffer);
+  //
+  //     if (bbox) {
+  //       map.fitBounds(bbox, props.boundingBoxOptions, props.boundingBoxData);
+  //     }
+  //   }
+  // }, boundingBoxDependencies);
 
   /**
    * Sets the mapLoaded state to true.

--- a/packages/core-data/src/hooks/ProgressiveSearch.js
+++ b/packages/core-data/src/hooks/ProgressiveSearch.js
@@ -46,24 +46,14 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
    * @returns {boolean}
    */
   const hasStateChanged = (a: any, b: any, ignorePageNo?: boolean) => {
-    if (a) {
+    if (a && ignorePageNo) {
       // eslint-disable-next-line no-param-reassign
-      delete a.maxValuesPerFacet;
-
-      if (ignorePageNo) {
-        // eslint-disable-next-line no-param-reassign
-        delete a.page;
-      }
+      delete a.page;
     }
 
-    if (b) {
+    if (b && ignorePageNo) {
       // eslint-disable-next-line no-param-reassign
-      delete b.maxValuesPerFacet;
-
-      if (ignorePageNo) {
-        // eslint-disable-next-line no-param-reassign
-        delete b.page;
-      }
+      delete b.page;
     }
 
     return !dequal(a, b);
@@ -87,9 +77,7 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
   };
 
   useEffect(() => {
-    const { results } = infiniteHits;
-
-    const isFirstPage = results.page === 0;
+    const { isFirstPage, results } = infiniteHits;
     const hits = getHits(results);
 
     // Add to cache and load next page
@@ -101,10 +89,8 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
   }, [infiniteHits.results]);
 
   useEffect(() => {
-    const { results } = infiniteHits;
+    const { isLastPage, results } = infiniteHits;
     const hits = getHits(results);
-
-    const isLastPage = results.page + 1 >= results.nbPages;
 
     if (!isLastPage && infiniteHits.showMore) {
       setTimeout(() => infiniteHits.showMore(), 25);

--- a/packages/core-data/src/hooks/ProgressiveSearch.js
+++ b/packages/core-data/src/hooks/ProgressiveSearch.js
@@ -14,6 +14,7 @@ type OnCompleteCallback = (results: Array<SearchResult>) => void;
 
 const useProgressiveSearch = (infiniteHits, transformResults = null) => {
   const [cachedHits, setCachedHits] = useState(TypesenseUtils.createCachedHits([]));
+  const [searching, setSearching] = useState(false);
 
   const lastSearchState = useRef<any>();
   const callbacks = useRef<Array<OnCompleteCallback>>([]);
@@ -82,6 +83,10 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
     const isFirstPage = results.page === 0;
     const hits = getHits(results);
 
+    if (isFirstPage) {
+      setSearching(true);
+    }
+
     // Add to cache and load next page
     if (isFirstPage && hasStateChanged(results._state, lastSearchState.current, true)) {
       setCachedHits(() => TypesenseUtils.createCachedHits(hits));
@@ -105,10 +110,19 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
       });
     }
 
+    if (isLastPage) {
+      setSearching(false);
+    }
+
     lastSearchState.current = results._state;
   }, [cachedHits]);
 
-  return { cachedHits: cachedHits.hits, observe, unobserve };
+  return {
+    cachedHits: cachedHits.hits,
+    observe,
+    unobserve,
+    searching
+  };
 };
 
 export default useProgressiveSearch;

--- a/packages/core-data/src/hooks/ProgressiveSearch.js
+++ b/packages/core-data/src/hooks/ProgressiveSearch.js
@@ -14,7 +14,6 @@ type OnCompleteCallback = (results: Array<SearchResult>) => void;
 
 const useProgressiveSearch = (infiniteHits, transformResults = null) => {
   const [cachedHits, setCachedHits] = useState(TypesenseUtils.createCachedHits([]));
-  const [searching, setSearching] = useState(false);
 
   const lastSearchState = useRef<any>();
   const callbacks = useRef<Array<OnCompleteCallback>>([]);
@@ -83,10 +82,6 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
     const isFirstPage = results.page === 0;
     const hits = getHits(results);
 
-    if (isFirstPage) {
-      setSearching(true);
-    }
-
     // Add to cache and load next page
     if (isFirstPage && hasStateChanged(results._state, lastSearchState.current, true)) {
       setCachedHits(() => TypesenseUtils.createCachedHits(hits));
@@ -110,18 +105,13 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
       });
     }
 
-    if (isLastPage) {
-      setSearching(false);
-    }
-
     lastSearchState.current = results._state;
   }, [cachedHits]);
 
   return {
     cachedHits: cachedHits.hits,
     observe,
-    unobserve,
-    searching
+    unobserve
   };
 };
 

--- a/packages/core-data/src/hooks/ProgressiveSearch.js
+++ b/packages/core-data/src/hooks/ProgressiveSearch.js
@@ -47,12 +47,12 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
    * @returns {boolean}
    */
   const hasStateChanged = (a: any, b: any, ignorePageNo?: boolean) => {
-    if (a && ignorePageNo) {
+    if (ignorePageNo && a) {
       // eslint-disable-next-line no-param-reassign
       delete a.page;
     }
 
-    if (b && ignorePageNo) {
+    if (ignorePageNo && b) {
       // eslint-disable-next-line no-param-reassign
       delete b.page;
     }

--- a/packages/core-data/src/hooks/ProgressiveSearch.js
+++ b/packages/core-data/src/hooks/ProgressiveSearch.js
@@ -46,14 +46,24 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
    * @returns {boolean}
    */
   const hasStateChanged = (a: any, b: any, ignorePageNo?: boolean) => {
-    if (ignorePageNo && a) {
+    if (a) {
       // eslint-disable-next-line no-param-reassign
-      delete a.page;
+      delete a.maxValuesPerFacet;
+
+      if (ignorePageNo) {
+        // eslint-disable-next-line no-param-reassign
+        delete a.page;
+      }
     }
 
-    if (ignorePageNo && b) {
+    if (b) {
       // eslint-disable-next-line no-param-reassign
-      delete b.page;
+      delete b.maxValuesPerFacet;
+
+      if (ignorePageNo) {
+        // eslint-disable-next-line no-param-reassign
+        delete b.page;
+      }
     }
 
     return !dequal(a, b);

--- a/packages/core-data/src/hooks/ProgressiveSearch.js
+++ b/packages/core-data/src/hooks/ProgressiveSearch.js
@@ -14,6 +14,7 @@ type OnCompleteCallback = (results: Array<SearchResult>) => void;
 
 const useProgressiveSearch = (infiniteHits, transformResults = null) => {
   const [cachedHits, setCachedHits] = useState(TypesenseUtils.createCachedHits([]));
+  const [searching, setSearching] = useState(false);
 
   const lastSearchState = useRef<any>();
   const callbacks = useRef<Array<OnCompleteCallback>>([]);
@@ -80,6 +81,10 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
     const { isFirstPage, results } = infiniteHits;
     const hits = getHits(results);
 
+    if (isFirstPage) {
+      setSearching(true);
+    }
+
     // Add to cache and load next page
     if (isFirstPage && hasStateChanged(results._state, lastSearchState.current, true)) {
       setCachedHits(() => TypesenseUtils.createCachedHits(hits));
@@ -101,13 +106,18 @@ const useProgressiveSearch = (infiniteHits, transformResults = null) => {
       });
     }
 
+    if (isLastPage) {
+      setSearching(false);
+    }
+
     lastSearchState.current = results._state;
   }, [cachedHits]);
 
   return {
     cachedHits: cachedHits.hits,
     observe,
-    unobserve
+    unobserve,
+    searching
   };
 };
 

--- a/packages/core-data/src/hooks/Typesense.js
+++ b/packages/core-data/src/hooks/Typesense.js
@@ -36,6 +36,11 @@ export const useSearchCompleted = (callback: ((hits: TypesenseSearchResult[]) =>
   }, deps);
 };
 
+export const useSearching = () => {
+  const { searching } = useContext(PersistentSearchStateContext);
+  return searching;
+};
+
 export const useGeoSearchToggle = () => {
   const { clearMapRefinement, isRefinedWithMap, refine } = useGeoSearch();
 

--- a/packages/core-data/src/hooks/Typesense.js
+++ b/packages/core-data/src/hooks/Typesense.js
@@ -36,11 +36,6 @@ export const useSearchCompleted = (callback: ((hits: TypesenseSearchResult[]) =>
   }, deps);
 };
 
-export const useSearching = () => {
-  const { searching } = useContext(PersistentSearchStateContext);
-  return searching;
-};
-
 export const useGeoSearchToggle = () => {
   const { clearMapRefinement, isRefinedWithMap, refine } = useGeoSearch();
 

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -77,8 +77,7 @@ export {
   useGeoSearch,
   useGeoSearchToggle,
   useSearchBox,
-  useSearchCompleted,
-  useSearching
+  useSearchCompleted
 } from './hooks/Typesense';
 
 // Services

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -77,7 +77,8 @@ export {
   useGeoSearch,
   useGeoSearchToggle,
   useSearchBox,
-  useSearchCompleted
+  useSearchCompleted,
+  useSearching
 } from './hooks/Typesense';
 
 // Services


### PR DESCRIPTION
This pull request makes the following changes in support of https://github.com/performant-software/core-data-places/issues/68, which allows for the bounding box of the map to be adjusted as the layout changes. Previously, we were only adjusting the map bounding box on search.

- Fixes a bug with `isFirstPage` and `isLastPage` in `ProgressiveSearch`. There were situations where the `results` object did not contain `nbResults`, so `isLastPage` was always evaluating to "false", leading to Typesense making requests for pages that did not exist. We've updated the component to use the `isFirstPage` and `isLastPage` values that are provided by `infiniteHits`.
- Adds the `searching` property to the `ProgressiveSearch` state. This can be used to determine if we're currently making requests to the Typesense search API.
- Updates `SearchResultsLayer` to use `searching` instead of `searchCompleted`. This will allow us to only adjust the map bounding box when the search has completed.