### PR TITLE
Change wrong "detail" event attribute from Geocoder to "feature" (CDC #515)

### DIFF
--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -156,19 +156,19 @@ const MapDraw = (props: Props) => {
   /**
    * Adds the selected geometry to the map.
    *
-   * @type {(function({detail: *}): void)|*}
+   * @type {(function({feature: *}): void)|*}
    */
-  const onSelection = useCallback(({ detail }) => {
-    if (isValid(detail)) {
+  const onSelection = useCallback(({ feature }) => {
+    if (isValid(feature)) {
       // Add the geometry to the map
-      drawRef.current.add(detail.geometry);
+      drawRef.current.add(feature.geometry);
 
       // Trigger the onChange prop
       onChange();
 
       // Call the onGeocoding selection callback
       if (props.onGeocodingSelection) {
-        props.onGeocodingSelection(detail);
+        props.onGeocodingSelection(feature);
       }
     }
   }, [isValid, onChange, props.onGeocodingSelection]);


### PR DESCRIPTION
### In this PR

Per performant-software/core-data-cloud#515:
- Fix the MapTiler Geocoder Control `pick` event callback to use the correct attribute
   - The function was expecting a `detail` attribute as per [API docs](https://docs.maptiler.com/sdk-js/modules/geocoding/api/api-reference/#event:pick), but in fact the event includes a `feature` attribute with the intended data instead