### PR TITLE
Linting config for TS files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,42 @@ import jsxA11y from 'eslint-plugin-jsx-a11y';
 import react from 'eslint-plugin-react';
 import globals from 'globals';
 import stylistic from '@stylistic/eslint-plugin';
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
+
+const commonRules = {
+  'class-methods-use-this': 'off',
+  '@stylistic/comma-dangle': ['error', 'never'],
+  "import-x/no-named-as-default": "off",
+  "import-x/no-named-as-default-member": "off",
+  'import-x/prefer-default-export': 'off',
+  'jsx-a11y/media-has-caption': 'off',
+  '@stylistic/jsx-quotes': ['error', 'prefer-single'],
+  '@stylistic/lines-between-class-members': 'off',
+  '@stylistic/max-len': ['error', {
+    code: 120,
+    ignoreStrings: true
+  }],
+  'no-underscore-dangle': 'off',
+  'no-use-before-define': 'off',
+  '@stylistic/quote-props': ['error', 'as-needed', {
+    keywords: false,
+    unnecessary: true,
+    numbers: true
+  }],
+  'react/display-name': 'off',
+  'react/default-props-match-prop-types': 'off',
+  'react/destructuring-assignment': 'off',
+  'react/jsx-no-bind': 'off',
+  'react/jsx-props-no-spreading': 'off',
+  'react/no-array-index-key': 'off',
+  'react/no-did-update-set-state': 'off',
+  'react/prefer-stateless-function': 'off',
+  'react/require-default-props': 'off',
+  'react/sort-comp': 'off',
+  'react/static-property-placement': 'off',
+  '@stylistic/semi-style': ['error', 'last'],
+  '@stylistic/semi': ['error', 'always']
+};
 
 export default [
   importX.flatConfigs.recommended,
@@ -50,41 +86,10 @@ export default [
       '@stylistic': stylistic
     },
     rules: {
-      'class-methods-use-this': 'off',
-      '@stylistic/comma-dangle': ['error', 'never'],
-      "import-x/no-named-as-default": "off",
-      "import-x/no-named-as-default-member": "off",
-      'import-x/prefer-default-export': 'off',
-      'jsx-a11y/media-has-caption': 'off',
-      '@stylistic/jsx-quotes': ['error', 'prefer-single'],
-      '@stylistic/lines-between-class-members': 'off',
-      '@stylistic/max-len': ['error', {
-        code: 120,
-        ignoreStrings: true
-      }],
-      'no-underscore-dangle': 'off',
-      'no-use-before-define': 'off',
-      '@stylistic/quote-props': ['error', 'as-needed', {
-        keywords: false,
-        unnecessary: true,
-        numbers: true
-      }],
-      'react/display-name': 'off',
-      'react/default-props-match-prop-types': 'off',
-      'react/destructuring-assignment': 'off',
+      ...commonRules,
       'react/jsx-filename-extension': [1, {
         extensions: ['.js', '.jsx']
-      }],
-      'react/jsx-no-bind': 'off',
-      'react/jsx-props-no-spreading': 'off',
-      'react/no-array-index-key': 'off',
-      'react/no-did-update-set-state': 'off',
-      'react/prefer-stateless-function': 'off',
-      'react/require-default-props': 'off',
-      'react/sort-comp': 'off',
-      'react/static-property-placement': 'off',
-      '@stylistic/semi-style': ['error', 'last'],
-      '@stylistic/semi': ['error', 'always']
+      }]
     },
     settings: {
       react: {
@@ -119,51 +124,23 @@ export default [
       react,
       '@typescript-eslint': typescriptEslint,
       jest,
-      'jsx-a11y': jsxA11y
+      'jsx-a11y': jsxA11y,
+      '@stylistic': stylistic
     },
     rules: {
-      'class-methods-use-this': 'off',
-      'comma-dangle': ['error', 'never'],
-      "import-x/no-named-as-default": "off",
-      "import-x/no-named-as-default-member": "off",
-      'import-x/prefer-default-export': 'off',
-      'jsx-a11y/media-has-caption': 'off',
-      'jsx-quotes': ['error', 'prefer-single'],
-      'lines-between-class-members': 'off',
-      'max-len': ['error', {
-        code: 120,
-        ignoreStrings: true
-      }],
-      'no-underscore-dangle': 'off',
-      'quote-props': ['error', 'as-needed', {
-        keywords: false,
-        unnecessary: true,
-        numbers: true
-      }],
-      'react/display-name': 'off',
-      'react/default-props-match-prop-types': 'off',
-      'react/destructuring-assignment': 'off',
-      'react/jsx-filename-extension': [1, {
-        extensions: ['.tsx']
-      }],
-      'react/jsx-no-bind': 'off',
-      'react/jsx-props-no-spreading': 'off',
-      'import-x/no-unresolved': [ 2, {ignore: '\\.tsx$'}],
-      'react/no-array-index-key': 'off',
-      'react/no-did-update-set-state': 'off',
-      'react/prefer-stateless-function': 'off',
-      'react/require-default-props': 'off',
-      'react/sort-comp': 'off',
-      'react/static-property-placement': 'off',
-      'semi-style': ['error', 'last'],
-      'no-use-before-define': 'off',
-      'no-unused-vars': 'off',
-      'no-shadow': 'off'
+      ...commonRules,
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": ["error"]
     },
     settings: {
       react: {
         version: 'detect'
-      }
+      },
+      'import-x/resolver-next': [
+        createTypeScriptImportResolver({
+          project: 'packages/*/{ts,js}config.json'
+        })
+      ]
     }
   },
   {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "eslint": "^9.31.0",
     "eslint-config-airbnb": "^19.0.4",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-jest": "^29.0.1",

--- a/packages/storybook/src/tailwind-ui/Input.stories.tsx
+++ b/packages/storybook/src/tailwind-ui/Input.stories.tsx
@@ -9,7 +9,7 @@ export default {
 };
 
 export const Default = () => {
-  const [val, setVal] = useState('')
+  const [val, setVal] = useState('');
 
   return (
     <Input
@@ -17,11 +17,11 @@ export const Default = () => {
       onChange={(str) => setVal(str)}
       value={val}
     />
-  )
-}
+  );
+};
 
 export const Placeholder = () => {
-  const [val, setVal] = useState('')
+  const [val, setVal] = useState('');
 
   return (
     <Input
@@ -30,11 +30,11 @@ export const Placeholder = () => {
       onChange={(str) => setVal(str)}
       value={val}
     />
-  )
-}
+  );
+};
 
 export const Disabled = () => {
-  const [val, setVal] = useState('')
+  const [val, setVal] = useState('');
 
   return (
     <Input
@@ -44,34 +44,34 @@ export const Disabled = () => {
       onChange={(str) => setVal(str)}
       value={val}
     />
-  )
-}
+  );
+};
 
 export const Error = () => {
-  const [val, setVal] = useState('')
+  const [val, setVal] = useState('');
 
   return (
     <Input
       label='Name'
       error
-      helperText="I have an error!"
+      helperText='I have an error!'
       onChange={(str) => setVal(str)}
       value={val}
     />
-  )
-}
+  );
+};
 
 export const Icons = () => {
-  const [val, setVal] = useState('')
+  const [val, setVal] = useState('');
 
   return (
     <Input
       label='Country'
       iconLeft={MdLocationOn}
       iconRight={FaRegQuestionCircle}
-      helperText="I have icons!"
+      helperText='I have icons!'
       onChange={(str) => setVal(str)}
       value={val}
     />
-  )
-}
+  );
+};

