### PR TITLE
Migrate SearchList to InfiniteScroll

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -7,10 +7,10 @@ import React, {
   useRef
 } from 'react';
 import clsx from 'clsx';
+import { InfiniteScroll } from '@performant-software/shared-components';
 import { type Attribute } from '../types/SearchList';
 import SearchListItem from './SearchListItem';
 import i18n from '../i18n/i18n';
-import InfiniteScroll from '../../../shared/src/components/InfiniteScroll';
 
 type Props = {
   /**

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -71,7 +71,7 @@ const SearchListItem = (props: SearchListItemProps) => {
   }), [props.attributes, props.item]);
 
   return (
-    <li
+    <div
       className={clsx(
         { 'bg-primary/20': props.isHighlight },
         { 'hover:bg-primary/20': !!props.onClick }
@@ -111,7 +111,7 @@ const SearchListItem = (props: SearchListItemProps) => {
           )}
         </div>
       </ItemWrapper>
-    </li>
+    </div>
   );
 };
 


### PR DESCRIPTION
# Summary

* replaces the scroll event listener logic in `SearchList` with the `InfiniteScroll` component
* changes the `<ul>` and `<li>` elements in `SearchList` to `div`s because `InfiniteScroll` inserts a `div` between the two layers that will cause accessibility warnings
  * not sure how to feel about this - it's more semantic (and therefore more accessible) to use list elements to display a list. This feels like another case where we're trying to satisfy warnings on a piecemeal basis without looking at the big picture. But keeping a semantic list would require some breaking changes to `InfiniteScroll` and I'm not sure what exactly those changes would look like.