### PR TITLE
Add `"type": "module"` to `shared-components`

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
   "style": "./dist/style.css",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/index.es.js",


### PR DESCRIPTION
# Summary

This PR adds `"type": "module"` to `shared-components`'s `package.json`. This field is already present in the other packages, and its absence caused errors when importing it in a Node context.

I tested with a beta release and this change doesn't seem to have broken anything on the browser side.