### PR TITLE
Timeline revisions (CDC #116)

### DIFF
--- a/packages/core-data/src/components/Button.js
+++ b/packages/core-data/src/components/Button.js
@@ -55,7 +55,7 @@ const Button = (props: Props) => (
       { 'border border-solid border-gray-200': !props.primary },
       { 'border border-solid border-transparent bg-primary hover:bg-primary hover:saturate-50 text-white fill-white': props.primary && !props.disabled },
       { 'rounded-md': props.rounded },
-      { 'text-gray-400 bg-white hover:bg-white': props.disabled },
+      { 'border border-solid border-gray-200 text-gray-400 bg-white hover:bg-white': props.disabled },
       props.className
     )}
     type='button'

--- a/packages/core-data/src/components/FacetTimeline.js
+++ b/packages/core-data/src/components/FacetTimeline.js
@@ -23,18 +23,12 @@ import i18n from '../i18n/i18n';
 /**
  * Helper constants: periods of time in milliseconds.
  */
-const ONE_DAY = 86400000;
+const ONE_SECOND = 1000;
 const MIN_MONTH = 2419200000; // 28 days
 const MAX_MONTH = 2678400000; // 31 days
 
 /**
- * Width/height of a single event in px.
- */
-const EVENT_WIDTH = 154;
-const EVENT_HEIGHT = 42;
-
-/**
- * Additional timeline display constants.
+ * Timeline display constants.
  */
 const MARKER_RADIUS = 4; // radius of a circular marker on the timeline
 const MARKER_DIAMETER = MARKER_RADIUS * 2;
@@ -43,6 +37,14 @@ const TIMELINE_PADTOP = 8; // vertical padding between timeline and events
 const TIMELINE_HEIGHT = 1; // height of the actual line
 const SVG_WIGGLE_ROOM = 0.5; // helper to line up left and right edges in svg
 const FRAME_PADDING = 32; // right padding between timeline and frame
