### PR TITLE
Smarter item rendering for `SearchList`

### DIFF
--- a/packages/storybook/src/core-data/SearchList.stories.js
+++ b/packages/storybook/src/core-data/SearchList.stories.js
@@ -8,6 +8,8 @@ import { shuffle } from '../utils/Array';
 
 const LOTS_OF_DATA = shuffle(new Array(10).fill(data).flat());
 
+const LOTS_AND_LOTS_OF_DATA = shuffle(new Array(250).fill(data).flat());
+
 LOTS_OF_DATA[0].name = "I'm a really long name to showcase how this component handles really long names.";
 
 export default {
@@ -222,6 +224,35 @@ export const ControlledHighlightWithOnClick = () => (
       items={LOTS_OF_DATA}
       itemTitle='name'
       isHighlight={(item) => item.id % 2 === 0}
+      onItemClick={action('click')}
+    />
+  </div>
+);
+
+export const HugeAmountOfData = () => (
+  <div className='h-[600px] w-[360px]'>
+    <SearchList
+      attributes={[
+        {
+          label: 'UUID',
+          name: 'uuid',
+        },
+        {
+          label: 'Record ID',
+          name: 'record_id',
+          icon: 'person'
+        },
+        {
+          label: 'Location',
+          name: 'geometry',
+          icon: 'location',
+          render: (item) => (item.coordinates
+            ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+            : '')
+        },
+      ]}
+      items={LOTS_AND_LOTS_OF_DATA}
+      itemTitle='name'
       onItemClick={action('click')}
     />
   </div>


### PR DESCRIPTION
# Summary

This PR updates `SearchList` to only show 50 items in the list by default. When the user scrolls 80% of the way down the list, the next 50 items will be displayed, and so on until we're showing the entire list. The feature is pretty minimalist, just some event listeners on the parent `<ul>` component, so there's plenty of room to tweak the values if it feels off.

It also includes a new Storybook story with 1250 list items to test out performance.

(`react-window` wasn't an option for this fix because it expects list items to be a consistent, hardcoded size.)