### PR TITLE
Fix linting with ESLint 9

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-"typescript.validate.enable": false,
-"javascript.validate.enable": false
+  "typescript.validate.enable": false,
+  "javascript.validate.enable": false,
+  "eslint.workingDirectories": ["."]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,16 +1,15 @@
-// @flow
-
 import js from '@eslint/js';
 import babelParser from '@babel/eslint-parser';
 import flowtype from 'eslint-plugin-flowtype';
-import importPlugin from 'eslint-plugin-import-x';
+import { importX } from 'eslint-plugin-import-x';
 import jest from 'eslint-plugin-jest';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 import react from 'eslint-plugin-react';
 import globals from 'globals';
+import stylistic from '@stylistic/eslint-plugin';
 
 export default [
-  importPlugin.flatConfigs.recommended,
+  importX.flatConfigs.recommended,
   js.configs.recommended,
   react.configs.flat.recommended,
   {
@@ -32,7 +31,7 @@ export default [
         ecmaFeatures: {
           jsx: true
         },
-        requireConfigFile: true,
+        requireConfigFile: false,
         babelOptions: {
           parserOpts: {
             plugins: ['jsx']
@@ -45,24 +44,25 @@ export default [
       react,
       flowtype,
       jest,
-      'jsx-a11y': jsxA11y
+      'jsx-a11y': jsxA11y,
+      '@stylistic': stylistic
     },
     rules: {
       'class-methods-use-this': 'off',
-      'comma-dangle': ['error', 'never'],
+      '@stylistic/comma-dangle': ['error', 'never'],
       "import-x/no-named-as-default": "off",
       "import-x/no-named-as-default-member": "off",
       'import-x/prefer-default-export': 'off',
       'jsx-a11y/media-has-caption': 'off',
-      'jsx-quotes': ['error', 'prefer-single'],
-      'lines-between-class-members': 'off',
-      'max-len': ['error', {
+      '@stylistic/jsx-quotes': ['error', 'prefer-single'],
+      '@stylistic/lines-between-class-members': 'off',
+      '@stylistic/max-len': ['error', {
         code: 120,
         ignoreStrings: true
       }],
       'no-underscore-dangle': 'off',
       'no-use-before-define': 'off',
-      'quote-props': ['error', 'as-needed', {
+      '@stylistic/quote-props': ['error', 'as-needed', {
         keywords: false,
         unnecessary: true,
         numbers: true
@@ -81,7 +81,8 @@ export default [
       'react/require-default-props': 'off',
       'react/sort-comp': 'off',
       'react/static-property-placement': 'off',
-      'semi-style': ['error', 'last']
+      '@stylistic/semi-style': ['error', 'last'],
+      '@stylistic/semi': ['error', 'always']
     },
     settings: {
       react: {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "globals": "^16.3.0",
     "jest": "^27.5.1",
     "minimist": "^1.2.6",
+    "@stylistic/eslint-plugin": "^5.2.2",
     "underscore": "^1.13.4"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4240,6 +4240,18 @@
     "@storybook/global" "^5.0.0"
     "@storybook/react-dom-shim" "9.0.17"
 
+"@stylistic/eslint-plugin@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin/-/eslint-plugin-5.2.2.tgz#a1cb24f17263e1dcb2d5c94069dc3ae7af1eb9ce"
+  integrity sha512-bE2DUjruqXlHYP3Q2Gpqiuj2bHq7/88FnuaS0FjeGGLCy+X6a07bGVuwtiOYnPSLHR6jmx5Bwdv+j7l8H+G97A==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.7.0"
+    "@typescript-eslint/types" "^8.37.0"
+    eslint-visitor-keys "^4.2.1"
+    espree "^10.4.0"
+    estraverse "^5.3.0"
+    picomatch "^4.0.3"
+
 "@swc/helpers@^0.5.0":
   version "0.5.17"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.17.tgz#5a7be95ac0f0bf186e7e6e890e7a6f6cda6ce971"
@@ -14403,7 +14415,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.2:
+picomatch@^4.0.2, picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==


### PR DESCRIPTION
# Summary

This PR addresses an issue where some of the stylistic linting rules were silently broken after the ESLint 9 upgrade.

I installed `@stylistic/eslint-plugin` on the recommendation of the ESLint developers and prefixed the affected rules in the ESLint config file with `@stylistic`.

That was enough to get most of them working, but I noticed I still wasn't getting red squigglies for missing semicolons. The config file didn't have anything set up to require semicolons, so I guess that rule came built-in with older versions of ESLint. I added the `@stylistic/semi` rule to fix that issue, but it wouldn't surprise me if some other rules might have slipped through the cracks.

It's also likely that some configuration will be required on the `tailwind-ui` branch, but that should happen on that branch instead of here.