--- a/packages/tailwind-ui/src/components/Input.tsx
+++ b/packages/tailwind-ui/src/components/Input.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import { Description, Field, Input as HeadlessInput, Label } from '@headlessui/react'
-import clsx from 'clsx'
+import React from 'react';
+import { Description, Field, Input as HeadlessInput, Label } from '@headlessui/react';
+import clsx from 'clsx';
 
 interface Props {
   classes?: {
@@ -20,51 +20,49 @@ interface Props {
   value: string
 }
 
-const Input: React.FC<Props> = (props) => {
-  return (
-    <Field
-      className='flex flex-col gap-2 text-zinc-950 dark:text-white group font-sans'
-      data-disabled={props.disabled}
+const Input: React.FC<Props> = (props) => (
+  <Field
+    className='flex flex-col gap-2 text-zinc-950 dark:text-white group font-sans'
+    data-disabled={props.disabled}
+  >
+    {props.label && (
+      <Label className={clsx('text-sm font-semibold', props.classes?.label)}>
+        {props.label}
+      </Label>
+    )}
+    <div
+      className='rounded-lg bg-white border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 hover:dark:border-zinc-600 focus-within:border-blue-500 py-1.5 px-3 group-data-[disabled]:bg-zinc-50 group-data-[disabled]:text-zinc-400 group-data-[disabled]:dark:bg-zinc-800 data-[error]:border-red-500 data-[error]:hover:border-red-600 data-[error]:hover:dark:border-red-500 flex gap-2 items-center dark:bg-black'
+      data-error={props.error}
     >
-      {props.label && (
-        <Label className={clsx('text-sm font-semibold', props.classes?.label)}>
-          {props.label}
-        </Label>
+      {props.iconLeft && (
+        <props.iconLeft
+          className='fill-zinc-400 dark:fill-zinc-500'
+          size={16}
+        />
       )}
-      <div
-        className='rounded-lg bg-white border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 hover:dark:border-zinc-600 focus-within:border-blue-500 py-1.5 px-3 group-data-[disabled]:bg-zinc-50 group-data-[disabled]:text-zinc-400 group-data-[disabled]:dark:bg-zinc-800 data-[error]:border-red-500 data-[error]:hover:border-red-600 data-[error]:hover:dark:border-red-500 flex gap-2 items-center dark:bg-black'
+      <HeadlessInput
+        className={clsx('focus:outline-none grow bg-transparent leading-6', props.classes?.input)}
+        disabled={props.disabled}
+        placeholder={props.placeholder}
+        onChange={e => props.onChange(e.target.value)}
+        value={props.value}
+      />
+      {props.iconRight && (
+        <props.iconRight
+          className='fill-zinc-400 dark:fill-zinc-500'
+          size={16}
+        />
+      )}
+    </div>
+    {props.helperText && (
+      <Description 
+        className={clsx('text-sm font-medium data-[error]:text-red-700 data-[error]:dark:text-red-400 text-sm group-data-[disabled]:text-zinc-400', props.classes?.description)}
         data-error={props.error}
       >
-        {props.iconLeft && (
-          <props.iconLeft
-            className='fill-zinc-400 dark:fill-zinc-500'
-            size={16}
-          />
-        )}
-        <HeadlessInput
-          className={clsx('focus:outline-none grow bg-transparent leading-6', props.classes?.input)}
-          disabled={props.disabled}
-          placeholder={props.placeholder}
-          onChange={e => props.onChange(e.target.value)}
-          value={props.value}
-        />
-        {props.iconRight && (
-          <props.iconRight
-            className='fill-zinc-400 dark:fill-zinc-500'
-            size={16}
-          />
-        )}
-      </div>
-      {props.helperText && (
-        <Description 
-          className={clsx('text-sm font-medium data-[error]:text-red-700 data-[error]:dark:text-red-400 text-sm group-data-[disabled]:text-zinc-400', props.classes?.description)}
-          data-error={props.error}
-        >
-          {props.helperText}
-        </Description>
-      )}
-    </Field>
-  )
-}
+        {props.helperText}
+      </Description>
+    )}
+  </Field>
+);
 
-export default Input
+export default Input;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9101,13 +9101,26 @@ eslint-config-airbnb@^19.0.4:
     object.assign "^4.1.2"
     object.entries "^1.1.5"
 
-eslint-import-context@^0.1.9:
+eslint-import-context@^0.1.8, eslint-import-context@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/eslint-import-context/-/eslint-import-context-0.1.9.tgz#967b0b2f0a90ef4b689125e088f790f0b7756dbe"
   integrity sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==
   dependencies:
     get-tsconfig "^4.10.1"
     stable-hash-x "^0.2.0"
+
+eslint-import-resolver-typescript@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz#3e83a9c25f4a053fe20e1b07b47e04e8519a8720"
+  integrity sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==
+  dependencies:
+    debug "^4.4.1"
+    eslint-import-context "^0.1.8"
+    get-tsconfig "^4.10.1"
+    is-bun-module "^2.0.0"
+    stable-hash-x "^0.2.0"
+    tinyglobby "^0.2.14"
+    unrs-resolver "^1.7.11"
 
 eslint-plugin-flowtype@^8.0.3:
   version "8.0.3"
@@ -10577,6 +10590,13 @@ is-boolean-object@^1.2.1:
   dependencies:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
+
+is-bun-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-bun-module/-/is-bun-module-2.0.0.tgz#4d7859a87c0fcac950c95e666730e745eae8bddd"
+  integrity sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==
+  dependencies:
+    semver "^7.7.1"
 
 is-callable@^1.2.7:
   version "1.2.7"
@@ -14359,7 +14379,7 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.7.2:
+semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.7.1, semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
@@ -15436,7 +15456,7 @@ unplugin@^1.3.1:
     acorn "^8.14.0"
     webpack-virtual-modules "^0.6.2"
 
-unrs-resolver@^1.9.2:
+unrs-resolver@^1.7.11, unrs-resolver@^1.9.2:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/unrs-resolver/-/unrs-resolver-1.11.1.tgz#be9cd8686c99ef53ecb96df2a473c64d304048a9"
   integrity sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==


### PR DESCRIPTION
# Summary

This PR extends on the changes in #532 for the `tailwind-ui` branch.

* refactor the ESLint config so rules shared by both the JS and TS linters are in a `commonRules` object that both linters can extend (previously the TS linter just had most of the same rules copy/pasted)
* add `eslint-import-resolver-typescript` so the `import-x/no-unresolved` doesn't happen for TSX component imports
* lint the `Input` component and its Storybook story