### PR TITLE
Fuzzy place adustments

### DIFF
--- a/packages/core-data/src/utils/CoreData.js
+++ b/packages/core-data/src/utils/CoreData.js
@@ -35,5 +35,5 @@ const toFeatureCollection = (places) => featureCollection(_.map(places, toFeatur
 
 export default {
   toFeature,
-  toFeatureCollection,
+  toFeatureCollection
 };

--- a/packages/core-data/src/utils/CoreData.js
+++ b/packages/core-data/src/utils/CoreData.js
@@ -12,8 +12,14 @@ import _ from 'underscore';
  */
 const toFeature = (place, index) => {
   const geometry = place?.place_geometry?.geometry_json;
-  const properties = _.omit(place, 'place_geometry');
+  const placeData = _.omit(place, 'place_geometry');
+  const originalProperties = place?.place_geometry?.properties;
   const options = { id: place.id || index };
+
+  const properties = {
+    ...placeData,
+    originalProperties
+  };
 
   return feature(geometry, properties, options);
 };
@@ -29,5 +35,5 @@ const toFeatureCollection = (places) => featureCollection(_.map(places, toFeatur
 
 export default {
   toFeature,
-  toFeatureCollection
+  toFeatureCollection,
 };

--- a/packages/core-data/src/utils/Typesense.js
+++ b/packages/core-data/src/utils/Typesense.js
@@ -374,11 +374,19 @@ const getFeatures = (
             record.properties?.items.push(trimmedResult);
           }
         } else {
-          newFeatures.push(MapUtils.toFeature({
+          const feature = MapUtils.toFeature({
             ...place,
             layerId,
             url: geometryUrl
-          }, trimmedResult, geometry, properties));
+          }, trimmedResult, geometry, properties);
+
+          const certaintyRadius = feature.properties?.originalProperties?.certainty_radius;
+
+          if (certaintyRadius) {
+            newFeatures.push(MapUtils.toCertaintyCircle(feature, certaintyRadius));
+          } else {
+            newFeatures.push(feature);
+          }
         }
       }
     });

--- a/packages/geospatial/src/components/CertaintyLayer.js
+++ b/packages/geospatial/src/components/CertaintyLayer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Layer, Source } from 'react-map-gl/maplibre';
 import MapStyles from '../utils/MapStyles';
 import MapUtils from '../utils/Map';
@@ -14,11 +14,17 @@ type Props = {
  * Renders circles with the given certainty_radius circumference around all points in a new layer.
  */
 const CertaintyLayer = (props: Props) => {
-  const circles = MapUtils.getCertaintyCircles([props.geometry], () => props.certaintyRadius);
+  const data = useMemo(() => {
+    if (props.geometry) {
+      return MapUtils.toCertaintyCircle(props.geometry, props.certaintyRadius);
+    } else {
+      return {};
+    }
+  }, [props.geometry, props.certaintyRadius]);
 
   return (
     <Source
-      data={circles}
+      data={data}
       type='geojson'
     >
       <Layer

--- a/packages/geospatial/src/components/CertaintyLayer.js
+++ b/packages/geospatial/src/components/CertaintyLayer.js
@@ -31,7 +31,7 @@ const CertaintyLayer = (props: Props) => {
         {...MapStyles.fill}
         id='certainty-layer'
         paint={{
-          ...MapStyles.fill.paint,
+          ...MapStyles.fill.paint
         }}
       />
     </Source>

--- a/packages/geospatial/src/utils/Map.js
+++ b/packages/geospatial/src/utils/Map.js
@@ -26,36 +26,54 @@ const buildCircle = (point, radius) => (
   circle(point.coordinates, radius, { units: 'kilometers', steps: 32 })
 );
 
-/**
- * Returns a GeoJSON feature collection containing circles for each item in the given array.
- */
-const getCertaintyCircles = (
-  items,
-  getCertaintyRadius: (item: any) => number | undefined
-) => {
-  const features = [];
+const toCertaintyCircle = (item, radius: number) => {
+  if (item.geometry?.type === 'FeatureCollection') {
+    let children = [];
 
-  for (const item of items) {
-    if (getCertaintyRadius(item)) {
-      if (item.geometry?.type === 'FeatureCollection') {
-        for (const childFeature of item.geometry.features) {
-          if (childFeature.geometry?.type === 'Point') {
-            features.push(buildCircle(childFeature.geometry, getCertaintyRadius(item)));
-          }
-        }
-      } else if (item.geometry.type === 'GeometryCollection') {
-        for (const geometry of item.geometry.geometries) {
-          if (geometry.type === 'Point') {
-            features.push(buildCircle(geometry, getCertaintyRadius(item)));
-          }
-        }
-      } else if (item.geometry?.type === 'Point') {
-        features.push(buildCircle(item.geometry, getCertaintyRadius(item)));
+    for (const childFeature of item.geometry.features) {
+      if (childFeature.geometry?.type === 'Point') {
+        const { geometry, type } = buildCircle(childFeature.geometry, radius);
+        children.push({
+          ...childFeature,
+          geometry,
+          type
+        });
       }
     }
+
+    return {
+      ...item,
+      geometry: {
+        type: 'GeometryCollection',
+        geometries: children
+      }
+    };
+  } else if (item.geometry?.type === 'GeometryCollection') {
+    let children = [];
+    for (const geometry of item.geometry.geometries) {
+
+      if (geometry.type === 'Point') {
+        children.push(buildCircle(geometry, radius));
+      }
+    }
+
+    return {
+      ...item,
+      geometry: {
+        ...item.geometry,
+        geometries: children
+      }
+    };
+  } else if (item.geometry?.type === 'Point') {
+    const { geometry, type } = buildCircle(item.geometry, radius);
+    return {
+      ...item,
+      geometry,
+      type
+    };
   }
 
-  return featureCollection(features);
+  return item;
 };
 
 /**
@@ -204,7 +222,7 @@ const validateCoordinates = (coordinates) => {
 
 export default {
   addGeoreferenceLayer,
-  getCertaintyCircles,
+  toCertaintyCircle,
   getBoundingBox,
   removeLayer,
   toFeature,

--- a/packages/geospatial/src/utils/Map.js
+++ b/packages/geospatial/src/utils/Map.js
@@ -41,29 +41,11 @@ const toCertaintyCircle = (item, radius: number) => {
       }
     }
 
-    return {
-      ...item,
-      geometry: {
-        type: 'GeometryCollection',
-        geometries: children
-      }
-    };
+    return featureCollection(children);
   } else if (item.geometry?.type === 'GeometryCollection') {
-    let children = [];
-    for (const geometry of item.geometry.geometries) {
-
-      if (geometry.type === 'Point') {
-        children.push(buildCircle(geometry, radius));
-      }
-    }
-
-    return {
-      ...item,
-      geometry: {
-        ...item.geometry,
-        geometries: children
-      }
-    };
+    return featureCollection(item.geometry.geometries.map((geometry) => geometry.type === 'Point'
+      ? buildCircle(geometry, radius)
+      : feature(geometry)));
   } else if (item.geometry?.type === 'Point') {
     const { geometry, type } = buildCircle(item.geometry, radius);
     return {


### PR DESCRIPTION
# Summary

This PR makes some changes to the fuzzy place code from #575.

* replaces `getCertaintyCircles`, which returned a feature collection from an array of items, with the more flexible `toCertaintyCircle` that accepts one item as an argument and returns a feature
* updates `toFeature` from the Core Data package to include `originalProperties` in the same format as the Typesense package's `toFeature`
* update `CertaintyCircle` to use the new `getCertaintyCircles` function