### PR TITLE
CDP #139 - Map clustering

### DIFF
--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -47,8 +47,8 @@
   "peerDependencies": {
     "@performant-software/geospatial": "^2.3.8",
     "@performant-software/shared-components": "^2.3.8",
-    "@peripleo/maplibre": "^0.5.2",
-    "@peripleo/peripleo": "^0.5.2",
+    "@peripleo/maplibre": "^0.8.7",
+    "@peripleo/peripleo": "^0.8.7",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -7,6 +7,10 @@ import TypesenseInstantsearchAdapter from 'typesense-instantsearch-adapter';
 import _ from 'underscore';
 import type { TypesenseSearchResult } from '../types/typesense/SearchResult';
 
+type Options = {
+  type?: string
+};
+
 type TypesenseConfig = {
   api_key: string,
   host: string,
@@ -174,10 +178,11 @@ const toFeature = (record: any, item: any, geometry: any) => {
  *
  * @param results
  * @param path
+ * @param options
  *
  * @returns {FeatureCollection<Geometry, Properties>}
  */
-const toFeatureCollection = (results: Array<any>, path: string) => {
+const toFeatureCollection = (results: Array<any>, path: string, options: Options = {}) => {
   const features = [];
 
   const objectPath = path.substring(0, path.lastIndexOf(ATTRIBUTE_DELIMITER));
@@ -193,7 +198,9 @@ const toFeatureCollection = (results: Array<any>, path: string) => {
     _.each(geometryObjects, (geometryObject) => {
       const geometry = _.get(geometryObject, geometryPath);
 
-      if (geometry) {
+      const include = geometry && (!options.type || geometry.type === options.type);
+
+      if (include) {
         const record = _.find(features, (f) => f.properties?.uuid === geometryObject.uuid);
 
         if (record) {

--- a/packages/geospatial/package.json
+++ b/packages/geospatial/package.json
@@ -29,7 +29,7 @@
     "underscore": "^1.13.6"
   },
   "peerDependencies": {
-    "@peripleo/maplibre": "^0.5.1",
+    "@peripleo/maplibre": "^0.8.7",
     "react": ">= 16.13.1 < 19.0.0",
     "react-dom": ">= 16.13.1 < 19.0.0"
   },

--- a/packages/geospatial/src/components/LocationMarkers.js
+++ b/packages/geospatial/src/components/LocationMarkers.js
@@ -69,6 +69,11 @@ type Props = {
   fitBoundingBox?: boolean,
 
   /**
+   * If `true`, the selection and hover state will apply to the layer.
+   */
+  interactive?: boolean,
+
+  /**
    * An ID value to apply to the layer.
    */
   layerId?: string,
@@ -133,6 +138,7 @@ const LocationMarkers = (props: Props) => {
         data={props.data}
         fillStyle={props.fillStyle}
         id={props.layerId}
+        interactive={props.interactive}
         strokeStyle={props.strokeStyle}
         pointStyle={props.pointStyle}
       />


### PR DESCRIPTION
This pull request makes the following changes to support [#139](https://github.com/performant-software/core-data-places/issues/139) and making clustering less brittle.

- Upgrades the Peripleo peer dependency to the latest version
- Updates `SearchResultsLayer` to accept a `data` prop instead of using `useCachedHits` hook
  - This will allow data to be transformed before it is added to the map
  - Updates `toFeatureCollection` to allow filtering geometries by "type"
  - Adds the `interactive` prop to `LocationMarkers`