### PR TITLE
CDC #484 - User defined fields

### DIFF
--- a/packages/user-defined-fields/src/components/UserDefinedFieldsForm.js
+++ b/packages/user-defined-fields/src/components/UserDefinedFieldsForm.js
@@ -196,7 +196,7 @@ const UserDefinedFieldsForm: ComponentType<any> = (props: Props) => {
    */
   useEffect(() => {
     // If the fields have been provided as a prop, there is no need to query them here.
-    if (!_.isEmpty(fields)) {
+    if (props.fields) {
       return;
     }
 


### PR DESCRIPTION
This pull request fixes a bug in the `UserDefinedFields` form where provided preloaded fields via the `fields` prop was not working as expected. If the prop was provided (meaning the fields were preloaded), but empty, the component was will making an additional request for the fields. The solution was to check for the presence of the `fields` prop, rather than the `fields` state not being empty.