### PR TITLE
Tailwind `Badge` component

### DIFF
--- a/packages/storybook/src/tailwind-ui/Badge.stories.tsx
+++ b/packages/storybook/src/tailwind-ui/Badge.stories.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Badge from '../../../tailwind-ui/src/components/Badge';
+import DarkContainer from './DarkContainer';
+
+export default {
+  title: 'Components/TailwindUI/Badge',
+  component: Badge
+};
+
+export const Default = () => {
+  return (
+    <div className='flex flex-wrap gap-8'>
+      <Badge color='faircopy'>
+        FairCopy
+      </Badge>
+      <Badge color='red'>
+        FairCopy
+      </Badge>
+      <Badge color='gray'>
+        FairCopy
+      </Badge>
+      <Badge color='green'>
+        FairCopy
+      </Badge>
+      <Badge color='blue'>
+        FairCopy
+      </Badge>
+    </div>
+  );
+};
+
+export const Dark = () => {
+  return (
+    <DarkContainer>
+      <div className='flex flex-wrap gap-8'>
+        <Badge color='faircopy'>
+          FairCopy
+        </Badge>
+        <Badge color='red'>
+          FairCopy
+        </Badge>
+        <Badge color='gray'>
+          FairCopy
+        </Badge>
+        <Badge color='green'>
+          FairCopy
+        </Badge>
+        <Badge color='blue'>
+          FairCopy
+        </Badge>
+      </div>
+    </DarkContainer>
+  );
+};

--- a/packages/tailwind-ui/src/components/Badge.tsx
+++ b/packages/tailwind-ui/src/components/Badge.tsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx';
+import React from 'react';
+
+const colors = {
+  faircopy: 'bg-[#E9ECF5] hover:bg-[#CED8E9] text-[#324872] dark:bg-[#2C3E60] dark:text-[#718FBF] hover:dark:bg-[#324872]',
+  green: 'bg-green-100 hover:bg-green-200 text-green-500 dark:bg-green-900 dark:text-green-400 hover:dark:bg-green-800',
+  gray: 'bg-gray-100 hover:bg-gray-200 text-gray-500 dark:bg-gray-900 dark:text-gray-400 hover:dark:bg-gray-800',
+  red: 'bg-red-100 hover:bg-red-200 text-red-500 dark:bg-red-900 dark:text-red-400 hover:dark:bg-red-800',
+  blue: 'bg-blue-100 hover:bg-blue-200 text-blue-500 dark:bg-blue-900 dark:text-blue-400 hover:dark:bg-blue-800'
+} as const;
+
+interface Props {
+  className?: string
+  children: React.ElementType | React.ElementType[]
+  color?: keyof typeof colors
+}
+
+const Badge: React.FC<Props> = (props) => {
+  const color = props.color || 'faircopy';
+
+  return (
+    <span className={clsx(
+      'py-1 px-1.5 rounded-md text-xs font-semibold',
+      colors[color],
+      props.className
+    )}>
+      {props.children}
+    </span>
+  );
+};
+
+export default Badge;


### PR DESCRIPTION
# Summary

This PR adds the `Badge` component to the `tailwind-ui` package.

<img width="481" height="78" alt="Screenshot 2025-07-31 at 2 56 16 PM" src="https://github.com/user-attachments/assets/cc286bf4-02e2-432d-a972-e59fa2612348" />

It accepts a `color` prop for one of a set of five colors. The design in Figma has a lot more, but I think they came from Catalyst so we can't use the same exact list. I focused on generic versions of colors that appear in the FCC 2 UI.