### PR TITLE
Fix NPM packaging

### DIFF
--- a/packages/controlled-vocabulary/package.json
+++ b/packages/controlled-vocabulary/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
+  "files": [
+    "dist"
+  ],
   "style": "./dist/style.css",
   "type": "module",
   "exports": {

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
+  "files": [
+    "dist"
+  ],
   "style": "./dist/style.css",
   "type": "module",
   "exports": {

--- a/packages/geospatial/package.json
+++ b/packages/geospatial/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
+  "files": [
+    "dist"
+  ],
   "style": "./dist/style.css",
   "type": "module",
   "exports": {

--- a/packages/geospatial/src/utils/Map.js
+++ b/packages/geospatial/src/utils/Map.js
@@ -6,7 +6,7 @@ import {
   bboxPolygon,
   buffer,
   feature,
-  featureCollection,
+  featureCollection
 } from '@turf/turf';
 import _ from 'underscore';
 import circle from '@turf/circle';

--- a/packages/geospatial/src/utils/Map.js
+++ b/packages/geospatial/src/utils/Map.js
@@ -4,9 +4,15 @@ import { WarpedMapLayer } from '@allmaps/maplibre';
 import {
   bbox,
   bboxPolygon,
+  bearing,
+  bezierSpline,
   buffer,
+  destination,
+  distance,
   feature,
-  featureCollection
+  featureCollection,
+  lineString,
+  midpoint
 } from '@turf/turf';
 import _ from 'underscore';
 import circle from '@turf/circle';
@@ -202,11 +208,49 @@ const validateCoordinates = (coordinates) => {
   return valid;
 };
 
+/**
+ * Returns a GeoJSON FeatureCollection of LineStrings (arcs) for the passed coordinates.
+ *
+ * @param coordinates
+ * @param options
+ *
+ * @returns {FeatureCollection<LineString, GeoJsonProperties>}
+ */
+const toArcs = (coordinates, options = {}) => {
+  const { curvature = 0.2 } = options;
+  const features = [];
+
+  for (let i = 0; i < coordinates.length - 1; i += 1) {
+    const start = coordinates[i];
+    const end = coordinates[i + 1];
+
+    const d = distance(start, end);
+    const m = midpoint(start, end);
+    const b = bearing(start, end);
+
+    const offsetBearing = b + 90 > 180 ? b + 90 - 360 : b + 90;
+    const dest = destination(m, d * curvature, offsetBearing);
+
+    const line = lineString([start, dest.geometry.coordinates, end]);
+    const arc = bezierSpline(line);
+
+    arc.properties = {
+      ...arc.properties,
+      index: i
+    };
+
+    features.push(arc);
+  }
+
+  return featureCollection(features);
+};
+
 export default {
   addGeoreferenceLayer,
   toCertaintyCircle,
   getBoundingBox,
   removeLayer,
+  toArcs,
   toFeature,
   toFeatureCollection,
   validateBoundingBox,

--- a/packages/geospatial/src/utils/Map.js
+++ b/packages/geospatial/src/utils/Map.js
@@ -4,15 +4,9 @@ import { WarpedMapLayer } from '@allmaps/maplibre';
 import {
   bbox,
   bboxPolygon,
-  bearing,
-  bezierSpline,
   buffer,
-  destination,
-  distance,
   feature,
   featureCollection,
-  lineString,
-  midpoint
 } from '@turf/turf';
 import _ from 'underscore';
 import circle from '@turf/circle';
@@ -208,49 +202,11 @@ const validateCoordinates = (coordinates) => {
   return valid;
 };
 
-/**
- * Returns a GeoJSON FeatureCollection of LineStrings (arcs) for the passed coordinates.
- *
- * @param coordinates
- * @param options
- *
- * @returns {FeatureCollection<LineString, GeoJsonProperties>}
- */
-const toArcs = (coordinates, options = {}) => {
-  const { curvature = 0.2 } = options;
-  const features = [];
-
-  for (let i = 0; i < coordinates.length - 1; i += 1) {
-    const start = coordinates[i];
-    const end = coordinates[i + 1];
-
-    const d = distance(start, end);
-    const m = midpoint(start, end);
-    const b = bearing(start, end);
-
-    const offsetBearing = b + 90 > 180 ? b + 90 - 360 : b + 90;
-    const dest = destination(m, d * curvature, offsetBearing);
-
-    const line = lineString([start, dest.geometry.coordinates, end]);
-    const arc = bezierSpline(line);
-
-    arc.properties = {
-      ...arc.properties,
-      index: i
-    };
-
-    features.push(arc);
-  }
-
-  return featureCollection(features);
-};
-
 export default {
   addGeoreferenceLayer,
   toCertaintyCircle,
   getBoundingBox,
   removeLayer,
-  toArcs,
   toFeature,
   toFeatureCollection,
   validateBoundingBox,

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
+  "files": [
+    "dist"
+  ],
   "style": "./dist/style.css",
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,9 @@
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
   "style": "./dist/style.css",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/user-defined-fields/package.json
+++ b/packages/user-defined-fields/package.json
@@ -7,6 +7,9 @@
   "module": "./dist/index.es.js",
   "style": "./dist/style.css",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.es.js",

--- a/packages/visualize/package.json
+++ b/packages/visualize/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.es.js",
+  "files": [
+    "dist"
+  ],
   "style": "./dist/style.css",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# Summary

After #587, the actual `dist` files stopped being uploaded to NPM, making the packages unusable. I think this is because of the switch from `yarn publish` to `npm publish`. `yarn publish` included the `dist` folder by default while `npm publish` does not.

This PR adds a `files` array to each `package.json` to tell NPM to include that directory in the published package.