### PR TITLE
Add `tags` prop to `SearchListItem`

### DIFF
--- a/packages/core-data/src/components/SearchList.js
+++ b/packages/core-data/src/components/SearchList.js
@@ -51,7 +51,12 @@ type Props = {
   /**
    * Callback that fires when the pointer stops hovering over an item
    */
-  onItemPointerLeave?: (item: any) => void
+  onItemPointerLeave?: (item: any) => void,
+
+  /**
+   * List of attributes that appear as pills on the top of the item
+   */
+  tags?: { attribute: string, className?: string }[]
 };
 
 const LIMIT_STEP = 50;
@@ -119,6 +124,7 @@ const SearchList = (props: Props) => {
               onClick={props.onItemClick}
               onPointerEnter={props.onItemPointerEnter}
               onPointerLeave={props.onItemPointerLeave}
+              tags={props.tags}
             />
           ))}
         </InfiniteScroll>

--- a/packages/core-data/src/components/SearchListItem.js
+++ b/packages/core-data/src/components/SearchListItem.js
@@ -4,6 +4,7 @@ import React, { type Element, useMemo } from 'react';
 import clsx from 'clsx';
 import Icon from './Icon';
 import { type Attribute } from '../types/SearchList';
+import Pill from "./Pill.js";
 
 type SearchListItemProps = {
   /**
@@ -39,7 +40,12 @@ type SearchListItemProps = {
   /**
    * Title of the record
    */
-  title: string
+  title: string,
+
+  /**
+   * List of attributes that appear as pills on the top of the item
+   */
+  tags?: { attribute: string, className?: string }[]
 };
 
 type ItemWrapperProps = {
@@ -93,6 +99,17 @@ const SearchListItem = (props: SearchListItemProps) => {
             ? () => props.onPointerLeave(props.item)
             : undefined}
         >
+          {props.tags && props.tags.length > 0 && (
+            <div className='flex flex-wrap gap-2'>
+              {props.tags.map((tag) => (
+                <Pill
+                  className={tag.className}
+                  label={props.item[tag.attribute]}
+                  key={tag.attribute}
+                />
+              ))}
+            </div>
+          )}
           <p className='font-bold text-neutral-800'>{props.title}</p>
           {props.attributes && attributeValues.some(Boolean) && (
             <ul className='list-none'>

--- a/packages/storybook/src/core-data/SearchList.stories.js
+++ b/packages/storybook/src/core-data/SearchList.stories.js
@@ -45,6 +45,39 @@ export const Default = () => (
   </div>
 );
 
+export const WithTags = () => (
+  <div className='h-[600px] w-[360px]'>
+    <SearchList
+      attributes={[
+        {
+          label: 'UUID',
+          name: 'uuid'
+        },
+        {
+          label: 'Record ID',
+          name: 'record_id',
+          icon: 'person'
+        },
+        {
+          label: 'Location',
+          name: 'geometry',
+          icon: 'location',
+          render: (item) => (item.coordinates
+            ? `${item.coordinates[0]}, ${item.coordinates[1]}`
+            : '')
+        }
+      ]}
+      tags={[
+        {
+          attribute: 'type'
+        }
+      ]}
+      items={LOTS_OF_DATA}
+      itemTitle='name'
+    />
+  </div>
+);
+
 export const TitleCallback = () => (
   <div className='h-[600px] w-[360px]'>
     <SearchList


### PR DESCRIPTION
# Summary

(This PR will remain a draft until I get feedback from Jamie about what exactly this should look like.)

This PR adds a new `tags` prop to `SearchListItem`. When an array of tags in the structure of `{ attribute: string, className?: string }` is included, each tag is rendered in a list of pills in the top of the component:

<img width="363" height="600" alt="Screenshot 2025-09-09 at 11 44 08 AM" src="https://github.com/user-attachments/assets/286c887c-29e8-4257-bb05-6fd2eea250a4" />
