### PR TITLE
Performant UI `Dialog` component

### DIFF
--- a/packages/storybook/src/tailwind-ui/Dialog.stories.tsx
+++ b/packages/storybook/src/tailwind-ui/Dialog.stories.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import Dialog from '../../../tailwind-ui/src/components/Dialog';
+import { Button } from '../../../tailwind-ui/src';
+
+export default {
+  title: 'Components/TailwindUI/Dialog',
+  component: Dialog
+};
+
+export const Default = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        Add User
+      </Button>
+      <Dialog
+        className='w-[50vw] max-w-[50vw] max-h-[50vh] top-[30%]'
+        open={open}
+        onClose={() => setOpen(false)}
+      >
+        <h3 className='text-xl font-semibold'>Add user</h3>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Consectetur, perspiciatis facilis enim illum distinctio quaerat deserunt excepturi veniam accusantium dolorem, similique tempora at sed aspernatur iusto! Obcaecati consequatur enim inventore?</p>
+      </Dialog>
+    </>
+  );
+};

--- a/packages/tailwind-ui/src/components/Dialog.tsx
+++ b/packages/tailwind-ui/src/components/Dialog.tsx
@@ -9,9 +9,7 @@ const Dialog: React.FC = (props: DialogProps) => {
       className='relative z-50'
     >
       <DialogBackdrop
-        className={clsx(
-          'fixed inset-0 bg-black/10 flex justify-center text-zinc-950'
-        )}
+        className='fixed inset-0 bg-black/10 flex justify-center text-zinc-950'
       >
         <DialogPanel
           className={clsx(

--- a/packages/tailwind-ui/src/components/Dialog.tsx
+++ b/packages/tailwind-ui/src/components/Dialog.tsx
@@ -10,7 +10,7 @@ const Dialog: React.FC = (props: DialogProps) => {
     >
       <DialogBackdrop
         className={clsx(
-          'fixed inset-0 bg-black/10 flex justify-center justify-center text-zinc-950'
+          'fixed inset-0 bg-black/10 flex justify-center text-zinc-950'
         )}
       >
         <DialogPanel

--- a/packages/tailwind-ui/src/components/Dialog.tsx
+++ b/packages/tailwind-ui/src/components/Dialog.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Dialog as HeadlessDialog, DialogBackdrop, DialogPanel, DialogProps } from '@headlessui/react';
+import clsx from 'clsx';
+
+const Dialog: React.FC = (props: DialogProps) => {
+  return (
+    <HeadlessDialog
+      {...props}
+      className='relative z-50'
+    >
+      <DialogBackdrop
+        className={clsx(
+          'fixed inset-0 bg-black/10 flex justify-center justify-center text-zinc-950'
+        )}
+      >
+        <DialogPanel
+          className={clsx(
+            'bg-white rounded-xl shadow-lg p-6 fixed font-sans',
+            props.className
+          )}
+        >
+        {props.children}
+        </DialogPanel>
+      </DialogBackdrop>
+    </HeadlessDialog>
+  );
+};
+
+export default Dialog;

--- a/packages/tailwind-ui/src/index.ts
+++ b/packages/tailwind-ui/src/index.ts
@@ -4,3 +4,4 @@ export { default as Dropdown } from './components/Dropdown';
 export { default as Input } from './components/Input';
 export { default as Listbox } from './components/Listbox';
 export { default as Navbar } from './components/Navbar';
+export { default as Dialog } from './components/Dialog';


### PR DESCRIPTION
# Summary

This PR contains the `Dialog` component for Performant UI.

As with Card, I ended up paring down the API to just be a really minimal wrapper around Headless UI's `Dialog` with some basic Tailwind classes.

In the future we might want to expand it to have built-in positioning for a title or a bottom button bar, but FCC 2 has enough variations that nothing stood out to bake into the component.

<img width="678" height="218" alt="Screenshot 2025-08-05 at 3 26 45 PM" src="https://github.com/user-attachments/assets/42d2d5cf-5c48-4db4-9f0c-bf4b5540667c" />
