### PR TITLE
Performant UI `MediaSelect` component

### DIFF
--- a/packages/performant-ui/src/components/MediaSelect.tsx
+++ b/packages/performant-ui/src/components/MediaSelect.tsx
@@ -9,7 +9,6 @@ interface Props {
   multiple?: boolean
   onChange: (arg: FileList) => void
   onRemoveFile?: (index: number) => void
-  value?: any
 }
 
 interface FileInfo {

--- a/packages/performant-ui/src/components/MediaSelect.tsx
+++ b/packages/performant-ui/src/components/MediaSelect.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+interface Props {
+  acceptedTypes?: string
+  description?: string
+  label?: string
+}
+
+const MediaSelect: React.FC<Props> = (props) => {
+  return (
+    <input type="file" multiple />
+  )
+}
+
+export default MediaSelect

--- a/packages/performant-ui/src/components/MediaSelect.tsx
+++ b/packages/performant-ui/src/components/MediaSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react'
-import { HiPhoto } from 'react-icons/hi2'
+import { HiOutlineTrash, HiPhoto } from 'react-icons/hi2'
 
 interface Props {
   accept?: string
@@ -7,7 +7,8 @@ interface Props {
   fileDescription?: string
   label?: string
   multiple?: boolean
-  onChange: (arg: any) => void
+  onChange: (arg: FileList) => void
+  onRemoveFile?: (index: number) => void
   value?: any
 }
 
@@ -17,11 +18,11 @@ interface FileInfo {
 }
 
 const BYTES_PER_KB = 1024
-const BYTES_PER_MB = 1024 * 1024
+const BYTES_PER_MB = Math.pow(BYTES_PER_KB, 2)
 
 const MediaSelect: React.FC<Props> = (props) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [fileInfo, setFileInfo] = useState([])
+  const [fileInfo, setFileInfo] = useState<FileInfo[]>([]);
 
   const openDialog = () => inputRef.current?.click();
 
@@ -29,20 +30,19 @@ const MediaSelect: React.FC<Props> = (props) => {
     if (bytes < BYTES_PER_MB) {
       return `${(bytes / BYTES_PER_KB).toFixed(2)} KB`
     } else {
-      console.log(bytes)
-      return `${(bytes / (BYTES_PER_MB)).toFixed(2)} MB`
+      return `${(bytes / BYTES_PER_MB).toFixed(2)} MB`
     }
-  }, [])
+  }, []);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { files } = e.target
-    props.onChange(files)
+    const { files } = e.target;
+    props.onChange(files);
 
     if (files) {
       const fileArray = Array.from(files)
       setFileInfo(fileArray.map(f => ({
-          name: f.name,
-          size: getFileSize(f.size)
+        name: f.name,
+        size: getFileSize(f.size)
       })))
     }
   }
