### PR TITLE
Performant UI `Pagination` and `PageStats` components

### DIFF
--- a/packages/performant-ui/src/components/PageStats.tsx
+++ b/packages/performant-ui/src/components/PageStats.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const PageStats: React.FC<Props> = (props) => {
   const start = (props.perPage * (props.page - 1)) + 1
-  const end = Math.min(start + props.perPage - 1, props.count)
+  const end = Math.min(start + props.perPage - 1, props.itemCount)
 
   return (
     <p className='text-sm font-sans'>

--- a/packages/performant-ui/src/components/PageStats.tsx
+++ b/packages/performant-ui/src/components/PageStats.tsx
@@ -1,0 +1,25 @@
+import React, { useMemo } from 'react'
+
+interface Props {
+  perPage: number,
+  page: number,
+  itemCount: number
+}
+
+const PageStats: React.FC<Props> = (props) => {
+  const start = (props.perPage * (props.page - 1)) + 1
+  const end = Math.min(start + props.perPage - 1, props.count)
+
+  return (
+    <p className='text-sm font-sans'>
+      Showing&nbsp;
+      <span className='font-semibold'>{start}</span>
+      &nbsp;to&nbsp;
+      <span className='font-semibold'>{end}</span>
+      &nbsp;of&nbsp;
+      <span className='font-semibold'>{props.itemCount}</span>
+    </p>
+  );
+}
+
+export default PageStats

--- a/packages/performant-ui/src/components/Pagination.tsx
+++ b/packages/performant-ui/src/components/Pagination.tsx
@@ -1,0 +1,44 @@
+import React, { useMemo } from 'react';
+import Button from './Button';
+import { HiArrowLongLeft, HiArrowLongRight } from 'react-icons/hi2';
+
+interface Props {
+  className?: string
+  count: number
+  current: number
+}
+
+const getFirstThree = (count: number, current: number) => {
+  if (count <= 3) {
+    return [1, 2, 3];
+  }
+
+  if (count >= current - 2) {
+    return [count - 2, count - 1, count];
+  }
+
+  return [];
+};
+
+const Pagination: React.FC<Props> = (props) => {
+  // const firstThree = useMemo(() => )
+
+  return (
+    <div className='flex justify-between'>
+      <Button variant='plain'>
+        <span className='flex gap-2 items-center'>
+          <HiArrowLongLeft />
+          Previous
+        </span>
+      </Button>
+      <Button variant='plain'>
+        <span className='flex gap-2 items-center'>
+          Next
+          <HiArrowLongRight />
+        </span>
+      </Button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/packages/performant-ui/src/components/Pagination.tsx
+++ b/packages/performant-ui/src/components/Pagination.tsx
@@ -47,7 +47,6 @@ const Pagination: React.FC<Props> = (props) => {
     <div className='flex justify-between font-sans'>
       <div className='flex gap-1'>
         <Button
-          className='w-10'
           disabled={props.current <= 1}
           onClick={onPrevious}
           variant='outline'
@@ -78,7 +77,6 @@ const Pagination: React.FC<Props> = (props) => {
           }
         })}
         <Button
-          className='w-10'
           disabled={props.current >= props.pageCount}
           onClick={onNext}
           variant='outline'

--- a/packages/performant-ui/src/components/Pagination.tsx
+++ b/packages/performant-ui/src/components/Pagination.tsx
@@ -1,42 +1,91 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import Button from './Button';
-import { HiArrowLongLeft, HiArrowLongRight } from 'react-icons/hi2';
+import { HiArrowLongLeft, HiArrowLongRight, HiChevronLeft, HiChevronRight } from 'react-icons/hi2';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 
 interface Props {
   className?: string
-  count: number
   current: number
+  onChange: (page: number) => void
+  pageCount: number
 }
 
-const getFirstThree = (count: number, current: number) => {
-  if (count <= 3) {
-    return [1, 2, 3];
+const getPageBatches = (count: number, current: number) => {
+  if (count <= 7) {
+    const arr = []
+    for (let i = 1; i <= count; i++) {
+      arr.push(i)
+    }
+    return arr;
   }
 
-  if (count >= current - 2) {
-    return [count - 2, count - 1, count];
+  if (current > 3 && current < count - 2) {
+    return [1, null, current - 1, current, current + 1, null, count]
+  }
+
+  if (current >= count - 2) {
+    return [1, 2, 3, null, count - 2, count - 1, count];
+  }
+
+  if (current <= 3) {
+    return [1, 2, 3, null, count - 2, count - 1, count]
   }
 
   return [];
 };
 
 const Pagination: React.FC<Props> = (props) => {
-  // const firstThree = useMemo(() => )
+  const batches = useMemo(
+    () => getPageBatches(props.pageCount, props.current),
+    [props.pageCount, props.current]
+  );
+
+  const onNext = useCallback(() => props.onChange(props.current + 1), [props.current])
+  const onPrevious = useCallback(() => props.onChange(props.current - 1), [props.current])
 
   return (
-    <div className='flex justify-between'>
-      <Button variant='plain'>
-        <span className='flex gap-2 items-center'>
-          <HiArrowLongLeft />
-          Previous
-        </span>
-      </Button>
-      <Button variant='plain'>
-        <span className='flex gap-2 items-center'>
-          Next
-          <HiArrowLongRight />
-        </span>
-      </Button>
+    <div className='flex justify-between font-sans'>
+      <div className='flex gap-1'>
+        <Button
+          className='w-10'
+          disabled={props.current <= 1}
+          onClick={onPrevious}
+          variant='outline'
+        >
+          <HiChevronLeft />
+        </Button>
+        {batches.map(pg => {
+          if (pg) {
+            return (
+              <Button
+                className='min-w-10'
+                onClick={() => props.onChange(pg)}
+                variant={pg === props.current ? 'filled' : 'outline'}
+              >
+                {pg}
+              </Button>
+            )
+          } else {
+            return (
+              <Button
+                className='min-w-10'
+                disabled
+                variant='outline'
+              >
+                ...
+              </Button>
+            )
+          }
+        })}
+        <Button
+          className='w-10'
+          disabled={props.current >= props.pageCount}
+          onClick={onNext}
+          variant='outline'
+        >
+          <HiChevronRight />
+        </Button>
+      </div>
     </div>
   );
 };

--- a/packages/storybook/src/performant-ui/PageStats.stories.tsx
+++ b/packages/storybook/src/performant-ui/PageStats.stories.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import PageStats from '../../../performant-ui/src/components/PageStats';
+
+export default {
+  title: 'Components/Performant UI/PageStats',
+  component: PageStats
+};
+
+export const Default = () => {
+  return (
+    <PageStats
+      itemCount={100}
+      page={1}
+      perPage={10}
+    />
+  );
+};
+
+export const TrickierNumbers = () => {
+  return (
+    <PageStats
+      itemCount={43279}
+      page={23}
+      perPage={77}
+    />
+  )
+}

--- a/packages/storybook/src/performant-ui/Pagination.stories.tsx
+++ b/packages/storybook/src/performant-ui/Pagination.stories.tsx
@@ -1,13 +1,31 @@
-import React from 'react';
-import Pagination from '../../../tailwind-ui/src/components/Pagination';
+import React, { useState } from 'react';
+import Pagination from '../../../performant-ui/src/components/Pagination';
 
 export default {
-  title: 'Components/TailwindUI/Pagination',
+  title: 'Components/Performant UI/Pagination',
   component: Pagination
 };
 
 export const Default = () => {
+  const [page, setPage] = useState(1);
+
   return (
-    <Pagination />
+    <Pagination
+      pageCount={50}
+      current={page}
+      onChange={setPage}
+    />
+  );
+};
+
+export const SmallPageCount = () => {
+  const [page, setPage] = useState(1);
+
+  return (
+    <Pagination
+      pageCount={5}
+      current={page}
+      onChange={setPage}
+    />
   );
 };

--- a/packages/storybook/src/performant-ui/Pagination.stories.tsx
+++ b/packages/storybook/src/performant-ui/Pagination.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Pagination from '../../../tailwind-ui/src/components/Pagination';
+
+export default {
+  title: 'Components/TailwindUI/Pagination',
+  component: Pagination
+};
+
+export const Default = () => {
+  return (
+    <Pagination />
+  );
+};


### PR DESCRIPTION
# Summary

This PR includes two components for Performant UI: Pagination and PageStats

PageStats was part of Pagination in Figma but it made sense to me to split it into its own component.

## Screenshots

### Pagination
<img width="435" height="78" alt="Screenshot 2025-08-11 at 12 07 44 PM" src="https://github.com/user-attachments/assets/1742c101-e3f2-4445-904c-733d87d37811" />

### PageStats
<img width="235" height="44" alt="Screenshot 2025-08-11 at 12 08 27 PM" src="https://github.com/user-attachments/assets/ea288424-be22-4150-b11f-e56a5a18a4eb" />
