### PR TITLE
`className` and `as` props for InfiniteScroll

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -90,12 +90,14 @@ const SearchList = (props: Props) => {
           : i18n.t('Common.words.results') }
       </div>
       <div
-        className='overflow-y-auto h-full divide-y divide-solid divide-neutral-200'
+        className='overflow-y-auto h-full'
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
         ref={listRef}
       >
         <InfiniteScroll
+          as='ul'
+          className='divide-y divide-solid divide-neutral-200'
           offset={150}
           onBottomReached={onBottomReached}
           context={listRef}

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -71,7 +71,7 @@ const SearchListItem = (props: SearchListItemProps) => {
   }), [props.attributes, props.item]);
 
   return (
-    <div
+    <li
       className={clsx(
         { 'bg-primary/20': props.isHighlight },
         { 'hover:bg-primary/20': !!props.onClick }
@@ -111,7 +111,7 @@ const SearchListItem = (props: SearchListItemProps) => {
           )}
         </div>
       </ItemWrapper>
-    </div>
+    </li>
   );
 };
 

--- a/packages/shared/src/components/InfiniteScroll.js
+++ b/packages/shared/src/components/InfiniteScroll.js
@@ -2,6 +2,7 @@
 
 import React, {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type Element
@@ -9,7 +10,9 @@ import React, {
 import Browser from '../utils/Browser';
 
 type Props = {
+  as?: string;
   children: Element<any>,
+  className?: string,
   context?: { current: HTMLElement },
   offset: number,
   onBottomReached: () => void
@@ -104,12 +107,15 @@ const InfiniteScroll = (props: Props) => {
     }
   });
 
+  const Component = useMemo(() => props.as || 'div', [props.as]);
+
   return (
-    <div
+    <Component
+      className={props.className}
       ref={containerRef}
     >
       { props.children }
-    </div>
+    </Component>
   );
 };
 


### PR DESCRIPTION
# Summary

* adds a `className` prop to `InfiniteScroll` to allow consuming applications to style its root element
* adds an `as` prop that allows `InfiniteScroll` to be rendered as something other than a `div`
* updates `SearchList` to use the new props to render its `InfiniteScroll` instance as a `<ul>` and add divider styles back to the list
* updates `SearchListItem` to be contained in a `<li>` now that `SearchList` wraps it in a `<ul>` again