### PR TITLE
Archnet #985 - Saved sets

### DIFF
--- a/packages/semantic-ui/src/components/DataList.js
+++ b/packages/semantic-ui/src/components/DataList.js
@@ -553,6 +553,9 @@ const useDataList = (WrappedComponent: ComponentType<any>) => (
       this.setState({ sortColumn, sortDirection, page }, this.fetchData.bind(this));
     }
 
+    /**
+     * Replaces the item in the list with the updateItem.
+     */
     onUpdateItem() {
       this.setState((state) => ({
         items: _.map(state.items, (item) => item.id !== this.props.updateItem.id ? item : this.props.updateItem)


### PR DESCRIPTION
This pull request adds the following props to the `DataList` component:

- `onReload` - Callback fired when the `reload` prop is "true"
- `reload` - If true, the `onReload` callback will be fired and the resulting object set on the internal state
- `updateItem` - If provided, the `updateItem` value will replace the record with the same ID in internal state

These props should probably be used infrequently, but are useful for making updates to the component when the state is modified outside of the component. 