### PR TITLE
Button style and props tweaks (CDP #116)

### DIFF
--- a/packages/core-data/src/components/Button.js
+++ b/packages/core-data/src/components/Button.js
@@ -46,7 +46,7 @@ const Button = (props: Props) => (
       { 'px-4': !props.icon },
       { 'rounded-full px-2': props.icon },
       { 'bg-secondary': props.secondary },
-      { 'border border-solid border-gray-200': !props.primary },
+      { 'border border-solid border-gray-200 bg-white': !props.primary },
       { 'border border-solid border-transparent bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary },
       { 'rounded-md': props.rounded },
       props.className

--- a/packages/core-data/src/components/Button.js
+++ b/packages/core-data/src/components/Button.js
@@ -47,7 +47,7 @@ const Button = (props: Props) => (
       { 'rounded-full px-2': props.icon },
       { 'bg-secondary': props.secondary },
       { 'border border-solid border-gray-200': !props.primary },
-      { 'bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary },
+      { 'border border-solid border-transparent bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary },
       { 'rounded-md': props.rounded },
       props.className
     )}

--- a/packages/core-data/src/components/Button.js
+++ b/packages/core-data/src/components/Button.js
@@ -50,11 +50,12 @@ const Button = (props: Props) => (
       'py-2',
       { 'px-4': !props.icon },
       { 'rounded-full px-2': props.icon },
+      { 'bg-white': !props.primary && !props.secondary },
       { 'bg-secondary': props.secondary },
-      { 'border border-solid border-gray-200 bg-white': !props.primary },
+      { 'border border-solid border-gray-200': !props.primary },
       { 'border border-solid border-transparent bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary && !props.disabled },
       { 'rounded-md': props.rounded },
-      { 'text-gray-400 hover:bg-white': props.disabled },
+      { 'text-gray-400 bg-white hover:bg-white': props.disabled },
       props.className
     )}
     type='button'

--- a/packages/core-data/src/components/Button.js
+++ b/packages/core-data/src/components/Button.js
@@ -51,7 +51,7 @@ const Button = (props: Props) => (
       { 'px-4': !props.icon },
       { 'rounded-full px-2': props.icon },
       { 'bg-white': !props.primary && !props.secondary },
-      { 'bg-secondary': props.secondary },
+      { 'bg-secondary': props.secondary && !props.disabled },
       { 'border border-solid border-gray-200': !props.primary },
       { 'border border-solid border-transparent bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary && !props.disabled },
       { 'rounded-md': props.rounded },

--- a/packages/core-data/src/components/Button.js
+++ b/packages/core-data/src/components/Button.js
@@ -15,6 +15,11 @@ type Props = {
   children: Node,
 
   /**
+   * If `true`, the button will get the `disabled` HTML attribute and appropriate styles.
+   */
+  disabled?: boolean,
+
+  /**
    * If `true`, the button will be assumed to contain a single icon.
    */
   icon?: boolean,
@@ -47,8 +52,9 @@ const Button = (props: Props) => (
       { 'rounded-full px-2': props.icon },
       { 'bg-secondary': props.secondary },
       { 'border border-solid border-gray-200 bg-white': !props.primary },
-      { 'border border-solid border-transparent bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary },
+      { 'border border-solid border-transparent bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary && !props.disabled },
       { 'rounded-md': props.rounded },
+      { 'text-gray-400 hover:bg-white': props.disabled },
       props.className
     )}
     type='button'

--- a/packages/storybook/src/core-data/Button.stories.js
+++ b/packages/storybook/src/core-data/Button.stories.js
@@ -77,3 +77,12 @@ export const customClasses = () => (
     This is blue
   </Button>
 );
+
+export const Disabled = () => (
+  <Button
+    onClick={action('click')}
+    disabled
+  >
+    Button
+  </Button>
+);


### PR DESCRIPTION
## In this PR

Per https://github.com/performant-software/core-data-places/issues/116:
- Per [designs](https://www.figma.com/design/5AWa1c3pJeVXwEeVPbRqZj/Place-Components-2.0?node-id=15-9790&t=xAKdjWVT7HJmFM0A-4), add `bg-white` to default button state
- Timeline button and Table button: one must be disabled when the other is enabled, so add `disabled` prop and style for button, per designs
- Apply a transparent border across all `primary` buttons to ensure size consistency. (I noticed that an `icon` button can cause content to shift when `primary` is enabled or disabled, due to the border changing)