### PR TITLE
`RecordDetailPanel` design fixes

### DIFF
--- a/packages/core-data/src/components/AccordionItemsList.js
+++ b/packages/core-data/src/components/AccordionItemsList.js
@@ -31,6 +31,7 @@ const AccordionItemsList = (props: Props) => (
   <Accordion.Root
     className={clsx(
       'accordion-items-list',
+      'bg-white',
       props.className
     )}
     type='multiple'

--- a/packages/core-data/src/components/AccordionItemsList.js
+++ b/packages/core-data/src/components/AccordionItemsList.js
@@ -42,7 +42,7 @@ const AccordionItemsList = (props: Props) => (
         >
           <h2>
             <Accordion.Trigger
-              className='accordion-list-trigger border-neutral-100 border border-t border-b-0 border-l-0 border-r-0 border-solid rounded-none w-full flex justify-between items-center p-4 text-[15px] font-bold leading-[120%]'
+              className='accordion-list-trigger border-neutral-200 border border-t border-b-0 border-l-0 border-r-0 border-solid rounded-none w-full flex justify-between items-center p-4 text-[15px] font-bold leading-[120%]'
             >
               {
                 relation.renderTitle ? (

--- a/packages/core-data/src/components/RecordDetailPanel.js
+++ b/packages/core-data/src/components/RecordDetailPanel.js
@@ -70,12 +70,18 @@ const RecordDetailPanel = (props: Props) => (
   <div
     className={clsx(
       'relative',
-      'shadow-[0px_5px_12px_0px_rgba(0,0,0,.10)]',
       'overflow-y-auto',
       props.classNames?.root
     )}
   >
-    <div className='sticky inset-0 shadow-[0px_1px_4px_0px_rgba(0,0,0,.15)] bg-white z-[5]'>
+    <div className={clsx(
+      'sticky',
+      'inset-0',
+      'bg-white',
+      'z-[5]',
+      { 'shadow-[0px_1px_4px_0px_rgba(0,0,0,.15)]': props.relations && props.relations.length }
+    )}
+    >
       { props.onClose && (
         <div onClick={props.onClose} onKeyDown={props.onClose} tabIndex='0' role='button' aria-label='Close' className='absolute top-6 right-6 z-10 cursor-pointer'>
           <Icon
@@ -108,7 +114,7 @@ const RecordDetailPanel = (props: Props) => (
       </RecordDetailHeader>
     </div>
     <AccordionItemsList
-      className={clsx('shadow-[0px_1px_4px_rgba(0,0,0,.15)]', props.classNames?.relatedRecords)}
+      className={clsx(props.classNames?.relatedRecords)}
       items={props.relations}
       count={props.count}
     />

--- a/packages/core-data/src/components/RecordDetailTitle.js
+++ b/packages/core-data/src/components/RecordDetailTitle.js
@@ -27,7 +27,7 @@ const RecordDetailTitle = (props: Props) => (
       'flex',
       'flex-row',
       'gap-2',
-      'items-center',
+      'items-start',
       'text-[20px]',
       'font-bold',
       'leading-[120%]',

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -297,3 +297,28 @@ export const UnmountOnClose = () => {
   </RecordDetailPanel>
   );
 };
+
+export const NoRelatedRecords = () => (
+  <RecordDetailPanel
+    title='West Tokyo Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo.
+      {' '}
+      <span className='font-bold'>Tempor sem malesuada porttitor congue.</span>
+      {' '}
+      Nibh aenean vitae blandit vitae sapien ac varius mattis.
+      Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+);

--- a/packages/storybook/src/core-data/RecordDetailTitle.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailTitle.stories.js
@@ -25,5 +25,6 @@ export const Multiline = () => (
   <RecordDetailTitle
     text='This is a really long header that goes onto the second line'
     className='w-80'
+    icon='location'
   />
 );


### PR DESCRIPTION
### In this PR
Addresses the issues described in Issue #455:
- Removes the drop shadow from the related items accordion list. Note: I spent some time trying to research how to have a drop shadow effect on the sides of an element and not the bottom and it sounded either extremely complicated or impossible, although I may be missing something. I think the cleanest solution here is to add the shadow to the entire containing element in the map search layout in `core-data-places` if we want it along the sides of that column.
![image](https://github.com/user-attachments/assets/6e7fac22-fbb8-438d-ba1e-bf2f2b0df9c0)
- Removes the shadow entirely if there are no related items
![image](https://github.com/user-attachments/assets/31c5fd7d-7456-4200-a820-7689e0aef64e)
- Changes the icon alignment in the title to the top
![image](https://github.com/user-attachments/assets/7a88756d-9783-4d41-91f0-7ba0ca70c4bb)
- Updates the border color to `neutral-200` in the related items list
![image](https://github.com/user-attachments/assets/057d2491-479e-4a96-b346-61746492b5c0)
- Adds the `bg-white` class to the `AccordionItemsList` component