### PR TITLE
Update `toFeatureCollection` to handle records with no nested geometry

### DIFF
--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -205,18 +205,24 @@ const toFeatureCollection = (results: Array<any>, path: string, options: Options
       if (include) {
         const record = _.find(features, (f) => f.properties?.uuid === geometryObject.uuid);
 
-        const trimmedResult = ObjectUtils.setNestedValue(
-          result,
-          objectPath,
-          ObjectUtils.getNestedValue(result, objectPath).map((obj) => ({
-            ...obj,
-            geometry: undefined
-          }))
-        );
+        let trimmedResult = result;
 
-        trimmedResult._rawTypesenseHit = undefined;
-        trimmedResult._snippetResult = undefined;
-        trimmedResult._highlightResult = undefined;
+        const relatedRecords = _.get(result, objectPath);
+
+        if (relatedRecords) {
+          trimmedResult = ObjectUtils.setNestedValue(
+            result,
+            objectPath,
+            relatedRecords.map((obj) => ({
+              ...obj,
+              geometry: undefined
+            }))
+          );
+
+          trimmedResult._rawTypesenseHit = undefined;
+          trimmedResult._snippetResult = undefined;
+          trimmedResult._highlightResult = undefined;
+        }
 
         if (record) {
           record.properties?.items.push(trimmedResult);


### PR DESCRIPTION
# Summary

The `toFeatureCollection` changes from #483 caused an error when `geometry` was a top-level field (i.e. when we're indexing places directly, instead of another model with related places). In this case, we don't actually want to modify the result item at all. This PR fixes the error and updates the logic so it doesn't touch top-level places.