### PR TITLE
Use primary color highlight for `SearchResultsTable`

### DIFF
--- a/packages/core-data/src/components/SearchResultsTable.js
+++ b/packages/core-data/src/components/SearchResultsTable.js
@@ -102,8 +102,8 @@ const SearchResultsTable = (props: Props) => {
               <tr
                 className={clsx(
                   'divide-x divide-neutral-200',
-                  { 'hover:bg-neutral-200 cursor-pointer': props.onRowClick },
-                  { 'bg-neutral-200': props.isHighlight && props.isHighlight(hit) }
+                  { 'hover:bg-primary/20 cursor-pointer': props.onRowClick },
+                  { 'bg-primary/20': props.isHighlight && props.isHighlight(hit) }
                 )}
                 onClick={props.onRowClick
                   ? () => props.onRowClick(hit)


### PR DESCRIPTION
# Summary

This PR changes the highlight color for selected rows in `SearchResultsTable` from `neutral-200` to `primary/20`.