### PR TITLE
Display date filters correctly

### DIFF
--- a/packages/semantic-ui/src/components/FilterLabels.js
+++ b/packages/semantic-ui/src/components/FilterLabels.js
@@ -3,6 +3,7 @@
 import React, { useCallback } from 'react';
 import { Button, Label } from 'semantic-ui-react';
 import _ from 'underscore';
+import { Date as DateUtils } from '@performant-software/shared-components';
 import i18n from '../i18n/i18n';
 import { FilterOperatorOptions, type Filter } from './ListFilters';
 import './FilterLabels.css';
@@ -43,6 +44,15 @@ const FilterLabels = (props: Props) => {
     } else if (filter.type === 'boolean') {
       // format booleans as capitalized strings
       displayValue = filter.value ? 'True' : 'False';
+    } else if (filter.type === 'date' && typeof filter.value === 'object' && filter.value !== null) {
+      // format FuzzyDate objects
+      const { startDate, endDate, range } = filter.value;
+      const formattedStart = startDate ? DateUtils.formatDate(startDate) : '';
+      if (range && endDate) {
+        displayValue = `${formattedStart} - ${DateUtils.formatDate(endDate)}`;
+      } else {
+        displayValue = formattedStart;
+      }
     }
 
     // Append the value in quotes, if present


### PR DESCRIPTION
### In this PR

Per performant-software/archnet3#1679:
- Ensure date filter labels are formatted correctly for FuzzyDates