### PR TITLE
Prevent timeline timezone conversion issues (#564)

### DIFF
--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -133,7 +133,13 @@ const getDate = (event: EventType) => {
 
   if (_.isNumber(date)) {
     // Typesense date is a Unix timestamp, which is in seconds, so convert to ms
-    return new Date(date * ONE_SECOND);
+    const jsDate = new Date(date * ONE_SECOND);
+    // prevent timezone errors by just using year, month, date
+    return new Date(
+      jsDate.getUTCFullYear(),
+      jsDate.getUTCMonth(),
+      jsDate.getUTCDate()
+    );
   }
 
   return date;

--- a/packages/storybook/src/core-data/FacetTimeline.stories.js
+++ b/packages/storybook/src/core-data/FacetTimeline.stories.js
@@ -199,3 +199,23 @@ export const ListView = () => {
     </>
   );
 };
+
+// example of a single date at the exact beginning of the range, which
+// was causing errors due to timezone conversion
+const singleDate = {
+  end_date: [-662688000, -631152000],
+  end_year: [1949, 1950],
+  name: 'African Progressive Association Founded',
+  start_date: [-946771200, -915148800],
+  start_year: [1940, 1941],
+  uuid: '52f568cb-3036-478f-8a0c-62e93c1f0f20'
+};
+
+export const SingleItem = () => (
+  <FacetTimeline
+    data={[singleDate]}
+    range={{min: 1940, max: 1954}}
+    refine={action('refine')}
+    start={[1940, 1954]}
+  />
+);


### PR DESCRIPTION
### In this PR

Prevent timezone errors with the `FacetTimeline` component by converting Typesense dates to midnight on the same date in the user's local timezone.