### PR TITLE
Tailwind `Checkbox` component

### DIFF
--- a/packages/storybook/src/tailwind-ui/Checkbox.stories.tsx
+++ b/packages/storybook/src/tailwind-ui/Checkbox.stories.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import Checkbox from '../../../tailwind-ui/src/components/Checkbox';
+
+export default {
+  title: 'Components/TailwindUI/Checkbox',
+  component: Checkbox
+};
+
+export const Default = () => {
+  const [val, setVal] = useState(true);
+
+  return (
+    <Checkbox
+      label='Lights'
+      onChange={setVal}
+      value={val}
+    />
+  );
+};
+
+export const Description = () => {
+  const [val, setVal] = useState(true);
+
+  return (
+    <Checkbox
+      description='This toggle allows you to turn the lights on or off.'
+      label='Lights'
+      onChange={setVal}
+      value={val}
+    />
+  );
+};
+
+export const Disabled = () => {
+  const [val, setVal] = useState(true);
+
+  return (
+    <Checkbox
+      disabled
+      label='Lights'
+      onChange={setVal}
+      value={val}
+    />
+  );
+};
+
+export const Indeterminate = () => {
+  const [, setVal] = useState(true);
+
+  return (
+    <Checkbox
+      indeterminate
+      label='Lights'
+      onChange={setVal}
+    />
+  );
+};

--- a/packages/tailwind-ui/package.json
+++ b/packages/tailwind-ui/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "@headlessui/react": "^2.2.6"
+    "@headlessui/react": "^2.2.6",
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@bunchtogether/vite-plugin-flow": "^1.0.2",

--- a/packages/tailwind-ui/src/components/Checkbox.tsx
+++ b/packages/tailwind-ui/src/components/Checkbox.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Description, Field, Checkbox as HeadlessCheckbox, Label } from '@headlessui/react';
+import { FaCheck } from 'react-icons/fa';
+import { MdOutlineHorizontalRule } from 'react-icons/md';
+
+interface Props {
+  description?: string;
+  disabled?: boolean;
+  label?: string;
+  indeterminate?: boolean;
+  onChange: (arg: boolean) => any;
+  value?: boolean;
+}
+
+const Checkbox: React.FC<Props> = (props) => {
+  return (
+    <Field className='flex gap-3'>
+      <HeadlessCheckbox
+        disabled={props.disabled}
+        checked={props.value}
+        indeterminate={props.indeterminate}
+        onChange={(val) => props.onChange(val)}
+        className='group rounded-sm border border-zinc-200 w-4 h-4 flex items-center justify-center data-checked:bg-primary data-checked:border-primary data-indeterminate:border-primary data-indeterminate:bg-primary my-0.5 outline-offset-2 focus:outline-2 focus:outline-primary data-disabled:opacity-50 data-disabled:grayscale hover:border-zinc-300 hover:data-checked:bg-primary-light hover:data-checked:border-primary-light'
+      >
+        <FaCheck className='hidden size-2.5 fill-black group-data-checked:not-group-data-indeterminate:block group-data-checked:not-group-data-indeterminate:fill-white' />
+        <MdOutlineHorizontalRule className='hidden size-2.5 fill-black group-data-indeterminate:block group-data-indeterminate:fill-white' />
+      </HeadlessCheckbox>
+      <div className='flex flex-col gap-1 text-sm'>
+        {props.label && <Label className='font-semibold'>{props.label}</Label>}
+        {props.description && <Description className='text-zinc-500'>{props.description}</Description>}
+      </div>
+    </Field>
+  );
+};
+
+export default Checkbox;

--- a/packages/tailwind-ui/tailwind.css
+++ b/packages/tailwind-ui/tailwind.css
@@ -1,5 +1,6 @@
 @theme {
   --color-primary: #43639D;
+  --color-primary-light: #718FBF;
 
   --color-content-primary: var(--color-zinc-950);
   --color-content-seconday: var(--color-zinc-500);


### PR DESCRIPTION
# Summary

This PR includes the `Checkbox` component for `tailwind-ui`. It's built with `@headlessui/react`'s Checkbox component.

This is the first of my component PRs to not include a dark theme. We decided today to skip it to save time.

<img width="409" height="381" alt="Screenshot 2025-07-31 at 4 09 10 PM" src="https://github.com/user-attachments/assets/868cf37f-1e18-4255-94e7-0ee0b16b1510" />
