### PR TITLE
RC #470 - Record detail panel

### DIFF
--- a/packages/core-data/src/components/RecordDetailContent.js
+++ b/packages/core-data/src/components/RecordDetailContent.js
@@ -1,0 +1,130 @@
+// @flow
+
+import clsx from 'clsx';
+import React, {
+  type Node,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import _ from 'underscore';
+import Button from './Button';
+import i18n from '../i18n/i18n';
+import RecordDetailItem from './RecordDetailItem';
+
+type Item = {
+  className?: string,
+  icon?: string,
+  text: string
+};
+
+type Props = {
+  children?: Node,
+  classNames?: {
+    root?: string,
+    items?: string
+  },
+  items: Array<Item>
+};
+
+const RecordDetailContent = (props: Props) => {
+  const [expanded, setExpanded] = useState(false);
+  const [showMore, setShowMore] = useState(false);
+  const [contentHeight, setContentHeight] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  const content = useRef(null);
+
+  /**
+   * Sets the content and container heights on the state.
+   *
+   * @type {ResizeObserver}
+   */
+  const observer = useMemo(() => new ResizeObserver((entries) => {
+    const { target } = entries[0];
+
+    setContentHeight(target.scrollHeight);
+    setContainerHeight(target.clientHeight);
+  }), []);
+
+  /**
+   * Sets the resize ref when the observer changes.
+   *
+   * @type {(function(*): void)|*}
+   */
+  const sizeRef = useCallback((node) => {
+    if (node) {
+      content.current = node;
+      observer.observe(node);
+    } else {
+      content.current = null;
+    }
+  }, [observer]);
+
+  /**
+   * Toggles the "Show More" button based on the content and container heights.
+   */
+  useEffect(() => {
+    if (content.current) {
+      setShowMore(contentHeight > containerHeight || expanded);
+    }
+  }, [contentHeight, containerHeight]);
+
+  /**
+   * Disconnects the observer.
+   */
+  useEffect(() => () => observer.disconnect(), []);
+
+  return (
+    <>
+      <div
+        className={clsx(
+          'flex',
+          'flex-col',
+          'relative',
+          props.classNames?.root,
+          { 'max-h-[250px]': !expanded }
+        )}
+      >
+        <div
+          className='overflow-hidden'
+          ref={sizeRef}
+        >
+          <ul
+            className={props.classNames?.items}
+          >
+            { _.map(props.items, (item, idx) => (
+              <RecordDetailItem
+                className={item.className}
+                key={idx}
+                icon={item.icon}
+                text={item.text}
+              />
+            ))}
+          </ul>
+          { props.children }
+        </div>
+        { showMore && !expanded && (
+          <div
+            className='absolute left-0 bottom-0 w-full h-[50px] bg-gradient-to-b from-white/50 to-white/100'
+          />
+        )}
+      </div>
+      { showMore && (
+        <Button
+          className='w-full justify-center mb-4'
+          onClick={() => setExpanded((current) => (!current))}
+          rounded
+        >
+          { expanded
+            ? i18n.t('RecordDetailHeader.showLess')
+            : i18n.t('RecordDetailHeader.showMore') }
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default RecordDetailContent;

--- a/packages/core-data/src/components/RecordDetailContent.js
+++ b/packages/core-data/src/components/RecordDetailContent.js
@@ -78,13 +78,14 @@ const RecordDetailContent = (props: Props) => {
   useEffect(() => () => observer.disconnect(), []);
 
   return (
-    <>
+    <div
+      className={props.classNames?.root}
+    >
       <div
         className={clsx(
           'flex',
           'flex-col',
           'relative',
-          props.classNames?.root,
           { 'max-h-[250px]': !expanded }
         )}
       >
@@ -123,7 +124,7 @@ const RecordDetailContent = (props: Props) => {
             : i18n.t('RecordDetailHeader.showMore') }
         </Button>
       )}
-    </>
+    </div>
   );
 };
 

--- a/packages/core-data/src/components/RecordDetailHeader.js
+++ b/packages/core-data/src/components/RecordDetailHeader.js
@@ -1,30 +1,16 @@
 // @flow
 
 import clsx from 'clsx';
-import React, {
-  useState, useRef, useEffect, useMemo
-} from 'react';
-import _ from 'underscore';
+import React from 'react';
 import Button from './Button';
 import RecordDetailTitle from './RecordDetailTitle';
-import RecordDetailItem from './RecordDetailItem';
 import i18n from '../i18n/i18n';
 
 type Props = {
   /**
-   * Content to be rendered as the blurb
-   */
-  children?: Node,
-
-  /**
    * Class names to apply to the main div, the title element, and the list element containing the detail items.
    */
   classNames?: { items?: string, root?: string, title?: string },
-
-  /**
-   * List of detail fields to be rendered above the blurb
-   */
-  detailItems?: Array<{ text: string, icon?: string, className?: string }>,
 
   /**
    * If a URL for a record detail page is provided, will render a button that links to it
@@ -42,96 +28,36 @@ type Props = {
   title: string,
 };
 
-const RecordDetailHeader = (props: Props) => {
-  const [expanded, setExpanded] = useState(false);
-  const [showMore, setShowMore] = useState(false);
-  const [contentHeight, setContentHeight] = useState(0);
-  const [containerHeight, setContainerHeight] = useState(0);
-  const content = useRef(null);
-
-  const observer = useMemo(
-    () => new ResizeObserver((entries) => {
-      setContentHeight(entries[0].target.scrollHeight);
-      setContainerHeight(entries[0].target.clientHeight);
-    }),
-    []
-  );
-
-  const sizeRef = React.useCallback(
-    (node) => {
-      if (node) {
-        content.current = node;
-        observer.observe(node);
-      } else {
-        content.current = null;
-      }
-    },
-    [observer]
-  );
-
-  useEffect(() => {
-    if (content.current) {
-      setShowMore(contentHeight > containerHeight || expanded);
-    }
-  }, [contentHeight, containerHeight]);
-
-  useEffect(() => () => observer.disconnect(), []);
-
-  return (
-    <div
-      className={clsx(
-        'flex',
-        'flex-col',
-        'gap-4',
-        'px-6',
-        'pt-6',
-        'pb-4',
-        props.classNames?.root
-      )}
-    >
-      <RecordDetailTitle
-        text={props.title}
-        icon={props.icon}
-        className={props.classNames?.title}
-      />
-      {
-      !!props.detailItems?.length && (
-        <ul className={props.classNames?.items}>
-          {
-            _.map(props.detailItems, (item, idx) => (
-              <RecordDetailItem
-                text={item.text}
-                icon={item.icon}
-                className={item.className}
-                key={idx}
-              />
-            ))
-          }
-        </ul>
-      )
-    }
-      <div
-        ref={sizeRef}
-        className={clsx(
-          { 'line-clamp-6': !expanded }
-        )}
+const RecordDetailHeader = (props: Props) => (
+  <div
+    className={clsx(
+      'flex',
+      'flex-col',
+      'gap-4',
+      'px-6',
+      'pt-6',
+      'pb-4',
+      props.classNames?.root
+    )}
+  >
+    <RecordDetailTitle
+      text={props.title}
+      icon={props.icon}
+      className={props.classNames?.title}
+    />
+    { props.detailPageUrl && (
+      <a
+        href={props.detailPageUrl}
       >
-        { props.children }
-      </div>
-      { showMore && (
-      <Button rounded className='w-full justify-center' onClick={() => { setExpanded((current) => (!current)); }}>
-        { expanded ? i18n.t('RecordDetailHeader.showLess') : i18n.t('RecordDetailHeader.showMore') }
-      </Button>
-      )}
-      { props.detailPageUrl && (
-      <a href={props.detailPageUrl}>
-        <Button rounded className='w-full justify-center'>
+        <Button
+          className='w-full justify-center'
+          rounded
+        >
           { i18n.t('RecordDetailHeader.viewDetails') }
         </Button>
       </a>
-      )}
-    </div>
-  );
-};
+    )}
+  </div>
+);
 
 export default RecordDetailHeader;

--- a/packages/core-data/src/components/RecordDetailPanel.js
+++ b/packages/core-data/src/components/RecordDetailPanel.js
@@ -2,12 +2,13 @@
 
 import clsx from 'clsx';
 import React from 'react';
-import Icon from './Icon';
 import AccordionItemsList from './AccordionItemsList';
+import Icon from './Icon';
+import LoadAnimation from './LoadAnimation';
+import RecordDetailBreadcrumbs from './RecordDetailBreadcrumbs';
+import RecordDetailContent from './RecordDetailContent';
 import RecordDetailHeader from './RecordDetailHeader';
 import type { RelatedRecordsList } from '../types/RelatedRecordsList';
-import RecordDetailBreadcrumbs from './RecordDetailBreadcrumbs';
-import LoadAnimation from './LoadAnimation';
 
 type Props = {
   /**
@@ -89,7 +90,14 @@ const RecordDetailPanel = (props: Props) => (
     )}
     >
       { props.onClose && (
-        <div onClick={props.onClose} onKeyDown={props.onClose} tabIndex='0' role='button' aria-label='Close' className='absolute top-6 right-6 z-10 cursor-pointer'>
+        <div
+          aria-label='Close'
+          className='absolute top-6 right-6 z-10 cursor-pointer'
+          onClick={props.onClose}
+          onKeyDown={props.onClose}
+          role='button'
+          tabIndex='0'
+        >
           <Icon
             name='close'
             size={24}
@@ -106,28 +114,35 @@ const RecordDetailPanel = (props: Props) => (
       <RecordDetailHeader
         title={props.title}
         icon={props.icon}
-        classNames={
-          {
-            root: clsx({ '!pt-16': props.breadcrumbs || props.onGoBack }, props.classNames?.header),
-            title: clsx(props.classNames?.title, { 'pr-6': props.onClose }), // make sure there's space for the close icon
-            items: props.classNames?.items
-          }
-        }
-        detailItems={props.detailItems}
+        classNames={{
+          root: clsx({ '!pt-16': props.breadcrumbs || props.onGoBack }, props.classNames?.header),
+          title: clsx(props.classNames?.title, { 'pr-6': props.onClose }), // make sure there's space for the close icon
+          items: props.classNames?.items
+        }}
         detailPageUrl={props.detailPageUrl}
-      >
-        { props.children }
-      </RecordDetailHeader>
+      />
     </div>
-    { props.loading
-      ? <div className='py-4 px-8'><LoadAnimation /></div>
-      : (
-        <AccordionItemsList
-          className={clsx(props.classNames?.relatedRecords)}
-          items={props.relations}
-          count={props.count}
-        />
-      ) }
+    <RecordDetailContent
+      classNames={{
+        root: 'py-4 px-8',
+        items: props.classNames?.items
+      }}
+      items={props.detailItems}
+    >
+      { props.children }
+    </RecordDetailContent>
+    { props.loading && (
+      <div className='py-4 px-8'>
+        <LoadAnimation />
+      </div>
+    )}
+    { !props.loading && (
+      <AccordionItemsList
+        className={clsx(props.classNames?.relatedRecords)}
+        items={props.relations}
+        count={props.count}
+      />
+    )}
   </div>
 );
 

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useState } from 'react';
 import RecordDetailPanel from '../../../core-data/src/components/RecordDetailPanel';
+import { KeyValueList } from '@performant-software/core-data';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Components/Core Data/RecordDetailPanel',
@@ -131,7 +133,7 @@ export const WithClose = () => (
         icon: 'location'
       }
     ]}
-    onClose={() => { alert('Closed!'); }}
+    onClose={action('close')}
   >
     <p>
       Arcu imperdiet sit sit viverra id volutpat commodo.
@@ -159,7 +161,7 @@ export const WithBreadcrumbs = () => (
       }
     ]}
     breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
-    onGoBack={() => { alert('Go back!'); }}
+    onGoBack={action('back')}
   >
     <p>
       Arcu imperdiet sit sit viverra id volutpat commodo.
@@ -187,11 +189,11 @@ export const FixedWidthAndHeight = () => (
       }
     ]}
     breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
-    onGoBack={() => { alert('Go back!'); }}
+    onGoBack={action('back')}
     classNames={{
       root: 'w-[380px] h-[560px]'
     }}
-    onClose={() => { alert('Close!'); }}
+    onClose={action('close')}
     detailPageUrl='#'
   >
     <p>
@@ -286,7 +288,7 @@ export const UnmountOnClose = () => {
       }
     ]}
     breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
-    onGoBack={() => { alert('Go back!'); }}
+    onGoBack={action('back')}
     classNames={{
       root: 'w-[380px] h-[560px]'
     }}
@@ -359,3 +361,65 @@ export const WithLoadingDelay = () => {
     </RecordDetailPanel>
   );
 };
+
+export const Test = () => (
+  <RecordDetailPanel
+    classNames={{
+      root: 'w-[380px] h-[560px]'
+    }}
+    detailPageUrl='#'
+    icon='location'
+    onClose={action('close')}
+    relations={[{
+      title: 'Planification evenement new',
+      items: [{
+        name: 'Planification Salton City'
+      }]
+    }, {
+      title: 'Pays',
+      items: [{
+        name: 'États-Unis (Californie)'
+      }]
+    }]}
+    title='Saltaire'
+  >
+    <KeyValueList
+      items={[{
+        label: 'Serial Number',
+        value: '1976'
+      }, {
+        label: 'Periode Planification',
+        value: '1851-1853'
+      }, {
+        label: 'Annee Planification',
+        value: '1851'
+      }, {
+        label: 'Autre Nom Ou Localisation',
+        value: '(près de Bradford)'
+      }, {
+        label: 'Autres informations 1',
+        value: 'Site du patrimoine mondial.'
+      }, {
+        label: 'Autres informations 2',
+        value: '"Saltaire was built by Titus Salt to replace his woolen mills in Bradford by a single large factory and a new town for the work force. He selected a greenfield site crossed by a canal and railway, and between 1851 and 1871 completed a model industrial town of 820 dwellings and a population of 4,389. The town was endowed with a variety of community buildings and parks, and although the residentiel density of thirty-two houses (170 persons) per acre (eighty houses or 420 persons per hectare) appears crowded by today\'s standards, it represented a marked improvement on working-class living conditions of the time" (source: Pacione, Michael. 2009. Urban geography: a global perspective. Taylor & Francis. (à la page 166)).'
+      }]}
+    />
+    <p
+      className='text-sm py-4'
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse et mollis magna. Donec sed turpis sit amet purus condimentum sollicitudin id non nulla. Maecenas sit amet tellus fermentum, luctus risus fringilla, sollicitudin nisl. Nulla vitae tortor gravida, facilisis velit at, rhoncus justo. Aenean et hendrerit neque. Aliquam neque nunc, aliquet bibendum facilisis pellentesque, sagittis eu ligula. Suspendisse a nulla eget orci viverra elementum eu eu velit.
+      <br />
+      <br />
+      Suspendisse sed dolor tincidunt orci consectetur ultricies et eget nisi. Donec cursus cursus fringilla. In turpis quam, aliquet quis elit rhoncus, tempor tristique nisl. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc a sapien quis sapien lacinia posuere in sit amet lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Morbi metus felis, scelerisque vitae est varius, interdum posuere lectus. Morbi malesuada sagittis molestie. Pellentesque auctor ipsum et orci efficitur commodo. Etiam elit dui, suscipit eu consectetur a, hendrerit in urna. Quisque vitae sapien enim. Fusce ornare eget eros maximus ultrices. Sed dignissim odio quis eros accumsan, at auctor metus tempus.
+      <br />
+      <br />
+      Sed ut faucibus ante, vitae maximus tellus. Sed non mi sit amet lacus hendrerit accumsan a in lacus. Donec gravida varius nulla et scelerisque. Proin porttitor, nulla eget aliquet congue, magna libero tempor orci, quis laoreet ipsum nisi ut odio. Integer dignissim volutpat pretium. Vivamus lacus ante, scelerisque et metus et, imperdiet ornare ex. Nam condimentum, odio in feugiat accumsan, diam ligula varius velit, quis malesuada felis augue at tellus. Aliquam rhoncus nisl eu nulla laoreet aliquam. Donec lectus arcu, ullamcorper sit amet lacinia sed, pulvinar et nibh. In iaculis felis congue diam feugiat pharetra. Nam non arcu arcu. Fusce ex felis, porttitor sit amet metus quis, ornare bibendum quam. Quisque at mauris urna. Praesent feugiat luctus interdum.
+      <br />
+      <br />
+      Vivamus sed ultrices nunc, et auctor ante. Fusce sit amet porta lectus. Aliquam dapibus vitae dui commodo ornare. In efficitur, nisi sit amet tempor vehicula, nisi lectus maximus libero, sed dapibus massa augue nec nulla. Vestibulum sed tortor euismod, malesuada lacus quis, aliquam tellus. Proin sodales turpis velit, eget placerat dui maximus quis. Donec vulputate libero et ultrices tincidunt. Curabitur placerat placerat quam, sit amet iaculis ex pulvinar in. Nulla tincidunt mattis ex, eget varius sem blandit eu. Cras vulputate, massa ac lacinia hendrerit, purus libero sodales massa, in varius nisl leo et dui. In hac habitasse platea dictumst.
+      <br />
+      <br />
+      Praesent tempor placerat dignissim. Vivamus mi lorem, auctor at ipsum bibendum, semper pellentesque ante. Donec convallis feugiat arcu a volutpat. Suspendisse eu felis est. Nam fringilla ipsum vulputate justo commodo, eget pretium ante consequat. Donec ullamcorper arcu eu vestibulum finibus. Aliquam massa metus, ullamcorper at euismod vel, maximus ut neque. In a est a nibh auctor condimentum mattis quis mi. Nunc accumsan malesuada nisi non viverra. Mauris id eros magna. Nam pulvinar ullamcorper justo ac finibus. Mauris faucibus sapien eu ex porta, ut condimentum lectus accumsan. Nullam id ex ac nunc vehicula volutpat eu eget mauris. Etiam vitae bibendum eros.
+    </p>
+  </RecordDetailPanel>
+);


### PR DESCRIPTION
This pull request updates the `RecordDetailPanel` component to allow the "Show More" button to apply to the entire middle contents of the component. A `RecordDetailContent` component has been added to encompass the show/hide logic and all of the content that will be rendered. Additionally, the `RecordDetailHeader` component was refactored to display on the breadcrumbs, title, and close button.

## Initial View
The initial view with additional content to be displayed.

![Screenshot 2025-03-17 at 1 42 17 PM](https://github.com/user-attachments/assets/de03819a-fd2e-4f09-bb14-c81b0f722c38)

## Expanded View
The view when the "Show More" button is clicked.

![Screenshot 2025-03-17 at 1 42 21 PM](https://github.com/user-attachments/assets/35cd2e32-facf-42fe-8911-26c18f361c9a)

## Expanded View - Scrolled
The view scrolling down to the bottom of the component.

![Screenshot 2025-03-17 at 1 42 28 PM](https://github.com/user-attachments/assets/5ee70102-302f-43f9-a9d8-151ada891ec9)

## In Core Data Places
Screenshot from testing within Core Data Places.

![Screenshot 2025-03-17 at 1 45 50 PM](https://github.com/user-attachments/assets/76d38435-678c-42f3-92b2-dcc45295849c)
