### PR TITLE
Performant UI `Table` component

### DIFF
--- a/packages/performant-ui/src/components/Table.tsx
+++ b/packages/performant-ui/src/components/Table.tsx
@@ -39,7 +39,11 @@ const Table: React.FC<Props> = (props) => {
         )}
       >
         {head}
-        {rows}
+        {rows.length > 0 && (
+          <tbody>
+            {rows}
+          </tbody>
+        )}
       </table>
     </div>
   )

--- a/packages/performant-ui/src/components/Table.tsx
+++ b/packages/performant-ui/src/components/Table.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Element } from '@performant-software/shared-components';
+
+interface Props {
+  label?: string
+}
+
+const Table: React.FC<Props> = (props) => {
+  const head = Element.findByType(props.children, Table.Head);
+
+  return (
+    <div
+      className='rounded-xl border border-zinc-200 bg-white px-8 pt-8 pb-12'
+    >
+      <table
+        className=''
+      >
+        {head}
+      </table>
+    </div>
+  )
+}
+
+interface TableHeadProps {
+  children: React.ElementType | React.ElementType[]
+}
+
+Table.Head = (props: TableHeadProps) => (
+  <thead>
+    {props.children}
+  </thead>
+)
+
+export default Table

--- a/packages/performant-ui/src/components/Table.tsx
+++ b/packages/performant-ui/src/components/Table.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Element } from '@performant-software/shared-components';
+import clsx from 'clsx';
 
 interface Props {
   label?: string
@@ -7,6 +8,7 @@ interface Props {
 
 const Table: React.FC<Props> = (props) => {
   const head = Element.findByType(props.children, Table.Head);
+  const rows = Element.findByType(props.children, Table.Row);
 
   return (
     <div
@@ -16,19 +18,57 @@ const Table: React.FC<Props> = (props) => {
         className=''
       >
         {head}
+        {rows}
       </table>
     </div>
   )
 }
 
-interface TableHeadProps {
+interface ChildElementProps {
   children: React.ElementType | React.ElementType[]
+  className?: string
 }
 
-Table.Head = (props: TableHeadProps) => (
-  <thead>
+Table.Head = (props: ChildElementProps) => (
+  <thead
+    className={clsx(
+      props.className
+    )}
+  >
     {props.children}
   </thead>
+)
+
+Table.HeadCell = (props: ChildElementProps) => (
+  <th
+    className={clsx(
+      'py-4 px-6',
+      props.className
+    )}
+  >
+    {props.children}
+  </th>
+)
+
+Table.Cell = (props: ChildElementProps) => (
+  <td
+    className={clsx(
+      'py-4 px-6',
+      props.className
+    )}
+  >
+    {props.children}
+  </td>
+)
+
+Table.Row = (props: ChildElementProps) => (
+  <tr
+    className={clsx(
+      props.className
+    )}
+  >
+    {props.children}
+  </tr>
 )
 
 export default Table

--- a/packages/performant-ui/src/components/Table.tsx
+++ b/packages/performant-ui/src/components/Table.tsx
@@ -3,6 +3,11 @@ import { Element } from '@performant-software/shared-components';
 import clsx from 'clsx';
 
 interface Props {
+  classes?: {
+    container?: string,
+    header?: string,
+    table?: string
+  }
   label?: string
 }
 
@@ -12,10 +17,26 @@ const Table: React.FC<Props> = (props) => {
 
   return (
     <div
-      className='rounded-xl border border-zinc-200 bg-white px-8 pt-8 pb-12'
+      className={clsx(
+        'rounded-xl border border-zinc-200 bg-white px-8 pt-8 pb-12 font-sans w-full',
+        props.classes?.container
+      )}
     >
+      {props.label && (
+        <h3
+          className={clsx(
+            'text-gray-900 font-semibold mb-4',
+            props.classes?.header
+          )}
+        >
+          {props.label}
+        </h3>
+      )}
       <table
-        className=''
+        className={clsx(
+          'w-full text-sm',
+          props.classes?.table
+        )}
       >
         {head}
         {rows}
@@ -32,6 +53,7 @@ interface ChildElementProps {
 Table.Head = (props: ChildElementProps) => (
   <thead
     className={clsx(
+      'border-b border-zinc-200 text-zinc-500',
       props.className
     )}
   >
@@ -42,12 +64,23 @@ Table.Head = (props: ChildElementProps) => (
 Table.HeadCell = (props: ChildElementProps) => (
   <th
     className={clsx(
-      'py-4 px-6',
+      'py-2.5 px-6 text-left',
       props.className
     )}
   >
     {props.children}
   </th>
+)
+
+Table.Row = (props: ChildElementProps) => (
+  <tr
+    className={clsx(
+      'font-zinc-950 border-b border-zinc-100',
+      props.className
+    )}
+  >
+    {props.children}
+  </tr>
 )
 
 Table.Cell = (props: ChildElementProps) => (
@@ -59,16 +92,6 @@ Table.Cell = (props: ChildElementProps) => (
   >
     {props.children}
   </td>
-)
-
-Table.Row = (props: ChildElementProps) => (
-  <tr
-    className={clsx(
-      props.className
-    )}
-  >
-    {props.children}
-  </tr>
 )
 
 export default Table

--- a/packages/performant-ui/src/index.ts
+++ b/packages/performant-ui/src/index.ts
@@ -11,4 +11,5 @@ export { default as PageStats } from './components/PageStats';
 export { default as Pagination } from './components/Pagination';
 export { default as RadioGroup } from './components/RadioGroup';
 export { default as Switch } from './components/Switch';
+export { default as Table } from './components/Table';
 export { default as TextArea } from './components/TextArea';

--- a/packages/storybook/src/performant-ui/Table.stories.tsx
+++ b/packages/storybook/src/performant-ui/Table.stories.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import Table from '../../../performant-ui/src/components/Table';
+
+export default {
+  title: 'Components/Performant UI/Table',
+  component: Table
+};
+
+export const Default = () => {
+  return (
+    <Table>
+      <Table.Head>
+        Hello
+      </Table.Head>
+    </Table>
+  );
+};

--- a/packages/storybook/src/performant-ui/Table.stories.tsx
+++ b/packages/storybook/src/performant-ui/Table.stories.tsx
@@ -6,12 +6,48 @@ export default {
   component: Table
 };
 
+const data = [
+  { name: "Virgil", title: "The Aeneid", genre: "Epic Poetry" },
+  { name: "Ovid", title: "Metamorphoses", genre: "Narrative Poetry" },
+  { name: "Cicero", title: "De Oratore", genre: "Rhetoric" },
+  { name: "Julius Caesar", title: "Commentarii de Bello Gallico", genre: "Military History" },
+  { name: "Tacitus", title: "Annals", genre: "History" },
+  { name: "Seneca", title: "Letters from a Stoic", genre: "Philosophy" },
+  { name: "Livy", title: "Ab Urbe Condita", genre: "History" },
+  { name: "Horace", title: "Odes", genre: "Lyric Poetry" },
+  { name: "Pliny the Elder", title: "Natural History", genre: "Natural Philosophy" },
+  { name: "Martial", title: "Epigrams", genre: "Satirical Poetry" }
+]
+
 export const Default = () => {
   return (
     <Table>
       <Table.Head>
-        Hello
+        <Table.HeadCell>
+          Title
+        </Table.HeadCell>
+        <Table.HeadCell>
+          Author
+        </Table.HeadCell>
+        <Table.HeadCell>
+          Genre
+        </Table.HeadCell>
       </Table.Head>
+      {data.map(d => (
+        <Table.Row
+          key={d.name}
+        >
+          <Table.Cell>
+            {d.title}
+          </Table.Cell>
+          <Table.Cell>
+            {d.name}
+          </Table.Cell>
+          <Table.Cell>
+            {d.genre}
+          </Table.Cell>
+        </Table.Row>
+      ))}
     </Table>
   );
 };

--- a/packages/storybook/src/performant-ui/Table.stories.tsx
+++ b/packages/storybook/src/performant-ui/Table.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import Table from '../../../performant-ui/src/components/Table';
+import { Button } from '../../../performant-ui/src';
+import { FaUser } from 'react-icons/fa';
 
 export default {
   title: 'Components/Performant UI/Table',
@@ -20,6 +22,39 @@ const data = [
 ]
 
 export const Default = () => {
+  return (
+    <Table label='Ancient Roman Books'>
+      <Table.Head>
+        <Table.HeadCell>
+          Title
+        </Table.HeadCell>
+        <Table.HeadCell>
+          Author
+        </Table.HeadCell>
+        <Table.HeadCell>
+          Genre
+        </Table.HeadCell>
+      </Table.Head>
+      {data.map(d => (
+        <Table.Row
+          key={d.name}
+        >
+          <Table.Cell>
+            {d.title}
+          </Table.Cell>
+          <Table.Cell>
+            {d.name}
+          </Table.Cell>
+          <Table.Cell>
+            {d.genre}
+          </Table.Cell>
+        </Table.Row>
+      ))}
+    </Table>
+  );
+};
+
+export const NoLabel = () => {
   return (
     <Table>
       <Table.Head>
@@ -45,6 +80,42 @@ export const Default = () => {
           </Table.Cell>
           <Table.Cell>
             {d.genre}
+          </Table.Cell>
+        </Table.Row>
+      ))}
+    </Table>
+  );
+};
+
+export const Customized = () => {
+  return (
+    <Table
+      classes={{ table: 'bg-red-100'}}
+      label='Ancient Roman Books'
+    >
+      <Table.Head>
+        <Table.HeadCell>
+          Title
+        </Table.HeadCell>
+        <Table.HeadCell>
+          Author
+        </Table.HeadCell>
+        <Table.HeadCell>
+          Genre
+        </Table.HeadCell>
+      </Table.Head>
+      {data.map(d => (
+        <Table.Row
+          key={d.name}
+        >
+          <Table.Cell className='italic'>
+            {d.title}
+          </Table.Cell>
+          <Table.Cell className='flex items-center justify-center'>
+            <FaUser />
+          </Table.Cell>
+          <Table.Cell>
+            <Button>Download</Button>
           </Table.Cell>
         </Table.Row>
       ))}

--- a/packages/storybook/src/performant-ui/Table.stories.tsx
+++ b/packages/storybook/src/performant-ui/Table.stories.tsx
@@ -25,15 +25,17 @@ export const Default = () => {
   return (
     <Table label='Ancient Roman Books'>
       <Table.Head>
-        <Table.HeadCell>
-          Title
-        </Table.HeadCell>
-        <Table.HeadCell>
-          Author
-        </Table.HeadCell>
-        <Table.HeadCell>
-          Genre
-        </Table.HeadCell>
+        <Table.Row>
+          <Table.HeadCell>
+            Title
+          </Table.HeadCell>
+          <Table.HeadCell>
+            Author
+          </Table.HeadCell>
+          <Table.HeadCell>
+            Genre
+          </Table.HeadCell>
+        </Table.Row>
       </Table.Head>
       {data.map(d => (
         <Table.Row
@@ -58,15 +60,17 @@ export const NoLabel = () => {
   return (
     <Table>
       <Table.Head>
-        <Table.HeadCell>
-          Title
-        </Table.HeadCell>
-        <Table.HeadCell>
-          Author
-        </Table.HeadCell>
-        <Table.HeadCell>
-          Genre
-        </Table.HeadCell>
+        <Table.Row>
+          <Table.HeadCell>
+            Title
+          </Table.HeadCell>
+          <Table.HeadCell>
+            Author
+          </Table.HeadCell>
+          <Table.HeadCell>
+            Genre
+          </Table.HeadCell>
+        </Table.Row>
       </Table.Head>
       {data.map(d => (
         <Table.Row
@@ -94,15 +98,17 @@ export const Customized = () => {
       label='Ancient Roman Books'
     >
       <Table.Head>
-        <Table.HeadCell>
-          Title
-        </Table.HeadCell>
-        <Table.HeadCell>
-          Author
-        </Table.HeadCell>
-        <Table.HeadCell>
-          Genre
-        </Table.HeadCell>
+        <Table.Row>
+          <Table.HeadCell>
+            Title
+          </Table.HeadCell>
+          <Table.HeadCell>
+            Author
+          </Table.HeadCell>
+          <Table.HeadCell>
+            Genre
+          </Table.HeadCell>
+        </Table.Row>
       </Table.Head>
       {data.map(d => (
         <Table.Row


### PR DESCRIPTION
# Summary

This PR adds the Table component to Performant UI. It uses the subcomponent model similar to #525, with e.g. `Table.Head`, `Table.Row`, etc.

As with #549, some caveats vs. the Figma designs:

* The component in Figma has a couple visual modes (striped and grid) that are not used in FCC 2. To save time, I only built the default mode that appears in the FCC 2 designs.
* The Figma designs have a lot of variations with dropdowns, avatars, etc. that do not need to be handled by the component, as the `Table.Cell` subcomponent just renders whatever is passed as `props.children` inside a styled `td` element.
* This component does not contain the Pagination component inside it the way it's shown in the designs. It seems more ergonomic to have the consuming application add the Pagination component below the table if they want to.

<img width="963" height="715" alt="Screenshot 2025-08-13 at 2 46 08 PM" src="https://github.com/user-attachments/assets/5d0e0e97-af3b-4b44-a27d-7927f5787a1f" />
