### PR TITLE
Adding compatibility between breadcrumbs and cover img

### DIFF
--- a/packages/core-data/src/components/RecordDetailPanel.js
+++ b/packages/core-data/src/components/RecordDetailPanel.js
@@ -113,13 +113,6 @@ const RecordDetailPanel = (props: Props) => (
           />
         </div>
       )}
-      { (props.breadcrumbs || props.onGoBack) && (
-        <RecordDetailBreadcrumbs
-          history={props.breadcrumbs || []}
-          onGoBack={props.onGoBack}
-          className='absolute top-6 left-6 pr-6 max-w-[calc(100%_-4.5em)] z-10'
-        />
-      ) }
       {props.coverUrl && (
         <img
           alt={props.title}
@@ -127,12 +120,22 @@ const RecordDetailPanel = (props: Props) => (
           className='object-cover h-[220px] max-h-[220px] w-full'
         />
       )}
+      { (props.breadcrumbs || props.onGoBack) && (
+        <RecordDetailBreadcrumbs
+          history={props.breadcrumbs || []}
+          onGoBack={props.onGoBack}
+          className={clsx({
+            'absolute top-6 left-6 pr-6 max-w-[calc(100%_-4.5em)] z-10': !props.coverUrl,
+            'px-6 pt-6': props.coverUrl
+          })}
+        />
+      ) }
       <RecordDetailHeader
         title={props.title}
         icon={props.icon}
         classNames={{
-          root: clsx({ '!pt-16': props.breadcrumbs || props.onGoBack }, props.classNames?.header),
-          title: clsx(props.classNames?.title, { 'pr-6': props.onClose }), // make sure there's space for the close icon
+          root: clsx({ '!pt-16': !props.coverUrl && (props.breadcrumbs || props.onGoBack) }, props.classNames?.header),
+          title: clsx(props.classNames?.title, { 'pr-6': !props.coverUrl && props.onClose }), // make sure there's space for the close icon
           items: props.classNames?.items
         }}
         detailPageUrl={props.detailPageUrl}

--- a/packages/storybook/src/core-data/RecordDetailPanel.stories.js
+++ b/packages/storybook/src/core-data/RecordDetailPanel.stories.js
@@ -203,6 +203,35 @@ export const WithBreadcrumbs = () => (
   </RecordDetailPanel>
 );
 
+export const WithBreadcrumbsAndCoverUrl = () => (
+  <RecordDetailPanel
+    coverUrl='https://m.media-amazon.com/images/I/91-OHYmdS2L._AC_SL1500_.jpg'
+    relations={sampleData}
+    title='West Tokyo Qualifiers Quarterfinal'
+    detailItems={[
+      {
+        text: 'July 27',
+        icon: 'date'
+      },
+      {
+        text: 'Meiji Jinju Stadium',
+        icon: 'location'
+      }
+    ]}
+    breadcrumbs={['West Tokyo Qualifiers Semifinal', 'West Tokyo Qualifiers Quarterfinal']}
+    onGoBack={action('back')}
+  >
+    <p>
+      Arcu imperdiet sit sit viverra id volutpat commodo.
+      {' '}
+      <span className='font-bold'>Tempor sem malesuada porttitor congue.</span>
+      {' '}
+      Nibh aenean vitae blandit vitae sapien ac varius mattis.
+      Aliquam vitae purus arcu eros enim tempus parturient orci fames.
+    </p>
+  </RecordDetailPanel>
+);
+
 export const FixedWidthAndHeight = () => (
   <RecordDetailPanel
     relations={sampleData}


### PR DESCRIPTION
### In this PR
Updates the styling of the breadcrumbs in the `RecordDetailPanel` to take into account whether or not there's a cover image, and to appear below the image if so.

![image](https://github.com/user-attachments/assets/63c49df7-eafe-4b53-b4b0-4a771c853ff1)
