### PR TITLE
Cover images for search panels

### DIFF
--- a/packages/core-data/src/components/RecordDetailPanel.js
+++ b/packages/core-data/src/components/RecordDetailPanel.js
@@ -33,6 +33,11 @@ type Props = {
   count?: Boolean,
 
   /**
+   * If provided, the panel will display this image above the header.
+   */
+  coverUrl?: string,
+
+  /**
    * List of detail fields to be rendered above the blurb
    */
   detailItems?: Array<{ text: string, icon?: string, className?: string }>,
@@ -92,7 +97,11 @@ const RecordDetailPanel = (props: Props) => (
       { props.onClose && (
         <div
           aria-label='Close'
-          className='absolute top-6 right-6 z-10 cursor-pointer'
+          className={clsx(
+            'absolute z-10 cursor-pointer',
+            { 'top-6 right-6': !props.coverUrl },
+            { 'bg-black rounded-full p-2.5 text-white top-2 right-2': props.coverUrl }
+          )}
           onClick={props.onClose}
           onKeyDown={props.onClose}
           role='button'
@@ -111,6 +120,13 @@ const RecordDetailPanel = (props: Props) => (
           className='absolute top-6 left-6 pr-6 max-w-[calc(100%_-4.5em)] z-10'
         />
       ) }
+      {props.coverUrl && (
+        <img
+          alt={props.title}
+          src={props.coverUrl}
+          className='object-cover max-h-[220px] w-full'
+        />
+      )}
       <RecordDetailHeader
         title={props.title}
         icon={props.icon}

--- a/packages/core-data/src/components/RecordDetailPanel.js
+++ b/packages/core-data/src/components/RecordDetailPanel.js
@@ -124,7 +124,7 @@ const RecordDetailPanel = (props: Props) => (
         <img
           alt={props.title}
           src={props.coverUrl}
-          className='object-cover max-h-[220px] w-full'
+          className='object-cover h-[220px] max-h-[220px] w-full'
         />
       )}
       <RecordDetailHeader

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -66,6 +66,34 @@ export const Default = () => (
   </RecordDetailPanel>
 );
 
+export const WithCoverUrl = () => (
+  <RecordDetailPanel
+    coverUrl='https://m.media-amazon.com/images/I/91-OHYmdS2L._AC_SL1500_.jpg'
+    relations={sampleData}
+    title='West Tokyo Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+    onClose={action('close')}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo.
+      {' '}
+      <span className='font-bold'>Tempor sem malesuada porttitor congue.</span>
+      {' '}
+      Nibh aenean vitae blandit vitae sapien ac varius mattis.
+      Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+);
+
 export const WithViewDetail = () => (
   <RecordDetailPanel
     relations={sampleData}


### PR DESCRIPTION
# Summary

* adds a new `coverUrl` prop to `RecordDetailPanel`. When provided, the component will display the image above the header
  * the image is set to a height of 220px (the exact pixel measurement from Figma) and 100% width, with `object-fit: cover` so it will zoom to fill the space. This means that every image takes up a consistent amount of space in the component and it allows us to hardcode the `img` element's height, avoiding layout shifts when it loads in.
* adds new conditional styling to the close button to use a rounded black background when a cover image is present

# Screenshot

<img width="400" alt="Screenshot 2025-04-16 at 4 22 37 PM" src="https://github.com/user-attachments/assets/6d27caa2-a9be-4eaa-83cd-60b6c97e6f3c" />
