### PR TITLE
Fix `SearchList` item loading when initialized with empty `props.items` array

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -77,10 +77,11 @@ const SearchList = (props: Props) => {
 
       return oldLimit;
     });
-  }, []);
+  }, [props.items]);
 
   useEffect(() => {
     if (listRef.current) {
+      listRef.current.removeEventListener('scroll', onScroll);
       listRef.current.addEventListener('scroll', onScroll);
     }
 
@@ -89,7 +90,7 @@ const SearchList = (props: Props) => {
         listRef.current.removeEventListener('scroll', onScroll);
       }
     };
-  }, []);
+  }, [props.items]);
 
   return (
     <div className={clsx(

--- a/packages/storybook/src/core-data/SearchList.stories.js
+++ b/packages/storybook/src/core-data/SearchList.stories.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { action } from '@storybook/addon-actions';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import SearchList from '../../../core-data/src/components/SearchList';
 import data from '../data/typesense/Places.json';
 import { shuffle } from '../utils/Array';
@@ -229,31 +229,39 @@ export const ControlledHighlightWithOnClick = () => (
   </div>
 );
 
-export const HugeAmountOfData = () => (
-  <div className='h-[600px] w-[360px]'>
-    <SearchList
-      attributes={[
-        {
-          label: 'UUID',
-          name: 'uuid',
-        },
-        {
-          label: 'Record ID',
-          name: 'record_id',
-          icon: 'person'
-        },
-        {
-          label: 'Location',
-          name: 'geometry',
-          icon: 'location',
-          render: (item) => (item.coordinates
-            ? `${item.coordinates[0]}, ${item.coordinates[1]}`
-            : '')
-        },
-      ]}
-      items={LOTS_AND_LOTS_OF_DATA}
-      itemTitle='name'
-      onItemClick={action('click')}
-    />
-  </div>
-);
+export const HugeAmountOfData = () => {
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    setTimeout(() => setItems(LOTS_AND_LOTS_OF_DATA), 500);
+  }, []);
+
+  return (
+    <div className='h-[600px] w-[360px]'>
+      <SearchList
+        attributes={[
+          {
+            label: 'UUID',
+            name: 'uuid',
+          },
+          {
+            label: 'Record ID',
+            name: 'record_id',
+            icon: 'person'
+          },
+          {
+            label: 'Location',
+            name: 'geometry',
+            icon: 'location',
+            render: (item) => (item.coordinates
+              ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+              : '')
+          },
+        ]}
+        items={items}
+        itemTitle='name'
+        onItemClick={action('click')}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
# Summary

This PR fixes an issue with `SearchList` where the `onScroll` function from #451 based its calculations on the initial version of `props.items` passed down from its parent. When the initial version was an empty array, the loading wouldn't work.

* add `props.items` as a dependency to the `onScroll` callback function
* remove and then re-add the `onScroll` function to the `<ul>`'s event listener each time `props.items` changes
* update the "Huge Amount of Data" Storybook example to use a 500ms timeout before setting its `items` array, as a test case for this bug