### PR TITLE
Tailwind `Listbox` component

### DIFF
--- a/packages/storybook/src/tailwind-ui/Listbox.stories.tsx
+++ b/packages/storybook/src/tailwind-ui/Listbox.stories.tsx
@@ -53,3 +53,21 @@ export const Disabled = () => {
     />
   );
 };
+
+
+export const CustomStyles = () => {
+  const [value, setValue] = useState(options[0]);
+
+  return (
+    <Listbox
+      classes={{
+        button: 'text-red-200',
+        option: 'data-selected:bg-purple-500!',
+        options: 'bg-yellow-500'
+      }}
+      onChange={setValue}
+      options={options}
+      value={value}
+    />
+  );
+};

--- a/packages/storybook/src/tailwind-ui/Listbox.stories.tsx
+++ b/packages/storybook/src/tailwind-ui/Listbox.stories.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import Listbox from '../../../tailwind-ui/src/components/Listbox';
+
+export default {
+  title: 'Components/TailwindUI/Listbox',
+  component: Listbox
+};
+
+const options = [
+  {
+    id: 1,
+    name: 'Baltimore'
+  },
+  {
+    id: 2,
+    name: 'Cincinnati'
+  },
+  {
+    id: 3,
+    name: 'Chicago'
+  },
+  {
+    id: 4,
+    name: 'Minneapolis'
+  },
+  {
+    id: 5,
+    name: 'Montreal'
+  }
+];
+
+export const Default = () => {
+  const [value, setValue] = useState(options[0]);
+
+  return (
+    <Listbox
+      onChange={setValue}
+      options={options}
+      value={value}
+    />
+  );
+};
+
+export const Disabled = () => {
+  const [value, setValue] = useState(options[0]);
+
+  return (
+    <Listbox
+      disabled
+      onChange={setValue}
+      options={options}
+      value={value}
+    />
+  );
+};

--- a/packages/tailwind-ui/src/components/Listbox.tsx
+++ b/packages/tailwind-ui/src/components/Listbox.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Listbox as HeadlessListbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react';
 import { HiCheck } from 'react-icons/hi';
 import { HiChevronUpDown } from 'react-icons/hi2';
+import clsx from 'clsx';
 
 interface ListboxItem {
   id: number,
@@ -9,6 +10,11 @@ interface ListboxItem {
 }
 
 interface Props {
+  classes?: {
+    button?: string
+    options?: string
+    option?: string
+  }
   disabled?: boolean;
   options: ListboxItem[];
   onChange: (arg: ListboxItem) => any;
@@ -20,7 +26,7 @@ const Listbox: React.FC<Props> = (props) => (
     onChange={props.onChange}
   >
     <ListboxButton
-      className='group flex items-center justify-between gap-3 py-2 px-3 rounded-lg border border-zinc-200 bg-white shadow-sm data-disabled:opacity-50 outline-2 outline-offset-2 outline-transparent focus:outline-primary text-black text-sm font-semibold'
+      className={clsx('group flex items-center justify-between gap-3 py-2 px-3 rounded-lg border border-zinc-200 bg-white shadow-sm data-disabled:opacity-50 outline-2 outline-offset-2 outline-transparent focus:outline-primary text-black text-sm font-semibold', props.classes?.button)}
       disabled={props.disabled}
     >
       {props.value.name}
@@ -32,11 +38,11 @@ const Listbox: React.FC<Props> = (props) => (
     <ListboxOptions
       anchor='bottom start'
       transition
-      className='bg-white shadow-lg border border-zinc-200 rounded-xl outline-none'
+      className={clsx('bg-white shadow-lg border border-zinc-200 rounded-xl outline-none', props.classes?.options)}
     >
       {props.options.map((option) => (
         <ListboxOption
-          className='group hover:bg-primary hover:text-white flex items-center gap-2 py-2 pl-2.5 pr-4 hover:cursor-pointer gap-2.5 text-sm text-zinc-950'
+          className={clsx('group hover:bg-primary hover:text-white flex items-center gap-2 py-2 pl-2.5 pr-4 hover:cursor-pointer gap-2.5 text-sm text-zinc-950', props.classes?.option)}
           key={option.name}
           value={option}
         >

--- a/packages/tailwind-ui/src/components/Listbox.tsx
+++ b/packages/tailwind-ui/src/components/Listbox.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Listbox as HeadlessListbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react';
+import { HiCheck } from 'react-icons/hi';
+import { HiChevronUpDown } from 'react-icons/hi2';
+
+interface ListboxItem {
+  id: number,
+  value: string
+}
+
+interface Props {
+  disabled?: boolean;
+  options: ListboxItem[];
+  onChange: (arg: ListboxItem) => any;
+  value: ListboxItem;
+}
+
+const Listbox: React.FC<Props> = (props) => (
+  <HeadlessListbox
+    onChange={props.onChange}
+  >
+    <ListboxButton
+      className='group flex items-center justify-between gap-3 py-2 px-3 rounded-lg border border-zinc-200 bg-white shadow-sm data-disabled:opacity-50 outline-2 outline-offset-2 outline-transparent focus:outline-primary text-black text-sm font-semibold'
+      disabled={props.disabled}
+    >
+      {props.value.name}
+      <HiChevronUpDown
+        aria-hidden='true'
+        size={20}
+      />
+    </ListboxButton>
+    <ListboxOptions
+      anchor='bottom start'
+      transition
+      className='bg-white shadow-lg border border-zinc-200 rounded-xl outline-none'
+    >
+      {props.options.map((option) => (
+        <ListboxOption
+          className='group hover:bg-primary hover:text-white flex items-center gap-2 py-2 pl-2.5 pr-4 hover:cursor-pointer gap-2.5 text-sm text-zinc-950'
+          key={option.name}
+          value={option}
+        >
+          <HiCheck
+            className='invisible size-4 fill-zinc-500 group-hover:fill-white group-data-selected:visible'
+            size={20}
+          />
+          <div className='text-sm/6'>{option.name}</div>
+        </ListboxOption>
+      ))}
+    </ListboxOptions>
+  </HeadlessListbox>
+);
+
+export default Listbox;

--- a/packages/tailwind-ui/src/index.ts
+++ b/packages/tailwind-ui/src/index.ts
@@ -1,5 +1,6 @@
 export { default as Button } from './components/Button';
+export { default as Card } from './components/Card';
 export { default as Dropdown } from './components/Dropdown';
 export { default as Input } from './components/Input';
+export { default as Listbox } from './components/Listbox';
 export { default as Navbar } from './components/Navbar';
-export { default as Card } from './components/Card';


### PR DESCRIPTION
# Summary

This PR adds the Listbox component to `tailwind-ui`.

As before, I skipped the pieces from Figma that do not appear in FCC 2, which turned this into a pretty simple component.

<img width="181" height="393" alt="Screenshot 2025-08-04 at 4 49 57 PM" src="https://github.com/user-attachments/assets/8aa7e5ca-7922-4fe6-9fdf-2ebadadd0b31" />
