### PR TITLE
Add `ssr` export to Core Data package

### DIFF
--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -12,6 +12,10 @@
       "import": "./dist/index.es.js",
       "require": "./dist/index.cjs.js"
     },
+    "./ssr": {
+      "import": "./dist/ssr.es.js",
+      "require": "./dist/ssr.cjs.js"
+    },
     "./style.css": "./dist/packages/core-data/src/index.css",
     "./tailwind.css": "./dist/packages/core-data/src/tailwind.css",
     "./tailwind.config": "./dist/tailwind.config.js"

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -3,74 +3,36 @@
 // CSS
 import './index.css';
 
+export * from './ssr';
+
 // Components
-export { default as AccordionItemsList } from './components/AccordionItemsList';
-export { default as Button } from './components/Button';
-export { default as ButtonGroup } from './components/ButtonGroup';
-export { default as Checkbox } from './components/Checkbox';
-export { default as Combobox } from './components/Combobox';
-export { default as CoreDataContextProvider } from './components/CoreDataContextProvider';
-export { default as EventDetails } from './components/EventDetails';
-export { default as EventsList } from './components/EventsList';
 export { default as FacetList } from './components/FacetList';
 export { default as FacetLists } from './components/FacetLists';
 export { default as FacetListsGrouped } from './components/FacetListsGrouped';
 export { default as FacetSlider } from './components/FacetSlider';
 export { default as FacetStateContextProvider } from './components/FacetStateContextProvider';
 export { default as FacetTimeline } from './components/FacetTimeline';
-export { default as HeaderImage } from './components/HeaderImage';
 export { default as HitsPerPage } from './components/HitsPerPage';
-export { default as Icon } from './components/Icon';
-export { default as Input } from './components/Input';
-export { default as KeyValueList } from './components/KeyValueList';
 export { default as LayerMenu } from './components/LayerMenu';
-export { default as LoadAnimation } from './components/LoadAnimation';
 export { default as MediaGallery } from './components/MediaGallery';
-export { default as Modal } from './components/Modal';
 export { default as OverlayLayers } from './components/OverlayLayers';
-export { default as Pagination } from './components/Pagination';
 export { default as PersistentSearchStateContextProvider } from './components/PersistentSearchStateContextProvider';
-export { default as Pill } from './components/Pill';
-export { default as PlaceDetails } from './components/PlaceDetails';
 export { default as PlaceLayersSelector } from './components/PlaceLayersSelector';
 export { default as PlaceMarkers } from './components/PlaceMarkers';
 export { default as SearchResultsList } from './components/SearchResultsList';
 export { default as RecordDetailPanel } from './components/RecordDetailPanel';
 export { default as RefinementListProxy } from './components/RefinementListProxy';
-export { default as RelatedEvents } from './components/RelatedEvents';
-export { default as RelatedItem } from './components/RelatedItem';
-export { default as RelatedItems } from './components/RelatedItems';
-export { default as RelatedItemsList } from './components/RelatedItemsList';
-export { default as RelatedList } from './components/RelatedList';
 export { default as RelatedMedia } from './components/RelatedMedia';
-export { default as RelatedOrganizations } from './components/RelatedOrganizations';
-export { default as RelatedPeople } from './components/RelatedPeople';
-export { default as RelatedPlaces } from './components/RelatedPlaces';
 export { default as RelatedPlacesLayer } from './components/RelatedPlacesLayer';
-export { default as RelatedSources } from './components/RelatedSources';
-export { default as RelatedTaxonomies } from './components/RelatedTaxonomies';
 export { default as SearchList } from './components/SearchList';
 export { default as SearchResultsLayer } from './components/SearchResultsLayer';
-export { default as SearchResultsTable } from './components/SearchResultsTable';
-export { default as SelectRecordPanel } from './components/SelectRecordPanel';
 export { default as Slider } from './components/Slider';
 
 // Contexts
-export { default as CoreDataContext } from './context/CoreData';
 export { default as FacetStateContext } from './context/FacetStateContext';
 export { default as PersistentSearchStateContext } from './context/PersistentSearchState';
 
 // Hooks
