### PR TITLE
Remove `geometry` fields from `toFeatureCollection`

### DIFF
--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -208,10 +208,10 @@ const toFeatureCollection = (results: Array<any>, path: string, options: Options
         const trimmedResult = ObjectUtils.setNestedValue(
           result,
           objectPath,
-          [...ObjectUtils.getNestedValue(result, objectPath).map((obj) => ({
+          ObjectUtils.getNestedValue(result, objectPath).map((obj) => ({
             ...obj,
             geometry: undefined
-          }))]
+          }))
         );
 
         trimmedResult._rawTypesenseHit = undefined;

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -205,10 +205,23 @@ const toFeatureCollection = (results: Array<any>, path: string, options: Options
       if (include) {
         const record = _.find(features, (f) => f.properties?.uuid === geometryObject.uuid);
 
+        const trimmedResult = ObjectUtils.setNestedValue(
+          result,
+          objectPath,
+          [...ObjectUtils.getNestedValue(result, objectPath).map((obj) => ({
+            ...obj,
+            geometry: undefined
+          }))]
+        );
+
+        trimmedResult._rawTypesenseHit = undefined;
+        trimmedResult._snippetResult = undefined;
+        trimmedResult._highlightResult = undefined;
+
         if (record) {
-          record.properties?.items.push(result);
+          record.properties?.items.push(trimmedResult);
         } else {
-          features.push(toFeature(geometryObject, result, geometry));
+          features.push(toFeature(geometryObject, trimmedResult, geometry));
         }
       }
     });

--- a/packages/shared/src/utils/Object.js
+++ b/packages/shared/src/utils/Object.js
@@ -83,7 +83,6 @@ const setNestedValue = (object: any, path: string, value: any) => {
 
   for (let i = 0; i < paths.length; i += 1) {
     if (i < paths.length - 1) {
-      // toUpdate = toUpdate[paths[i]]
       if (_.isArray(toUpdate[paths[i]])) {
         toUpdate = _.map(toUpdate, (entry) => _.get(entry, paths[i]));
       } else {
@@ -95,7 +94,7 @@ const setNestedValue = (object: any, path: string, value: any) => {
   }
 
   return cloned;
-}
+};
 
 /**
  * Returns true if the passed value is considered "empty".

--- a/packages/shared/src/utils/Object.js
+++ b/packages/shared/src/utils/Object.js
@@ -67,6 +67,37 @@ const getNestedValue = (object: any, path: string) => {
 };
 
 /**
+ * Returns a new object with the nested attribute at the given path
+ * replaced with the provided value.
+ *
+ * @param object
+ * @param path
+ *
+ * @returns {*}
+ */
+const setNestedValue = (object: any, path: string, value: any) => {
+  const paths = path.split('.');
+
+  const cloned = _.clone(object);
+  let toUpdate = cloned;
+
+  for (let i = 0; i < paths.length; i += 1) {
+    if (i < paths.length - 1) {
+      // toUpdate = toUpdate[paths[i]]
+      if (_.isArray(toUpdate[paths[i]])) {
+        toUpdate = _.map(toUpdate, (entry) => _.get(entry, paths[i]));
+      } else {
+        toUpdate = _.get(toUpdate, paths[i]);
+      }
+    } else {
+      toUpdate[paths[i]] = value;
+    }
+  }
+
+  return cloned;
+}
+
+/**
  * Returns true if the passed value is considered "empty".
  *
  * @param value
@@ -189,6 +220,7 @@ const without = (value: any, attribute: string) => {
 
 export default {
   getNestedValue,
+  setNestedValue,
   isEmpty,
   isEqual,
   isPromise,


### PR DESCRIPTION
# Summary

- updates `toFeatureCollection` to remove nested geometry fields (along with stripping the Typesense metadata fields `_rawTypesenseHit`, `_snippetResult`, and `_highlightResult`, which duplicate the geometry data) to drastically reduce the amount of data we send to Peripleo, improving performance when the search results contain polygons
- adds a new `setNestedValue` helper function to `ObjectUtils` inspired by `getNestedValue` that allows updating a value based on a string path, e.g. `setNestedValue(myObject, 'item.myArray[2].title', 'new title')`.