### PR TITLE
Fix`SearchList` not loading last group of items

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -70,7 +70,7 @@ const SearchList = (props: Props) => {
     setLimit((oldLimit) => {
       if (
         event.target.scrollTop / event.target.scrollHeight >= 0.8
-        && props.items.length >= oldLimit + LIMIT_STEP
+        && props.items.length > oldLimit
       ) {
         return oldLimit + LIMIT_STEP;
       }


### PR DESCRIPTION
# Summary

Previously, `SearchList` was checking for `props.items.length >= oldLimit + LIMIT_STEP` when determining whether to raise the limit. This prevented the last page from loading if the number of items was not divisible by 50.

This PR simplifies that check to `props.items.length > oldLimit`, which will correctly load the last page.