-export {
-  useEventsService,
-  useInstancesService,
-  useItemsService,
-  useLoader,
-  useOrganizationsService,
-  usePeopleService,
-  usePlacesService,
-  useWorksService
-} from './hooks/CoreData';
 export { default as useProgressiveSearch } from './hooks/ProgressiveSearch';
 export {
   useCachedHits,
@@ -81,18 +43,6 @@ export {
   useSearching
 } from './hooks/Typesense';
 
-// Services
-export { default as EventsService } from './services/Events';
-export { default as InstancesService } from './services/Instances';
-export { default as ItemsService } from './services/Items';
-export { default as OrganizationsService } from './services/Organizations';
-export { default as PeopleService } from './services/People';
-export { default as PlacesService } from './services/Places';
-export { default as WorksService } from './services/Works';
-
 // Utilities
-export { default as Api } from './utils/Api';
-export { default as CoreData } from './utils/CoreData';
-export { default as Event } from './utils/Event';
 export { default as Peripleo } from './utils/Peripleo';
 export { default as Typesense } from './utils/Typesense';

--- a/packages/core-data/src/ssr.js
+++ b/packages/core-data/src/ssr.js
@@ -1,0 +1,64 @@
+// @flow
+
+// CSS
+import './index.css';
+
+// Components
+export { default as AccordionItemsList } from './components/AccordionItemsList';
+export { default as Button } from './components/Button';
+export { default as ButtonGroup } from './components/ButtonGroup';
+export { default as Checkbox } from './components/Checkbox';
+export { default as Combobox } from './components/Combobox';
+export { default as CoreDataContextProvider } from './components/CoreDataContextProvider';
+export { default as EventDetails } from './components/EventDetails';
+export { default as EventsList } from './components/EventsList';
+export { default as HeaderImage } from './components/HeaderImage';
+export { default as Icon } from './components/Icon';
+export { default as Input } from './components/Input';
+export { default as KeyValueList } from './components/KeyValueList';
+export { default as LoadAnimation } from './components/LoadAnimation';
+export { default as Modal } from './components/Modal';
+export { default as Pagination } from './components/Pagination';
+export { default as Pill } from './components/Pill';
+export { default as PlaceDetails } from './components/PlaceDetails';
+export { default as RelatedEvents } from './components/RelatedEvents';
+export { default as RelatedItem } from './components/RelatedItem';
+export { default as RelatedItems } from './components/RelatedItems';
+export { default as RelatedItemsList } from './components/RelatedItemsList';
+export { default as RelatedList } from './components/RelatedList';
+export { default as RelatedOrganizations } from './components/RelatedOrganizations';
+export { default as RelatedPeople } from './components/RelatedPeople';
+export { default as RelatedPlaces } from './components/RelatedPlaces';
+export { default as RelatedSources } from './components/RelatedSources';
+export { default as RelatedTaxonomies } from './components/RelatedTaxonomies';
+export { default as SearchResultsTable } from './components/SearchResultsTable';
+export { default as SelectRecordPanel } from './components/SelectRecordPanel';
+
+// Contexts
+export { default as CoreDataContext } from './context/CoreData';
+
+// Hooks
+export {
+  useEventsService,
+  useInstancesService,
+  useItemsService,
+  useLoader,
+  useOrganizationsService,
+  usePeopleService,
+  usePlacesService,
+  useWorksService
+} from './hooks/CoreData';
+
+// Services
+export { default as EventsService } from './services/Events';
+export { default as InstancesService } from './services/Instances';
+export { default as ItemsService } from './services/Items';
+export { default as OrganizationsService } from './services/Organizations';
+export { default as PeopleService } from './services/People';
+export { default as PlacesService } from './services/Places';
+export { default as WorksService } from './services/Works';
+
+// Utilities
+export { default as Api } from './utils/Api';
+export { default as CoreData } from './utils/CoreData';
+export { default as Event } from './utils/Event';

--- a/packages/core-data/vite.config.js
+++ b/packages/core-data/vite.config.js
@@ -34,10 +34,17 @@ export default defineConfig(() => ({
     lib: {
       entry: [
         './src/index.js',
-        './src/tailwind.js'
+        './src/tailwind.js',
+        './src/ssr.js'
       ],
       formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format}.js`
+      fileName: (format, name) => {
+        if (name.endsWith('ssr')) {
+          return `ssr.${format}.js`;
+        }
+
+        return `index.${format}.js`;
+      }
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
# Summary

* adds a new file to the `core-data` package called `ssr.js`. `ssr.js` mirrors the contents of `index.js`, but anything that requires browser APIs is omitted
* updates the Vite config and `package.json` to allow consuming applications to import the SSR-safe version of the package via `@performant-software/core-data/ssr`

The standard package imported via `@performant-software/core-data` is unchanged, so this PR does not contain any breaking changes.

The Core Data model services are exported by `ssr.js` so #393 should be unblocked.