@@ -62,13 +62,23 @@ const MediaSelect: React.FC<Props> = (props) => {
           {props.fileDescription && (<p>{props.fileDescription}</p>)}
         </div>
       </button>
-      {fileInfo.map(file => (
+      {fileInfo.map((file, index) => (
         <div
-          className='py-2.5 px-3 rounded-xl border border-zinc-200 bg-white'
+          className='py-2.5 px-3 rounded-xl border border-zinc-200 bg-white flex justify-between items-center mt-2'
           key={file.name}
         >
-          {file.name}
-          {file.size}
+          <div>
+            <p className='text-sm font-semibold'>{file.name}</p>
+            <p className='text-xs'>{file.size}</p>
+          </div>
+          {props.onRemoveFile && (
+            <button
+              onClick={() => props.onRemoveFile(index)}
+              type='button'
+            >
+              <HiOutlineTrash size={16} />
+            </button>
+          )}
         </div>
       ))}
       <input

--- a/packages/performant-ui/src/components/MediaSelect.tsx
+++ b/packages/performant-ui/src/components/MediaSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { HiOutlineTrash, HiPhoto } from 'react-icons/hi2'
 
 interface Props {
@@ -6,6 +6,7 @@ interface Props {
   description?: string
   fileDescription?: string
   label?: string
+  files?: FileInfo
   multiple?: boolean
   onChange: (arg: FileList) => void
   onRemoveFile?: (index: number) => void
@@ -21,7 +22,6 @@ const BYTES_PER_MB = Math.pow(BYTES_PER_KB, 2)
 
 const MediaSelect: React.FC<Props> = (props) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [fileInfo, setFileInfo] = useState<FileInfo[]>([]);
 
   const openDialog = () => inputRef.current?.click();
 
@@ -33,18 +33,17 @@ const MediaSelect: React.FC<Props> = (props) => {
     }
   }, []);
 
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { files } = e.target;
-    props.onChange(files);
-
-    if (files) {
-      const fileArray = Array.from(files)
-      setFileInfo(fileArray.map(f => ({
+  const fileInfo = useMemo(() => {
+    if (props.files) {
+      const fileArray = Array.from(props.files)
+      return fileArray.map(f => ({
         name: f.name,
         size: getFileSize(f.size)
-      })))
+      }))
     }
-  }
+  }, [props.files])
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => props.onChange(e.target.files)
 
   return (
     <>

--- a/packages/performant-ui/src/components/MediaSelect.tsx
+++ b/packages/performant-ui/src/components/MediaSelect.tsx
@@ -1,14 +1,85 @@
-import React from 'react'
+import React, { useCallback, useRef, useState } from 'react'
+import { HiPhoto } from 'react-icons/hi2'
 
 interface Props {
-  acceptedTypes?: string
+  accept?: string
   description?: string
+  fileDescription?: string
   label?: string
+  multiple?: boolean
+  onChange: (arg: any) => void
+  value?: any
 }
 
+interface FileInfo {
+  name: string
+  size: string
+}
+
+const BYTES_PER_KB = 1024
+const BYTES_PER_MB = 1024 * 1024
+
 const MediaSelect: React.FC<Props> = (props) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [fileInfo, setFileInfo] = useState([])
+
+  const openDialog = () => inputRef.current?.click();
+
+  const getFileSize = useCallback((bytes: number) => {
+    if (bytes < BYTES_PER_MB) {
+      return `${(bytes / BYTES_PER_KB).toFixed(2)} KB`
+    } else {
+      console.log(bytes)
+      return `${(bytes / (BYTES_PER_MB)).toFixed(2)} MB`
+    }
+  }, [])
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.target
+    props.onChange(files)
+
+    if (files) {
+      const fileArray = Array.from(files)
+      setFileInfo(fileArray.map(f => ({
+          name: f.name,
+          size: getFileSize(f.size)
+      })))
+    }
+  }
+
   return (
-    <input type="file" multiple />
+    <>
+      <button
+        className='w-full flex items-center justify-center py-8 text-zinc-500 flex-col gap-4 rounded-lg border border-dashed shadow-sm border-zinc-200'
+        onClick={openDialog}
+        type='button'
+      >
+        <HiPhoto
+          size={48}
+        />
+        <div>
+          <p><span className='text-black font-semibold'>Upload a file</span> or drag and drop</p>
+          {props.fileDescription && (<p>{props.fileDescription}</p>)}
+        </div>
+      </button>
+      {fileInfo.map(file => (
+        <div
+          className='py-2.5 px-3 rounded-xl border border-zinc-200 bg-white'
+          key={file.name}
+        >
+          {file.name}
+          {file.size}
+        </div>
+      ))}
+      <input
+        accept={props.accept}
+        className='hidden'
+        multiple={props.multiple}
+        onChange={onChange}
+        ref={inputRef}
+        type="file"
+      />
+    </>
   )
 }
 

--- a/packages/performant-ui/src/index.ts
+++ b/packages/performant-ui/src/index.ts
@@ -6,6 +6,7 @@ export { default as Dialog } from './components/Dialog';
 export { default as Dropdown } from './components/Dropdown';
 export { default as Input } from './components/Input';
 export { default as Listbox } from './components/Listbox';
+export { default as MediaSelect } from './components/MediaSelect';
 export { default as Navbar } from './components/Navbar';
 export { default as PageStats } from './components/PageStats';
 export { default as Pagination } from './components/Pagination';

--- a/packages/storybook/src/performant-ui/MediaSelect.stories.tsx
+++ b/packages/storybook/src/performant-ui/MediaSelect.stories.tsx
@@ -15,9 +15,9 @@ export const Default = () => {
     <MediaSelect
       description='This will be visible to clients on the project.'
       fileDescription='PNG, JPG, GIF up to 2MB'
+      files={files}
       label='Label'
       onChange={setFiles}
-      value={files}
     />
   );
 };
@@ -29,10 +29,10 @@ export const Multiple = () => {
     <MediaSelect
       description='This will be visible to clients on the project.'
       fileDescription='PNG, JPG, GIF up to 2MB'
+      files={files}
       label='Label'
       multiple
       onChange={setFiles}
-      value={files}
     />
   );
 };
@@ -42,9 +42,9 @@ export const NoHelperText = () => {
 
   return (
     <MediaSelect
+      files={files}
       multiple
       onChange={setFiles}
-      value={files}
     />
   );
 };
@@ -56,11 +56,11 @@ export const WithRemove = () => {
     <MediaSelect
       description='This will be visible to clients on the project.'
       fileDescription='PNG, JPG, GIF up to 2MB'
+      files={files}
       label='Label'
       multiple
       onChange={setFiles}
       onRemoveFile={action('click')}
-      value={files}
     />
   );
 };