+
+/**
+ * Width/height of a single event in px.
+ */
+// account for difference in font size between storybook and CDP
+const ONE_REM = parseFloat(getComputedStyle(document.documentElement).fontSize);
+const EVENT_WIDTH = 11 * ONE_REM; // 11rem
+const EVENT_HEIGHT = 2.5 * ONE_REM + TIMELINE_PADTOP; // 2.5rem + timeline padding
 
 /**
  * Maximum width of the frame bounds in px.

--- a/packages/core-data/src/components/FacetTimeline.js
+++ b/packages/core-data/src/components/FacetTimeline.js
@@ -17,8 +17,9 @@ import _ from 'underscore';
 import type { Event as EventType } from '../types/Event';
 import FacetSlider, { type Action as ActionType, type ClassNames as ClassNamesType } from './FacetSlider';
 import Icon from './Icon';
-import { useEventsService } from '../hooks/CoreData';
 import i18n from '../i18n/i18n';
+import Button from './Button';
+import ButtonGroup from './ButtonGroup';
 
 /**
  * Helper constants: periods of time in milliseconds.
@@ -372,39 +373,29 @@ const Timeline = (props: TimelineProps) => {
       style={{ scrollbarWidth: 'none' }}
     >
       <div className='absolute top-5 right-5 z-30 flex flex-row'>
-        <button
-          aria-label={i18n.t('Timeline.zoomIn')}
-          className={clsx(
-            'p-3',
-            'disabled:opacity-50',
-            'disabled:hover:bg-transparent',
-            'rounded-tl',
-            'rounded-bl',
-            props.classNames?.zoom
-          )}
-          disabled={!canZoomIn}
-          type='button'
-          onClick={onZoomIn}
+        <ButtonGroup
+          className='h-12'
+          rounded
         >
-          <Icon name='magnifying_glass_plus' size={19} />
-        </button>
-        <button
-          aria-label={i18n.t('Timeline.zoomOut')}
-          className={clsx(
-            'ml-[1px]',
-            'p-3',
-            'disabled:opacity-50',
-            'disabled:hover:bg-transparent',
-            'rounded-tr',
-            'rounded-br',
-            props.classNames?.zoom
-          )}
-          disabled={!canZoomOut}
-          type='button'
-          onClick={onZoomOut}
-        >
-          <Icon name='magnifying_glass_minus' size={19} />
-        </button>
+          <Button
+            aria-label={i18n.t('Timeline.zoomIn')}
+            className={clsx('w-12', 'pl-3', props.classNames?.zoom)}
+            disabled={!canZoomIn}
+            onClick={onZoomIn}
+            primary
+          >
+            <Icon name='magnifying_glass_plus' size={19} />
+          </Button>
+          <Button
+            aria-label={i18n.t('Timeline.zoomOut')}
+            className={clsx('w-12', 'pl-3', 'border-l-slate-500', props.classNames?.zoom)}
+            disabled={!canZoomOut}
+            onClick={onZoomOut}
+            primary
+          >
+            <Icon name='magnifying_glass_minus' size={19} />
+          </Button>
+        </ButtonGroup>
       </div>
       <div
         className='h-full min-h-36 flex flex-col'

--- a/packages/core-data/src/components/Modal.js
+++ b/packages/core-data/src/components/Modal.js
@@ -62,7 +62,7 @@ const Modal = (props: Props) => {
       >
         <Dialog.Overlay
           className={clsx(
-            'fixed bg-black/70 inset-0 transition-opacity flex justify-center z-10',
+            'fixed bg-black/70 inset-0 transition-opacity flex justify-center z-50',
             { 'items-center': props.centered },
             { 'overflow-auto': !props.scrolling }
           )}

--- a/packages/core-data/src/utils/Peripleo.js
+++ b/packages/core-data/src/utils/Peripleo.js
@@ -31,7 +31,7 @@ const normalize = (config: RuntimeConfig) => ({
     ...search,
     typesense: {
       ...search.typesense,
-      host: search.typesense.host || '443',
+      port: search.typesense.port || '443',
       protocol: search.typesense.protocol || 'https',
       sort_by: `_text_match:desc${search.typesense.default_sort ? `,${search.typesense.default_sort}:asc` : ''}`
     }

--- a/packages/storybook/src/core-data/FacetTimeline.stories.js
+++ b/packages/storybook/src/core-data/FacetTimeline.stories.js
@@ -34,7 +34,7 @@ const createEvent = (count, range) => _.times(count, () => {
     from: `${range.min}-01-01`,
     to: `${range.max}-01-01`
   });
-  // convert to Unicode date for typesense mock (seconds since epoch)
+  // convert to Unix date for typesense mock (seconds since epoch)
   date = Math.floor(date.getTime() / 1000);
   return {
     uuid: faker.string.uuid(),

--- a/packages/storybook/src/core-data/FacetTimeline.stories.js
+++ b/packages/storybook/src/core-data/FacetTimeline.stories.js
@@ -64,7 +64,6 @@ export const FitBounds = () => (
 );
 
 export const LargeRange = () => (
-  // container with full height and negative margin to fill the storybook viewport
   <div className='h-[500px] p-2'>
     <FacetTimeline
       data={createEvent(50, largeRange)}
@@ -105,6 +104,8 @@ export const EventModal = withCoreDataContextProvider(() => {
 
   useEffect(() => {
     const fakeEvents = createEvent(10, smallRange);
+    // get "real" uuids from the EventService mock, so clicking
+    // them will bring up their data
     setData(_.map(fakeEvents, (event, i) => ({
       ...event,
       name: events[i]?.name,


### PR DESCRIPTION
## In this PR

Per https://github.com/performant-software/core-data-places/issues/116:
- Update `FacetTimeline` to use Typesense formatted data, instead of hitting a Core Data API endpoint
- Prevent timeline from showing out-of-bounds events during update
- Simplify functions to ensure full faceted date range is represented on the timeline
- Fix bug with event width/height on the timeline (was not accounting for `rem` size)
- Use `ButtonGroup` for zoom buttons, ensure `disabled` button always gets a border (was causing the zoom buttons to reflow content)
- Adjust `Modal` to always be at `z-50` z-index (we have some z-index stuff in the timeline that a `Modal` should always supersede)

Other:
- Fix a typo in the runtime config normalizer for typesense