--- a/packages/storybook/src/performant-ui/MediaSelect.stories.tsx
+++ b/packages/storybook/src/performant-ui/MediaSelect.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import MediaSelect from '../../../performant-ui/src/components/MediaSelect';
 import { FaPlus } from "react-icons/fa";
 
@@ -8,7 +8,15 @@ export default {
 };
 
 export const Default = () => {
+  const [files, setFiles] = useState([])
+
   return (
-    <MediaSelect />
+    <MediaSelect
+      description='This will be visible to clients on the project.'
+      fileDescription='PNG, JPG, GIF up to 2MB'
+      label='Label'
+      onChange={setFiles}
+      value={files}
+    />
   );
 };

--- a/packages/storybook/src/performant-ui/MediaSelect.stories.tsx
+++ b/packages/storybook/src/performant-ui/MediaSelect.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import MediaSelect from '../../../performant-ui/src/components/MediaSelect';
 import { FaPlus } from "react-icons/fa";
+import { action } from 'storybook/actions';
 
 export default {
   title: 'Components/Performant UI/MediaSelect',
@@ -16,6 +17,49 @@ export const Default = () => {
       fileDescription='PNG, JPG, GIF up to 2MB'
       label='Label'
       onChange={setFiles}
+      value={files}
+    />
+  );
+};
+
+export const Multiple = () => {
+  const [files, setFiles] = useState([])
+
+  return (
+    <MediaSelect
+      description='This will be visible to clients on the project.'
+      fileDescription='PNG, JPG, GIF up to 2MB'
+      label='Label'
+      multiple
+      onChange={setFiles}
+      value={files}
+    />
+  );
+};
+
+export const NoHelperText = () => {
+  const [files, setFiles] = useState([])
+
+  return (
+    <MediaSelect
+      multiple
+      onChange={setFiles}
+      value={files}
+    />
+  );
+};
+
+export const WithRemove = () => {
+  const [files, setFiles] = useState([])
+
+  return (
+    <MediaSelect
+      description='This will be visible to clients on the project.'
+      fileDescription='PNG, JPG, GIF up to 2MB'
+      label='Label'
+      multiple
+      onChange={setFiles}
+      onRemoveFile={action('click')}
       value={files}
     />
   );

--- a/packages/storybook/src/performant-ui/MediaSelect.stories.tsx
+++ b/packages/storybook/src/performant-ui/MediaSelect.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import MediaSelect from '../../../performant-ui/src/components/MediaSelect';
+import { FaPlus } from "react-icons/fa";
+
+export default {
+  title: 'Components/Performant UI/MediaSelect',
+  component: MediaSelect
+};
+
+export const Default = () => {
+  return (
+    <MediaSelect />
+  );
+};


### PR DESCRIPTION
# Summary

This PR adds the MediaSelect component to Performant UI.

Some caveats:

* The components expects the consuming application to handle state - this component passes up the native `FileList` value from the `<input>`.
* The trash can button to remove a file is only rendered only if the parent component passes an `onRemoveFile` prop, because working with the native `FileList` interface is tricky (it's read-only, so you have to come up with some sort of indirect technique) and because FCC 2 will only need the single-file version of this component.
* I did not include the thumbnails that are present in the Figma design. This, again, is kind of tricky (probably some sort of `createObjectURL` thing with some cleanup for when files are removed) and we need to save time.
* There's a high chance that we'll need to return to this component and adjust how it manages state once we've got it running in a real application. It's hard to guess what the most ergonomic API would be for uploading a form to a server when developing in Storybook.

<img width="966" height="539" alt="Screenshot 2025-08-12 at 3 34 50 PM" src="https://github.com/user-attachments/assets/2e6b05a2-f737-45a9-9bb9-1ea0609a93ba" />
