### PR TITLE
Replace deprecated `defaultProps` in functional components

### DIFF
--- a/packages/controlled-vocabulary/src/components/ReferenceCodeDropdown.js
+++ b/packages/controlled-vocabulary/src/components/ReferenceCodeDropdown.js
@@ -25,7 +25,7 @@ type Props = {
   value: Item | Array<Item>
 };
 
-const ReferenceCodeDropdown = (props: Props) => {
+const ReferenceCodeDropdown = ({disabled = false, fluid = true, multiple = false, placeholder = undefined, ...props}: Props) => {
   const [loading, setLoading] = useState(false);
   const [options, setOptions] = useState([]);
 
@@ -34,8 +34,8 @@ const ReferenceCodeDropdown = (props: Props) => {
    */
   const value = useMemo(() => {
     const v = _.pluck(_.filter(props.value, (x) => !x._destroy), 'reference_code_id');
-    return props.multiple ? v : _.first(v);
-  }, [props.multiple, props.value]);
+    return multiple ? v : _.first(v);
+  }, [multiple, props.value]);
 
   /**
    * Converts the passed ID to a reference code item.
@@ -73,7 +73,7 @@ const ReferenceCodeDropdown = (props: Props) => {
   const onChange = useCallback((e, data) => {
     let referenceCodeIds;
 
-    if (props.multiple) {
+    if (multiple) {
       referenceCodeIds = data.value;
     } else {
       referenceCodeIds = _.compact([data.value]);
@@ -100,7 +100,7 @@ const ReferenceCodeDropdown = (props: Props) => {
     });
 
     props.onChange(items);
-  }, [toItem, props.multiple, props.onChange, props.value]);
+  }, [toItem, multiple, props.onChange, props.value]);
 
   /**
    * Loads the list of reference codes from the server.
@@ -123,26 +123,19 @@ const ReferenceCodeDropdown = (props: Props) => {
   return (
     <Dropdown
       clearable
-      disabled={loading || props.disabled}
-      fluid={props.fluid}
+      disabled={loading || disabled}
+      fluid={fluid}
       loading={loading}
-      multiple={props.multiple}
+      multiple={multiple}
       onChange={onChange}
       options={options}
-      placeholder={props.placeholder}
+      placeholder={placeholder}
       search
       selection
       selectOnBlur={false}
       value={value}
     />
   );
-};
-
-ReferenceCodeDropdown.defaultProps = {
-  disabled: false,
-  fluid: true,
-  multiple: false,
-  placeholder: undefined
 };
 
 export default ReferenceCodeDropdown;

--- a/packages/core-data/src/components/EventsList.js
+++ b/packages/core-data/src/components/EventsList.js
@@ -33,7 +33,7 @@ type Props = {
   onClick?: (event: EventType) => void
 };
 
-const EventsList = (props: Props) => (
+const EventsList = ({isSelected = () => false, onClick = () => {}, ...props}: Props) => (
   <ul
     className={props.className}
   >
@@ -51,11 +51,11 @@ const EventsList = (props: Props) => (
               'inline-flex',
               'flex-col',
               'rounded-none',
-              { 'hover:bg-event-selected': props.isSelected(event) },
-              { 'text-white': props.isSelected(event) },
-              { 'bg-event-selected': props.isSelected(event) }
+              { 'hover:bg-event-selected': isSelected(event) },
+              { 'text-white': isSelected(event) },
+              { 'bg-event-selected': isSelected(event) }
             )}
-            onClick={() => props.onClick(event)}
+            onClick={() => onClick(event)}
             type='button'
           >
             <div
@@ -78,7 +78,7 @@ const EventsList = (props: Props) => (
               <p
                 className={clsx(
                   'py-2',
-                  { 'text-muted': !props.isSelected(event) }
+                  { 'text-muted': !isSelected(event) }
                 )}
               >
                 { event.description }
@@ -90,10 +90,5 @@ const EventsList = (props: Props) => (
     ))}
   </ul>
 );
-
-EventsList.defaultProps = {
-  isSelected: () => false,
-  onClick: () => {}
-};
 
 export default EventsList;

--- a/packages/core-data/src/components/FacetSlider.js
+++ b/packages/core-data/src/components/FacetSlider.js
@@ -16,7 +16,7 @@ type MarkerProps = {
   value: number
 };
 
-const SliderMarker = (props: MarkerProps) => {
+const SliderMarker = ({position = 'top', ...props}: MarkerProps) => {
   const [initialized, setInitialized] = useState(false);
   const [open, setOpen] = useState(false);
 
@@ -70,7 +70,7 @@ const SliderMarker = (props: MarkerProps) => {
           />
         </Tooltip.Trigger>
         <Tooltip.Content
-          side={props.position}
+          side={position}
           sideOffset={5}
         >
           <div
@@ -85,10 +85,6 @@ const SliderMarker = (props: MarkerProps) => {
       </Tooltip.Root>
     </Tooltip.Provider>
   );
-};
-
-SliderMarker.defaultProps = {
-  position: 'top'
 };
 
 type Action = {
@@ -200,7 +196,7 @@ type Props = {
   value: [number, number]
 };
 
-const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
+const FacetSlider = forwardRef(({classNames = {}, step = 1, value = [], ...props}) => {
   const { clearTimer, setTimer } = useTimer();
 
   /**
@@ -209,9 +205,9 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
    * @type {(function(): void)|*}
    */
   const onLeft = useCallback(() => {
-    const [start, end] = props.value;
+    const [start, end] = value;
 
-    let newStart = start - props.step;
+    let newStart = start - step;
     if (newStart < props.min) {
       newStart = props.min;
     }
@@ -223,7 +219,7 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
       clearTimer();
       setTimer(() => props.onValueCommit([newStart, end]));
     }
-  }, [props.min, props.onValueChange, props.onValueCommit, props.step, props.value]);
+  }, [props.min, props.onValueChange, props.onValueCommit, step, value]);
 
   /**
    * Callback fired when the right button is clicked. This function increments the max range value by the "step" prop.
@@ -231,9 +227,9 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
    * @type {(function(): void)|*}
    */
   const onRight = useCallback(() => {
-    const [start, end] = props.value;
+    const [start, end] = value;
 
-    let newEnd = end + props.step;
+    let newEnd = end + step;
     if (newEnd > props.max) {
       newEnd = props.max;
     }
@@ -245,7 +241,7 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
       clearTimer();
       setTimer(() => props.onValueCommit([start, newEnd]));
     }
-  }, [props.max, props.onValueChange, props.onValueCommit, props.step, props.value]);
+  }, [props.max, props.onValueChange, props.onValueCommit, step, value]);
 
   /**
    * Filtered actions by position.
@@ -277,7 +273,7 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
               'py-3',
               'disabled:opacity-50',
               'disabled:hover:bg-transparent',
-              props.classNames.button
+              classNames.button
             )}
             onClick={onLeft}
             type='button'
@@ -288,7 +284,7 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
         <Slider.Root
           className={clsx(
             'relative flex flex-grow h-5 touch-none items-center w-full',
-            props.classNames.root
+            classNames.root
           )}
           max={props.max}
           min={props.min}
@@ -297,18 +293,18 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
           onValueCommit={props.onValueCommit}
           ref={ref}
           step={1}
-          value={props.value}
+          value={value}
         >
           <Slider.Track
             className={clsx(
               'relative h-1 w-full grow bg-gray-100',
-              props.classNames.track
+              classNames.track
             )}
           >
             <Slider.Range
               className={clsx(
                 'absolute h-full bg-gray-600',
-                props.classNames.range
+                classNames.range
               )}
             />
           </Slider.Track>
@@ -345,14 +341,14 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
             </svg>
             )}
           <SliderMarker
-            className={props.classNames.thumb}
+            className={classNames.thumb}
             position={props.position}
-            value={props.value[0]}
+            value={value[0]}
           />
           <SliderMarker
-            className={props.classNames.thumb}
+            className={classNames.thumb}
             position={props.position}
-            value={props.value[1]}
+            value={value[1]}
           />
         </Slider.Root>
         {!props.hideStepButtons && (
@@ -363,7 +359,7 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
               'py-3',
               'disabled:opacity-50',
               'disabled:hover:bg-transparent',
-              props.classNames.button
+              classNames.button
             )}
             onClick={onRight}
             type='button'
@@ -375,7 +371,7 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
           <div
             className={clsx(
               'flex justify-center items-center py-3 text-gray-600',
-              props.classNames.reset
+              classNames.reset
             )}
           >
             { _.map(rightActions, (action, index) => (
@@ -408,7 +404,7 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
         <div
           className={clsx(
             'flex justify-center items-center w-full py-3 text-gray-600',
-            props.classNames.zoom
+            classNames.zoom
           )}
         >
           { _.map(bottomActions, (action, index) => (
@@ -434,12 +430,6 @@ const FacetSlider = forwardRef((props: Props, ref: HTMLElement) => {
     </>
   );
 });
-
-FacetSlider.defaultProps = {
-  classNames: {},
-  step: 1,
-  value: []
-};
 
 export default FacetSlider;
 

--- a/packages/core-data/src/components/RelatedEvents.js
+++ b/packages/core-data/src/components/RelatedEvents.js
@@ -33,7 +33,7 @@ type Props = {
   selected?: EventType
 };
 
-const RelatedEvents = (props: Props) => {
+const RelatedEvents = ({description = true, defaultPage = 1, onClick = () => {}, ...props}: Props) => {
   const {
     data: { events } = {},
     isNextDisabled,
@@ -62,10 +62,10 @@ const RelatedEvents = (props: Props) => {
   return (
     <div>
       <EventsList
-        description={props.description}
+        description={description}
         events={events}
         isSelected={isSelected}
-        onClick={props.onClick}
+        onClick={onClick}
       />
       { pages > 1 && (
         <div
@@ -138,12 +138,6 @@ const RelatedEvents = (props: Props) => {
       )}
     </div>
   );
-};
-
-RelatedEvents.defaultProps = {
-  description: true,
-  defaultPage: 1,
-  onClick: () => {}
 };
 
 export default RelatedEvents;

--- a/packages/core-data/src/components/RelatedList.js
+++ b/packages/core-data/src/components/RelatedList.js
@@ -50,7 +50,7 @@ type Props = {
 /**
  * This component is a helper component used to structure the lists for the other `Related*` components.
  */
-const RelatedList = (props: Props) => {
+const RelatedList = ({itemsPerRow = 1, ...props}: Props) => {
   const [items, setItems] = useState([]);
 
   const {
@@ -93,12 +93,12 @@ const RelatedList = (props: Props) => {
         className={clsx(
           'grid',
           'gap-2',
-          { 'grid-cols-1': props.itemsPerRow === 1 },
-          { 'grid-cols-2': props.itemsPerRow === 2 },
-          { 'grid-cols-3': props.itemsPerRow === 3 },
-          { 'grid-cols-4': props.itemsPerRow === 4 },
-          { 'grid-cols-5': props.itemsPerRow === 5 },
-          { 'grid-cols-6': props.itemsPerRow === 6 },
+          { 'grid-cols-1': itemsPerRow === 1 },
+          { 'grid-cols-2': itemsPerRow === 2 },
+          { 'grid-cols-3': itemsPerRow === 3 },
+          { 'grid-cols-4': itemsPerRow === 4 },
+          { 'grid-cols-5': itemsPerRow === 5 },
+          { 'grid-cols-6': itemsPerRow === 6 },
           props.className
         )}
       >
@@ -129,10 +129,6 @@ const RelatedList = (props: Props) => {
     </div>
 
   );
-};
-
-RelatedList.defaultProps = {
-  itemsPerRow: 1
 };
 
 export default RelatedList;

--- a/packages/core-data/src/components/RelatedMedia.js
+++ b/packages/core-data/src/components/RelatedMedia.js
@@ -49,7 +49,7 @@ const DEFAULT_THUMBNAIL_WIDTH = 80;
 /**
  * This component renders the related Core Data media records as well as a gallery viewer.
  */
-const RelatedMedia = (props: Props) => {
+const RelatedMedia = ({thumbnailHeight = DEFAULT_THUMBNAIL_HEIGHT, thumbnailWidth = DEFAULT_THUMBNAIL_WIDTH, ...props}: Props) => {
   const [manifestUrl, setManifestUrl] = useState<string>();
 
   /**
@@ -67,8 +67,8 @@ const RelatedMedia = (props: Props) => {
         onClick={() => setManifestUrl(id)}
         thumbnail={_.map(thumbnail, (t) => ({
           ...t,
-          width: props.thumbnailWidth,
-          height: props.thumbnailHeight
+          width: thumbnailWidth,
+          height: thumbnailHeight
         }))}
       />
       <div
@@ -77,7 +77,7 @@ const RelatedMedia = (props: Props) => {
         { label }
       </div>
     </div>
-  ), [props.thumbnailHeight, props.thumbnailWidth]);
+  ), [thumbnailHeight, thumbnailWidth]);
 
   return (
     <>
@@ -98,11 +98,6 @@ const RelatedMedia = (props: Props) => {
       )}
     </>
   );
-};
-
-RelatedMedia.defaultProps = {
-  thumbnailHeight: DEFAULT_THUMBNAIL_HEIGHT,
-  thumbnailWidth: DEFAULT_THUMBNAIL_WIDTH
 };
 
 export default RelatedMedia;

--- a/packages/core-data/src/components/SearchResultsLayer.js
+++ b/packages/core-data/src/components/SearchResultsLayer.js
@@ -44,7 +44,7 @@ type Props = {
 /**
  * This component renders a map layer for the search results from a Typesense search index.
  */
-const SearchResultsLayer = (props: Props) => {
+const SearchResultsLayer = ({fitBoundingBox = true, ...props}: Props) => {
   const [mapLoaded, setMapLoaded] = useState(false);
 
   const map = useMap();
@@ -59,12 +59,12 @@ const SearchResultsLayer = (props: Props) => {
     props.boundingBoxOptions,
     props.buffer,
     props.data,
-    props.fitBoundingBox,
+    fitBoundingBox,
     props.searching
   ];
 
   useEffect(() => {
-    if (props.fitBoundingBox && props.data && mapLoaded && !props.searching) {
+    if (fitBoundingBox && props.data && mapLoaded && !props.searching) {
       // Set the bounding box on the map
       const bbox = MapUtils.getBoundingBox(props.data, props.buffer);
 
@@ -101,10 +101,6 @@ const SearchResultsLayer = (props: Props) => {
       fitBoundingBox={false}
     />
   );
-};
-
-SearchResultsLayer.defaultProps = {
-  fitBoundingBox: true
 };
 
 export default SearchResultsLayer;

--- a/packages/core-data/src/components/SearchResultsList.js
+++ b/packages/core-data/src/components/SearchResultsList.js
@@ -49,7 +49,7 @@ type RowProps = {
 /**
  * This component renders a list of search results returned from a Core Data Typesense index.
  */
-const SearchResultsList = (props: Props) => {
+const SearchResultsList = ({itemSize = 88, ...props}: Props) => {
   const {
     hits,
     hover,
@@ -119,17 +119,13 @@ const SearchResultsList = (props: Props) => {
           height={height}
           itemCount={hits.length}
           width={width}
-          itemSize={props.itemSize}
+          itemSize={itemSize}
         >
           { Row }
         </FixedSizeList>
       )}
     </AutoSizer>
   );
-};
-
-SearchResultsList.defaultProps = {
-  itemSize: 88
 };
 
 export default SearchResultsList;

--- a/packages/core-data/src/components/Slider.js
+++ b/packages/core-data/src/components/Slider.js
@@ -15,7 +15,7 @@ type MarkerProps = {
   value: number
 };
 
-const SliderMarker = (props: MarkerProps) => {
+const SliderMarker = ({position = 'top', ...props}: MarkerProps) => {
   const [initialized, setInitialized] = useState(false);
   const [open, setOpen] = useState(false);
 
@@ -37,7 +37,7 @@ const SliderMarker = (props: MarkerProps) => {
 
     // Set a new timer
     setTimer(() => setOpen(false));
-  }, [props.value]);
+  }, [value]);
 
   /**
    * Sets the initialized state.
@@ -46,7 +46,7 @@ const SliderMarker = (props: MarkerProps) => {
     if (!initialized) {
       setInitialized(true);
     }
-  }, [props.value]);
+  }, [value]);
 
   return (
     <Tooltip.Provider>
@@ -69,13 +69,13 @@ const SliderMarker = (props: MarkerProps) => {
           />
         </Tooltip.Trigger>
         <Tooltip.Content
-          side={props.position}
+          side={position}
           sideOffset={5}
         >
           <div
             className='bg-white p-2 text-black rounded-md shadow-md shadow-gray-1000'
           >
-            { props.value }
+            { value }
           </div>
           <Tooltip.Arrow
             className='fill-white'
@@ -84,10 +84,6 @@ const SliderMarker = (props: MarkerProps) => {
       </Tooltip.Root>
     </Tooltip.Provider>
   );
-};
-
-SliderMarker.defaultProps = {
-  position: 'top'
 };
 
 type Action = {
@@ -168,7 +164,7 @@ type Props = {
   value: [number, number]
 };
 
-const Slider = (props: Props) => {
+const Slider = ({classNames = {}, value = [], ...props}: Props) => {
   /**
    * Adjusts the values entered by the user based on range
    * and step constraints.
@@ -207,7 +203,7 @@ const Slider = (props: Props) => {
   }, [props.onValueCommit, props.onValueChange, props.min, props.max]);
 
   return (
-    <div className={props.classNames?.container}>
+    <div className={classNames?.container}>
       {(props.icon || props.label) && (
       <div
         className='flex gap-2 items-center justify-center w-full'
@@ -234,7 +230,7 @@ const Slider = (props: Props) => {
         <RadixSlider.Root
           className={clsx(
             'relative flex flex-grow h-5 touch-none items-center w-full',
-            props.classNames.root
+            classNames.root
           )}
           max={props.max}
           min={props.min}
@@ -242,30 +238,30 @@ const Slider = (props: Props) => {
           onValueChange={props.onValueChange}
           onValueCommit={props.onValueCommit}
           step={1}
-          value={props.value}
+          value={value}
         >
           <RadixSlider.Track
             className={clsx(
               'relative h-1 w-full grow bg-gray-100',
-              props.classNames.track
+              classNames.track
             )}
           >
             <RadixSlider.Range
               className={clsx(
                 'absolute h-full bg-neutral-800',
-                props.classNames.range
+                classNames.range
               )}
             />
           </RadixSlider.Track>
           <SliderMarker
-            className={props.classNames.thumb}
+            className={classNames.thumb}
             position={props.position}
-            value={props.value[0]}
+            value={value[0]}
           />
           <SliderMarker
-            className={props.classNames.thumb}
+            className={classNames.thumb}
             position={props.position}
-            value={props.value[1]}
+            value={value[1]}
           />
         </RadixSlider.Root>
       </div>
@@ -276,32 +272,27 @@ const Slider = (props: Props) => {
           ariaLabel={i18n.t('Slider.start')}
           className={clsx(
             'rounded-md !w-20',
-            props.classNames.input
+            classNames.input
           )}
           clearable={false}
-          onBlur={(val) => onInputCommit([parseInt(val, 10), props.value[1]])}
-          onChange={(val) => props.onValueChange([parseInt(val, 10), props.value[1]])}
-          value={props.value[0]}
+          onBlur={(val) => onInputCommit([parseInt(val, 10), value[1]])}
+          onChange={(val) => props.onValueChange([parseInt(val, 10), value[1]])}
+          value={value[0]}
         />
         <Input
           ariaLabel={i18n.t('Slider.end')}
           className={clsx(
             'rounded-md !w-20',
-            props.classNames.input
+            classNames.input
           )}
           clearable={false}
-          onBlur={(val) => onInputCommit([props.value[0], parseInt(val, 10)])}
-          onChange={(val) => props.onValueChange([props.value[0], parseInt(val, 10)])}
-          value={props.value[1]}
+          onBlur={(val) => onInputCommit([value[0], parseInt(val, 10)])}
+          onChange={(val) => props.onValueChange([value[0], parseInt(val, 10)])}
+          value={value[1]}
         />
       </div>
     </div>
   );
-};
-
-Slider.defaultProps = {
-  classNames: {},
-  value: []
 };
 
 export default Slider;

--- a/packages/geospatial/src/components/GeoJsonLayer.js
+++ b/packages/geospatial/src/components/GeoJsonLayer.js
@@ -12,14 +12,14 @@ type Props = {
   url?: string
 };
 
-const GeoJsonLayer = (props: Props) => (
+const GeoJsonLayer = ({fillStyle = MapStyles.fill.paint, pointStyle = MapStyles.point.paint, strokeStyle = MapStyles.stroke.paint, ...props}: Props) => (
   <Source
     data={props.data || props.url}
     type='geojson'
   >
     <Layer
       filter={['!=', '$type', 'Point']}
-      paint={props.fillStyle}
+      paint={fillStyle}
       type='fill'
     />
     <Layer
@@ -29,16 +29,10 @@ const GeoJsonLayer = (props: Props) => (
     />
     <Layer
       filter={['==', '$type', 'Point']}
-      paint={props.pointStyle}
+      paint={pointStyle}
       type='circle'
     />
   </Source>
 );
-
-GeoJsonLayer.defaultProps = {
-  fillStyle: MapStyles.fill.paint,
-  pointStyle: MapStyles.point.paint,
-  strokeStyle: MapStyles.stroke.paint
-};
 
 export default GeoJsonLayer;

--- a/packages/geospatial/src/components/LayerMenu.js
+++ b/packages/geospatial/src/components/LayerMenu.js
@@ -23,7 +23,7 @@ type Props = {
 
 const MENU_PADDING = 30;
 
-const LayerMenu = (props: Props) => {
+const LayerMenu = ({position = 'top-left', ...props}: Props) => {
   const [canvasHeight, setCanvasHeight] = useState(0);
   const [visible, setVisible] = useState();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -102,7 +102,7 @@ const LayerMenu = (props: Props) => {
     <>
       <MapControl
         mapRef={mapRef}
-        position={props.position}
+        position={position}
       >
         <button
           aria-label='Toggle Menu'
@@ -153,10 +153,6 @@ const LayerMenu = (props: Props) => {
       { visibleChildren }
     </>
   );
-};
-
-LayerMenu.defaultProps = {
-  position: 'top-left'
 };
 
 export default LayerMenu;

--- a/packages/geospatial/src/components/LocationMarkers.js
+++ b/packages/geospatial/src/components/LocationMarkers.js
@@ -99,7 +99,7 @@ const DEFAULT_BUFFER = 2;
 /**
  * This component renders a location marker to be used in a Peripleo context.
  */
-const LocationMarkers = (props: Props) => {
+const LocationMarkers = ({buffer = DEFAULT_BUFFER, fillStyle = MapStyles.fill, fitBoundingBox = true, pointStyle = MapStyles.point, strokeStyle = MapStyles.stroke, ...props}: Props) => {
   const map = useLoadedMap();
 
   /**
@@ -113,14 +113,14 @@ const LocationMarkers = (props: Props) => {
    * Sets the bounding box on the map.
    */
   useEffect(() => {
-    if (map && data && props.fitBoundingBox) {
-      const bbox = MapUtils.getBoundingBox(data, props.buffer);
+    if (map && data && fitBoundingBox) {
+      const bbox = MapUtils.getBoundingBox(data, buffer);
 
       if (bbox) {
         map.fitBounds(bbox, props.boundingBoxOptions, props.boundingBoxData);
       }
     }
-  }, [map, props.buffer, props.data, props.boundingBoxData, props.boundingBoxOptions, props.fitBoundingBox]);
+  }, [map, buffer, props.data, props.boundingBoxData, props.boundingBoxOptions, fitBoundingBox]);
 
   if (!data) {
     return null;
@@ -141,23 +141,15 @@ const LocationMarkers = (props: Props) => {
         clusterProperties={props.clusterProperties}
         clusterRadius={props.clusterRadius}
         data={props.data}
-        fillStyle={props.fillStyle}
+        fillStyle={fillStyle}
         id={props.layerId}
         interactive={props.interactive}
-        strokeStyle={props.strokeStyle}
-        pointStyle={props.pointStyle}
+        strokeStyle={strokeStyle}
+        pointStyle={pointStyle}
         visible={props.visible}
       />
     </>
   );
-};
-
-LocationMarkers.defaultProps = {
-  buffer: DEFAULT_BUFFER,
-  fillStyle: MapStyles.fill,
-  fitBoundingBox: true,
-  pointStyle: MapStyles.point,
-  strokeStyle: MapStyles.stroke
 };
 
 export default LocationMarkers;

--- a/packages/geospatial/src/components/MapDraw.js
+++ b/packages/geospatial/src/components/MapDraw.js
@@ -121,7 +121,7 @@ const GeometryTypes = {
  * This component renders a map with controls for drawing one or more geometries. Geometries can be a point (lat/long),
  * a line, or a polygon.
  */
-const MapDraw = (props: Props) => {
+const MapDraw = ({buffer = DEFAULT_BUFFER, cooperativeGestures = true, preserveDrawingBuffer = false, zoomDuration = DEFAULT_ZOOM_DELAY, ...props}: Props) => {
   const [loaded, setLoaded] = useState(false);
 
   const drawRef = useRef<MapboxDraw>();
@@ -193,10 +193,10 @@ const MapDraw = (props: Props) => {
   useEffect(() => {
     if (loaded && props.data) {
       // Sets the bounding box for the current geometry
-      const bbox = MapUtils.getBoundingBox(props.data, props.buffer);
+      const bbox = MapUtils.getBoundingBox(props.data, buffer);
 
       if (bbox) {
-        mapRef.current.fitBounds(bbox, { duration: props.zoomDuration });
+        mapRef.current.fitBounds(bbox, { duration: zoomDuration });
       }
 
       // Handle special cases for geometry collection (not supported by mabox-gl-draw) and point
@@ -213,11 +213,11 @@ const MapDraw = (props: Props) => {
   return (
     <Map
       attributionControl={false}
-      cooperativeGestures={props.cooperativeGestures}
+      cooperativeGestures={cooperativeGestures}
       mapLib={maplibregl}
       maxPitch={props.maxPitch}
       onLoad={() => setLoaded(true)}
-      preserveDrawingBuffer={props.preserveDrawingBuffer}
+      preserveDrawingBuffer={preserveDrawingBuffer}
       ref={mapRef}
       style={style}
       mapStyle={mapStyleUrl}
@@ -256,13 +256,6 @@ const MapDraw = (props: Props) => {
       { props.children }
     </Map>
   );
-};
-
-MapDraw.defaultProps = {
-  buffer: DEFAULT_BUFFER,
-  cooperativeGestures: true,
-  preserveDrawingBuffer: false,
-  zoomDuration: DEFAULT_ZOOM_DELAY
 };
 
 export default MapDraw;

--- a/packages/geospatial/src/components/RasterLayer.js
+++ b/packages/geospatial/src/components/RasterLayer.js
@@ -11,28 +11,21 @@ type Props = {
   url?: string,
 };
 
-const RasterLayer = (props: Props) => (
+const RasterLayer = ({maxzoom = 22, minzoom = 0, opacity = 0.7, tileSize = 256, ...props}: Props) => (
   <Source
-    tileSize={props.tileSize}
+    tileSize={tileSize}
     tiles={[props.url]}
     type='raster'
   >
     <Layer
       type='raster'
       paint={{
-        'raster-opacity': props.opacity
+        'raster-opacity': opacity
       }}
-      minzoom={props.minzoom}
-      maxzoom={props.maxzoom}
+      minzoom={minzoom}
+      maxzoom={maxzoom}
     />
   </Source>
 );
-
-RasterLayer.defaultProps = {
-  maxzoom: 22,
-  minzoom: 0,
-  opacity: 0.7,
-  tileSize: 256
-};
 
 export default RasterLayer;

--- a/packages/geospatial/src/components/WarpedImageLayer.js
+++ b/packages/geospatial/src/components/WarpedImageLayer.js
@@ -26,7 +26,7 @@ type Props = {
   url?: string
 };
 
-const WarpedImageLayer = (props: Props) => {
+const WarpedImageLayer = ({opacity = 0.5, ...props}: Props) => {
   const [loaded, setLoaded] = useState(false);
 
   const mapRef = useMap();
@@ -55,7 +55,7 @@ const WarpedImageLayer = (props: Props) => {
 
     MapUtils.addGeoreferenceLayer(map, props.id, {
       manifest: props.manifest,
-      opacity: props.opacity,
+      opacity: opacity,
       url: props.url
     });
 
@@ -63,10 +63,6 @@ const WarpedImageLayer = (props: Props) => {
   }, [loaded]);
 
   return null;
-};
-
-WarpedImageLayer.defaultProps = {
-  opacity: 0.5
 };
 
 export default WarpedImageLayer;

--- a/packages/geospatial/src/components/WarpedImageLayerPeripleo.js
+++ b/packages/geospatial/src/components/WarpedImageLayerPeripleo.js
@@ -26,7 +26,7 @@ type Props = {
   url?: string
 };
 
-const WarpedImageLayer = (props: Props) => {
+const WarpedImageLayer = ({opacity = 0.5, ...props}: Props) => {
   const map = useLoadedMap();
 
   /**
@@ -39,7 +39,7 @@ const WarpedImageLayer = (props: Props) => {
 
     MapUtils.addGeoreferenceLayer(map, props.id, {
       manifest: props.manifest,
-      opacity: props.opacity,
+      opacity: opacity,
       url: props.url
     });
 
@@ -47,10 +47,6 @@ const WarpedImageLayer = (props: Props) => {
   }, [map]);
 
   return null;
-};
-
-WarpedImageLayer.defaultProps = {
-  opacity: 0.5
 };
 
 export default WarpedImageLayer;

--- a/packages/semantic-ui/src/components/ColorButton.js
+++ b/packages/semantic-ui/src/components/ColorButton.js
@@ -11,24 +11,18 @@ type Props = {
   width?: number
 }
 
-const ColorButton = (props: Props) => (
+const ColorButton = ({height = undefined, onClick = undefined, width = undefined, ...props}: Props) => (
   <Button
     className='color-button'
-    onClick={props.onClick && props.onClick.bind(this)}
+    onClick={onClick && onClick.bind(this)}
     style={{
       backgroundColor: props.color,
-      cursor: props.onClick ? 'pointer' : 'default',
-      height: props.height,
-      width: props.width
+      cursor: onClick ? 'pointer' : 'default',
+      height: height,
+      width: width
     }}
     title='color-button'
   />
 );
-
-ColorButton.defaultProps = {
-  height: undefined,
-  onClick: undefined,
-  width: undefined
-};
 
 export default ColorButton;

--- a/packages/semantic-ui/src/components/CurrentFacetLabels.js
+++ b/packages/semantic-ui/src/components/CurrentFacetLabels.js
@@ -19,7 +19,7 @@ type Props = {
  * This component displays the passed items as labels. If a <code>count</code> prop is provided, the component
  * will display a "+" button.
  */
-const CurrentFacetLabels = (props: Props) => (
+const CurrentFacetLabels = ({count = undefined, onShowMore = undefined, ...props}: Props) => (
   <Label.Group>
     { _.map(props.items, (item, index) => (
       <Label
@@ -28,20 +28,15 @@ const CurrentFacetLabels = (props: Props) => (
         onRemove={item.onClick}
       />
     ))}
-    { props.count && props.count > props.items.length && props.onShowMore && (
+    { count && count > props.items.length && onShowMore && (
       <Label
         as={Button}
-        content={`+${props.count - props.items.length}`}
-        onClick={props.onShowMore}
+        content={`+${count - props.items.length}`}
+        onClick={onShowMore}
       />
     )}
   </Label.Group>
 );
-
-CurrentFacetLabels.defaultProps = {
-  count: undefined,
-  onShowMore: undefined
-};
 
 export default CurrentFacetLabels;
 

--- a/packages/semantic-ui/src/components/CurrentFacets.js
+++ b/packages/semantic-ui/src/components/CurrentFacets.js
@@ -16,7 +16,7 @@ type Props = CurrentRefinementsProps & {
 /**
  * This component can be used to display the facets/refinements currently applied to an InstantSearch index.
  */
-const CurrentFacets = ({ useCurrentRefinements, ...props }: Props) => {
+const CurrentFacets = ({ useCurrentRefinements, limit = undefined,  ...props }: Props) => {
   const [modal, setModal] = useState(false);
   const { items } = useCurrentRefinements(props);
 
@@ -58,10 +58,6 @@ const CurrentFacets = ({ useCurrentRefinements, ...props }: Props) => {
       />
     </>
   );
-};
-
-CurrentFacets.defaultProps = {
-  limit: undefined
 };
 
 export default CurrentFacets;

--- a/packages/semantic-ui/src/components/CurrentFacetsModal.js
+++ b/packages/semantic-ui/src/components/CurrentFacetsModal.js
@@ -25,10 +25,10 @@ type Props = {
 /**
  * This component displays all of the facets currently applied, without any limit.
  */
-const CurrentFacetsModal = (props: Props) => (
+const CurrentFacetsModal = ({open = undefined, ...props}: Props) => (
   <Modal
     centered={false}
-    open={props.open}
+    open={open}
   >
     <Modal.Header
       content={i18n.t('CurrentFacetsModal.title')}
@@ -47,9 +47,5 @@ const CurrentFacetsModal = (props: Props) => (
     </Modal.Actions>
   </Modal>
 );
-
-CurrentFacetsModal.defaultProps = {
-  open: undefined
-};
 
 export default CurrentFacetsModal;

--- a/packages/semantic-ui/src/components/DataView.js
+++ b/packages/semantic-ui/src/components/DataView.js
@@ -125,7 +125,7 @@ const List = useDataList((props) => {
   );
 });
 
-const DataView = (props: Props) => {
+const DataView = ({columnCount = 5, layout = 'left', ...props}: Props) => {
   const [activeItem, setActiveItem] = useState();
   const [selectedRecord, setSelectedRecord] = useState();
 
@@ -178,7 +178,7 @@ const DataView = (props: Props) => {
         label: col.trim().replace(/^\w/, (c) => c.toUpperCase()).replaceAll('_', ' '),
         sortable: false,
         resolve: (item) => resolveValue(item, col),
-        hidden: index > props.columnCount,
+        hidden: index > columnCount,
         index
       };
 
@@ -296,10 +296,10 @@ const DataView = (props: Props) => {
    * If we're using the sidebar layout, set the padding so the fixed positioned menu does not overlap the content.
    */
   useEffect(() => {
-    if (props.layout === 'left' && menuRef && menuRef.current) {
+    if (layout === 'left' && menuRef && menuRef.current) {
       setPaddingLeft(menuRef.current.offsetWidth);
     }
-  }, [menuRef, props.layout]);
+  }, [menuRef, layout]);
 
   /**
    * Calculates the key value when the active item or columns are changed. This is done to force re-rendering
@@ -323,7 +323,7 @@ const DataView = (props: Props) => {
     <div
       className='data-view'
     >
-      { props.layout === 'top' && (
+      { layout === 'top' && (
         <MenuBar
           header={{
             content: props.title
@@ -331,7 +331,7 @@ const DataView = (props: Props) => {
           items={menu}
         />
       )}
-      { props.layout === 'left' && (
+      { layout === 'left' && (
         <MenuSidebar
           contextRef={menuRef}
           header={{
@@ -403,11 +403,6 @@ const DataView = (props: Props) => {
       )}
     </div>
   );
-};
-
-DataView.defaultProps = {
-  columnCount: 5,
-  layout: 'left'
 };
 
 export default DataView;

--- a/packages/semantic-ui/src/components/DatabaseView.js
+++ b/packages/semantic-ui/src/components/DatabaseView.js
@@ -18,7 +18,7 @@ type Props = {
   url: string
 };
 
-const DatabaseView = (props: Props) => {
+const DatabaseView = ({columnCount = Number.MAX_SAFE_INTEGER, ...props}: Props) => {
   const [columns, setColumns] = useState([]);
   const [selectedTable, setSelectedTable] = useState();
   const [tables, setTables] = useState([]);
@@ -74,8 +74,8 @@ const DatabaseView = (props: Props) => {
     label: column.column_name,
     resolve: resolveValue.bind(this, column),
     sortable: true,
-    hidden: index > props.columnCount
-  })), [columns, resolveValue, props.columnCount]);
+    hidden: index > columnCount
+  })), [columns, resolveValue, columnCount]);
 
   return (
     <div
@@ -117,10 +117,6 @@ const DatabaseView = (props: Props) => {
       </div>
     </div>
   );
-};
-
-DatabaseView.defaultProps = {
-  columnCount: Number.MAX_SAFE_INTEGER
 };
 
 export default DatabaseView;

--- a/packages/semantic-ui/src/components/DatePicker.js
+++ b/packages/semantic-ui/src/components/DatePicker.js
@@ -15,7 +15,7 @@ type Props = {
   value: ?Date
 };
 
-const DatePicker = (props: Props) => {
+const DatePicker = ({closeOnSelection = true, ...props}: Props) => {
   const [calendar, setCalendar] = useState(false);
   const calendarWrapper = useRef<any>(null);
 
@@ -58,7 +58,7 @@ const DatePicker = (props: Props) => {
             locale={props.locale}
             onChange={(date) => {
               props.onChange(date);
-              if (props.closeOnSelection) {
+              if (closeOnSelection) {
                 setCalendar(false);
               }
             }}
@@ -76,10 +76,6 @@ const DatePicker = (props: Props) => {
       </Transition>
     </>
   );
-};
-
-DatePicker.defaultProps = {
-  closeOnSelection: true
 };
 
 export default DatePicker;

--- a/packages/semantic-ui/src/components/DescriptorField.js
+++ b/packages/semantic-ui/src/components/DescriptorField.js
@@ -20,23 +20,17 @@ type Props = {
  *
  * @constructor
  */
-const DescriptorField = (props: Props) => (
+const DescriptorField = ({delayInterval = 1000, renderPopup = undefined, popupContent = undefined, ...props}: Props) => (
   <Popup
     className={props.className}
-    content={props.popupContent}
+    content={popupContent}
     hoverable
-    mouseEnterDelay={props.delayInterval}
-    trigger={props.renderPopup
-      ? props.renderPopup()
+    mouseEnterDelay={delayInterval}
+    trigger={renderPopup
+      ? renderPopup()
       : (<span className='text'>{ props.content }</span>)}
     wide
   />
 );
-
-DescriptorField.defaultProps = {
-  delayInterval: 1000,
-  renderPopup: undefined,
-  popupContent: undefined
-};
 
 export default DescriptorField;

--- a/packages/semantic-ui/src/components/DropdownButton.js
+++ b/packages/semantic-ui/src/components/DropdownButton.js
@@ -24,20 +24,20 @@ type Props = {
   value: any
 };
 
-const DropdownButton = (props: Props) => {
+const DropdownButton = ({color = undefined, icon = undefined, selectOnBlur = false, ...props}: Props) => {
   const dropdownRef = useRef();
 
   return (
     <Button.Group
       basic={props.basic}
       className='dropdown-button'
-      color={props.color}
+      color={color}
     >
       <Button
         aria-label='Select'
         content={props.text}
         disabled={props.disabled}
-        icon={props.icon}
+        icon={icon}
         onClick={(e) => dropdownRef.current && dropdownRef.current.handleClick(e)}
       />
       <Dropdown
@@ -50,18 +50,12 @@ const DropdownButton = (props: Props) => {
         options={props.options}
         ref={dropdownRef}
         scrolling={props.scrolling}
-        selectOnBlur={props.selectOnBlur}
+        selectOnBlur={selectOnBlur}
         trigger={<></>}
         value={props.value}
       />
     </Button.Group>
   );
-};
-
-DropdownButton.defaultProps = {
-  color: undefined,
-  icon: undefined,
-  selectOnBlur: false
 };
 
 export default DropdownButton;

--- a/packages/semantic-ui/src/components/DropdownMenu.js
+++ b/packages/semantic-ui/src/components/DropdownMenu.js
@@ -15,7 +15,7 @@ type Props = {
   role?: string
 };
 
-const DropdownMenu = (props: Props) => {
+const DropdownMenu = ({onClick = undefined, ...props}: Props) => {
   const [open, setOpen] = useState(false);
   const ref = useRef();
 
@@ -56,8 +56,8 @@ const DropdownMenu = (props: Props) => {
         {...props}
         open={open}
         onClick={() => {
-          if (props.onClick) {
-            props.onClick();
+          if (onClick) {
+            onClick();
           }
 
           setOpen(false);
@@ -69,10 +69,6 @@ const DropdownMenu = (props: Props) => {
       </Dropdown>
     </Ref>
   );
-};
-
-DropdownMenu.defaultProps = {
-  onClick: undefined
 };
 
 export default DropdownMenu;

--- a/packages/semantic-ui/src/components/EditModal.js
+++ b/packages/semantic-ui/src/components/EditModal.js
@@ -40,7 +40,7 @@ type Props = EditContainerProps & {
  * component uses the <code>EditContainer</code> higher-order component to facilitate all of the editing functionality.
  * This component is responsible for rendering the container in which the editable form is rendered.
  */
-const EditModal = useEditContainer((props: Props) => {
+const EditModal = useEditContainer(({showLoading = true, ...props}: Props) => {
   const OuterComponent = props.component;
 
   const [showToaster, setShowToaster] = useState(false);
@@ -50,7 +50,7 @@ const EditModal = useEditContainer((props: Props) => {
     <OuterComponent
       {...props}
     >
-      { props.showLoading && props.loading && (
+      { showLoading && props.loading && (
         <Dimmer
           active={props.loading}
           inverted
@@ -110,9 +110,5 @@ const EditModal = useEditContainer((props: Props) => {
     </OuterComponent>
   );
 });
-
-EditModal.defaultProps = {
-  showLoading: true
-};
 
 export default EditModal;

--- a/packages/semantic-ui/src/components/Facet.js
+++ b/packages/semantic-ui/src/components/Facet.js
@@ -62,8 +62,8 @@ type Props = {
 /**
  * This component can be used as a wrapper to display various types of facets (list, toggle, etc).
  */
-const Facet = (props: Props) => {
-  const [active, setActive] = useState(props.defaultActive);
+const Facet = ({children = undefined, defaultActive = true, divided = false, visible = true, ...props}: Props) => {
+  const [active, setActive] = useState(defaultActive);
 
   /**
    * Sets the class name variable for the Accordion component.
@@ -73,7 +73,7 @@ const Facet = (props: Props) => {
   const className = useMemo(() => {
     const classNames = ['facet'];
 
-    if (!props.visible) {
+    if (!visible) {
       classNames.push('hidden');
     }
 
@@ -82,7 +82,7 @@ const Facet = (props: Props) => {
     }
 
     return classNames.join(' ');
-  }, [props.className, props.visible]);
+  }, [props.className, visible]);
 
   /**
    * Expose collapse/expand functions on the ref object to allow parent components to imperatively open/close.
@@ -123,21 +123,14 @@ const Facet = (props: Props) => {
         <Accordion.Content
           active={active}
         >
-          { props.children }
+          { children }
         </Accordion.Content>
       </Accordion>
-      { props.divided && (
+      { divided && (
         <Divider />
       )}
     </>
   );
-};
-
-Facet.defaultProps = {
-  children: undefined,
-  defaultActive: true,
-  divided: false,
-  visible: true
 };
 
 export type {

--- a/packages/semantic-ui/src/components/FacetList.js
+++ b/packages/semantic-ui/src/components/FacetList.js
@@ -63,7 +63,7 @@ const OPERATOR_AND = 'and';
  * This component is used with the `useRefinementList` hook from Instant Search Hooks. If the `searchable` prop
  * is "true", the component will also render a search box used to filter the list of facet values.
  */
-const FacetList = forwardRef(({ useRefinementList, ...props }: Props, ref: HTMLElement) => {
+const FacetList = forwardRef(({ useRefinementList, children = undefined, defaultActive = true, divided = false, visible = true, defaultOperator = OPERATOR_OR,  ...props }: Props, ref: HTMLElement) => {
   const [operator, setOperator] = useState(props.defaultOperator || OPERATOR_OR);
 
   const {
@@ -225,10 +225,5 @@ const FacetList = forwardRef(({ useRefinementList, ...props }: Props, ref: HTMLE
     </Facet>
   );
 });
-
-FacetList.defaultProps = {
-  ...Facet.defaultProps,
-  defaultOperator: OPERATOR_OR
-};
 
 export default FacetList;

--- a/packages/semantic-ui/src/components/FacetSlider.js
+++ b/packages/semantic-ui/src/components/FacetSlider.js
@@ -23,7 +23,7 @@ const RADIX = 10;
 /**
  * This component can be used with the `useRange` hook from Instant Search Hooks.
  */
-const FacetSlider = forwardRef(({ useRangeSlider, ...props }: Props, ref: HTMLElement) => {
+const FacetSlider = forwardRef(({ useRangeSlider, children = undefined, defaultActive = true, divided = false, visible = true, editable = false,  ...props }: Props, ref: HTMLElement) => {
   const {
     start,
     range,
@@ -138,10 +138,5 @@ const FacetSlider = forwardRef(({ useRangeSlider, ...props }: Props, ref: HTMLEl
     </Facet>
   );
 });
-
-FacetSlider.defaultProps = {
-  ...Facet.defaultProps,
-  editable: false
-};
 
 export default FacetSlider;

--- a/packages/semantic-ui/src/components/FacetToggle.js
+++ b/packages/semantic-ui/src/components/FacetToggle.js
@@ -10,7 +10,7 @@ type Props = FacetProps & ToggleRefinementProps;
 /**
  * This component is used with the `useToggleRefinement` hook from Instant Search Hooks.
  */
-const FacetToggle = forwardRef(({ useToggleRefinement, ...props }: Props, ref: HTMLElement) => {
+const FacetToggle = forwardRef(({ useToggleRefinement, children = undefined, defaultActive = true, divided = false, visible = true,  ...props }: Props, ref: HTMLElement) => {
   const {
     value: {
       isRefined,
@@ -51,7 +51,5 @@ const FacetToggle = forwardRef(({ useToggleRefinement, ...props }: Props, ref: H
     </Facet>
   );
 });
-
-FacetToggle.defaultProps = Facet.defaultProps;
 
 export default FacetToggle;

--- a/packages/semantic-ui/src/components/FileInputButton.js
+++ b/packages/semantic-ui/src/components/FileInputButton.js
@@ -20,7 +20,7 @@ type Props = {
  * from their file system. This component also accepts
  * all of the props of the Semantic UI <code>Button</code> component.
  */
-const FileInputButton = ({ onSelection, multiple, ...buttonProps }: Props) => {
+const FileInputButton = ({ onSelection, multiple = false,  ...buttonProps }: Props) => {
   const fileInputRef = useRef();
 
   /**
@@ -57,10 +57,6 @@ const FileInputButton = ({ onSelection, multiple, ...buttonProps }: Props) => {
       />
     </>
   );
-};
-
-FileInputButton.defaultProps = {
-  multiple: false
 };
 
 export default FileInputButton;

--- a/packages/semantic-ui/src/components/FileUploadModal.js
+++ b/packages/semantic-ui/src/components/FileUploadModal.js
@@ -109,7 +109,7 @@ const Status = {
  * The <code>FileUploadModal</code> is a convenience wrapper for the <code>FileUpload</code> component, allowing
  * it to render in a modal.
  */
-const FileUploadModal: ComponentType<any> = (props: Props) => {
+const FileUploadModal: ComponentType<any> = ({closeOnComplete = true, itemComponentProps = {}, strategy = Strategy.batch, showPageLoader = true, ...props}: Props) => {
   const [items, setItems] = useState([]);
   const [uploadCount, setUploadCount] = useState(0);
   const [uploading, setUploading] = useState(false);
@@ -178,10 +178,10 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
       props.onComplete();
     }
 
-    if (props.closeOnComplete) {
+    if (closeOnComplete) {
       props.onClose();
     }
-  }, [props.closeOnComplete, props.onClose]);
+  }, [closeOnComplete, props.onClose]);
 
   /**
    * Deletes the passed item from the state.
@@ -344,12 +344,12 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
     // Upload the files
     onValidate()
       .then(() => (
-        props.strategy === Strategy.batch
+        strategy === Strategy.batch
           ? onBatchUpload()
           : onSingleUpload()
       ))
       .finally(onComplete);
-  }, [onBatchUpload, onComplete, onSingleUpload, onValidate, props.strategy]);
+  }, [onBatchUpload, onComplete, onSingleUpload, onValidate, strategy]);
 
   /**
    * Renders the error message for the passed item.
@@ -378,7 +378,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
    * @type {(function(*): (null|*))|*}
    */
   const renderStatus = useCallback((index) => {
-    if (props.strategy !== Strategy.single) {
+    if (strategy !== Strategy.single) {
       return null;
     }
 
@@ -387,7 +387,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
         status={statuses[index]}
       />
     );
-  }, [statuses, props.strategy]);
+  }, [statuses, strategy]);
 
   /**
    * Memoization and case correction for the <code>headerComponent</code> prop.
@@ -412,7 +412,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
           mountNode={mountNode}
           open
         >
-          { props.showPageLoader && (
+          { showPageLoader && (
             <Dimmer
               active={uploading}
               inverted
@@ -423,8 +423,8 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
             </Dimmer>
           )}
           <Modal.Header>
-            { props.strategy === Strategy.batch && i18n.t('FileUploadModal.title') }
-            { props.strategy === Strategy.single && (
+            { strategy === Strategy.batch && i18n.t('FileUploadModal.title') }
+            { strategy === Strategy.single && (
               <FileUploadProgress
                 completed={uploadCount}
                 total={items.length}
@@ -484,7 +484,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
             >
               { _.map(items, (item, index) => (
                 <UploadItem
-                  {...props.itemComponentProps}
+                  {...itemComponentProps}
                   isError={(key) => _.contains(item.errors, key)}
                   isRequired={(key) => !!(props.required && props.required[key])}
                   item={item}
@@ -504,7 +504,7 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
               content={i18n.t('Common.buttons.upload')}
               disabled={uploading || uploadCount > 0 || _.isEmpty(items)}
               icon='cloud upload'
-              loading={uploading && !props.showPageLoader}
+              loading={uploading && !showPageLoader}
               onClick={onUpload}
               primary
             />
@@ -520,13 +520,6 @@ const FileUploadModal: ComponentType<any> = (props: Props) => {
       )}
     </ModalContext.Consumer>
   );
-};
-
-FileUploadModal.defaultProps = {
-  closeOnComplete: true,
-  itemComponentProps: {},
-  strategy: Strategy.batch,
-  showPageLoader: true
 };
 
 export default FileUploadModal;

--- a/packages/semantic-ui/src/components/GoogleMap.js
+++ b/packages/semantic-ui/src/components/GoogleMap.js
@@ -35,11 +35,16 @@ type Props = {
 const DEFAULT_ZOOM = 1;
 const DEFAULT_ZOOM_MARKER = 12;
 
-const GoogleMap = (props: Props) => {
+const GoogleMap = ({containerStyle = {
+    height: '400px'
+  }, defaultCenter = {
+    lat: 0,
+    lng: 0
+  }, ...props}: Props) => {
   // Convert the position props to floats to avoid Javascript errors.
   const position = Map.getPosition(props.position);
 
-  const [center, setCenter] = useState(position || props.defaultCenter);
+  const [center, setCenter] = useState(position || defaultCenter);
   const [map, setMap] = useState();
 
   /**
@@ -96,7 +101,7 @@ const GoogleMap = (props: Props) => {
     <MapComponent
       center={center}
       mapContainerClassName={props.className}
-      mapContainerStyle={props.containerStyle}
+      mapContainerStyle={containerStyle}
       onClick={onDragEnd}
       onLoad={onLoad}
       zoom={zoom}
@@ -111,16 +116,6 @@ const GoogleMap = (props: Props) => {
       )}
     </MapComponent>
   );
-};
-
-GoogleMap.defaultProps = {
-  containerStyle: {
-    height: '400px'
-  },
-  defaultCenter: {
-    lat: 0,
-    lng: 0
-  }
 };
 
 export default GoogleMap;

--- a/packages/semantic-ui/src/components/HorizontalCards.js
+++ b/packages/semantic-ui/src/components/HorizontalCards.js
@@ -34,7 +34,7 @@ type Props = {
   renderMeta?: (item: any) => Element<any> | string,
 };
 
-const HorizontalCards = (props: Props) => {
+const HorizontalCards = ({perPage = 4, ...props}: Props) => {
   const [marginWidth, setMarginWidth] = useState(0);
   const [pageWidth, setPageWidth] = useState(0);
   const [scrollPage, setScrollPage] = useState(0);
@@ -48,8 +48,8 @@ const HorizontalCards = (props: Props) => {
    * @type {function(): {flex: string}}
    */
   const cardStyle = useMemo(() => ({
-    flex: `0 0 ${(pageWidth / props.perPage) - marginWidth}px`
-  }), [pageWidth, marginWidth, props.perPage]);
+    flex: `0 0 ${(pageWidth / perPage) - marginWidth}px`
+  }), [pageWidth, marginWidth, perPage]);
 
   /**
    * Helper function to concatenate class names.
@@ -289,10 +289,6 @@ const HorizontalCards = (props: Props) => {
       </div>
     </div>
   );
-};
-
-HorizontalCards.defaultProps = {
-  perPage: 4
 };
 
 export default HorizontalCards;

--- a/packages/semantic-ui/src/components/ItemList.js
+++ b/packages/semantic-ui/src/components/ItemList.js
@@ -48,7 +48,7 @@ type Props = DataListProps & ItemsProps & {
  * hood, the <code>DataList</code> component handles calling the API, storing the records, filters, etc, and
  * the <code>Items</code> component handles the presentation.
  */
-const ItemList = useDataList((props: Props) => {
+const ItemList = useDataList(({dimmable = true, filters = {}, searchable = true, ...props}: Props) => {
   useEffect(() => {
     const { page } = props;
 
@@ -99,7 +99,7 @@ const ItemList = useDataList((props: Props) => {
   return (
     <>
       <Dimmer
-        active={props.dimmable && props.loading}
+        active={dimmable && props.loading}
         inverted
       >
         <Loader
@@ -119,11 +119,5 @@ const ItemList = useDataList((props: Props) => {
     </>
   );
 });
-
-ItemList.defaultProps = {
-  dimmable: true,
-  filters: {},
-  searchable: true
-};
 
 export default ItemList;

--- a/packages/semantic-ui/src/components/LazyAudio.js
+++ b/packages/semantic-ui/src/components/LazyAudio.js
@@ -30,10 +30,10 @@ type Props = {
   src?: string
 };
 
-const LazyAudio = (props: Props) => {
+const LazyAudio = ({dimmable = true, duration = 1000, preview = undefined, size = 'medium', src = undefined, ...props}: Props) => {
   const [dimmer, setDimmer] = useState(false);
   const [error, setError] = useState(false);
-  const [loaded, setLoaded] = useState(!props.preview);
+  const [loaded, setLoaded] = useState(!preview);
   const [modal, setModal] = useState(false);
   const [visible, setVisible] = useState(false);
 
@@ -47,7 +47,7 @@ const LazyAudio = (props: Props) => {
         <Loader
           active
           inline='centered'
-          size={props.size}
+          size={size}
         />
       </Visibility>
     );
@@ -56,7 +56,7 @@ const LazyAudio = (props: Props) => {
   return (
     <>
       <Transition
-        duration={props.duration}
+        duration={duration}
         visible
       >
         <Dimmer.Dimmable
@@ -70,10 +70,10 @@ const LazyAudio = (props: Props) => {
           { !loaded && (
             <LazyLoader
               active
-              size={props.size}
+              size={size}
             />
           )}
-          { !error && props.preview && (
+          { !error && preview && (
             <Image
               {...props.image}
               onError={() => {
@@ -84,15 +84,15 @@ const LazyAudio = (props: Props) => {
                 setError(false);
                 setLoaded(true);
               }}
-              size={props.size}
-              src={props.preview}
+              size={size}
+              src={preview}
             />
           )}
-          { (error || !props.preview) && (
+          { (error || !preview) && (
             <Image
               {...props.image}
               className='placeholder-image'
-              size={props.size}
+              size={size}
             >
               <Icon
                 name='file audio outline'
@@ -100,14 +100,14 @@ const LazyAudio = (props: Props) => {
               />
             </Image>
           )}
-          { (props.src || props.children) && props.dimmable && (
+          { (src || props.children) && dimmable && (
             <Dimmer
               active={dimmer}
             >
               <div
                 className='buttons'
               >
-                { props.src && (
+                { src && (
                   <Button
                     content={props.playButtonLabel || i18n.t('LazyAudio.buttons.play')}
                     icon='play circle outline'
@@ -128,24 +128,16 @@ const LazyAudio = (props: Props) => {
           )}
         </Dimmer.Dimmable>
       </Transition>
-      { props.src && (
+      { src && (
         <AudioPlayer
           onClose={() => setModal(false)}
           open={modal}
           size='large'
-          src={props.src}
+          src={src}
         />
       )}
     </>
   );
-};
-
-LazyAudio.defaultProps = {
-  dimmable: true,
-  duration: 1000,
-  preview: undefined,
-  size: 'medium',
-  src: undefined
 };
 
 export default LazyAudio;

--- a/packages/semantic-ui/src/components/LazyDocument.js
+++ b/packages/semantic-ui/src/components/LazyDocument.js
@@ -30,10 +30,10 @@ type Props = {
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
 
-const LazyDocument = (props: Props) => {
+const LazyDocument = ({dimmable = true, duration = 1000, pdf = false, preview = undefined, size = 'medium', src = undefined, ...props}: Props) => {
   const [dimmer, setDimmer] = useState(false);
   const [error, setError] = useState(false);
-  const [loaded, setLoaded] = useState(!props.preview);
+  const [loaded, setLoaded] = useState(!preview);
   const [visible, setVisible] = useState(false);
 
   /**
@@ -65,7 +65,7 @@ const LazyDocument = (props: Props) => {
         <Loader
           active
           inline='centered'
-          size={props.size}
+          size={size}
         />
       </Visibility>
     );
@@ -74,7 +74,7 @@ const LazyDocument = (props: Props) => {
   return (
     <>
       <Transition
-        duration={props.duration}
+        duration={duration}
         visible
       >
         <Dimmer.Dimmable
@@ -88,10 +88,10 @@ const LazyDocument = (props: Props) => {
           {!loaded && (
             <LazyLoader
               active
-              size={props.size}
+              size={size}
             />
           )}
-          {!error && props.preview && (
+          {!error && preview && (
             <Image
               {...props.image}
               className={getClassNames()}
@@ -103,18 +103,18 @@ const LazyDocument = (props: Props) => {
                 setError(false);
                 setLoaded(true);
               }}
-              src={props.preview}
-              size={props.size}
+              src={preview}
+              size={size}
             />
           )}
-          {!error && loaded && !props.preview && props.src && props.pdf && (
+          {!error && loaded && !preview && src && pdf && (
             <Image
               {...props.image}
               className={getClassNames()}
-              size={props.size}
+              size={size}
             >
               <Document
-                file={props.src}
+                file={src}
                 onLoadError={(e) => console.log(e.message)}
               >
                 <Page
@@ -125,11 +125,11 @@ const LazyDocument = (props: Props) => {
               </Document>
             </Image>
           )}
-          {(error || (!props.preview && !(props.src && props.pdf))) && (
+          {(error || (!preview && !(src && pdf))) && (
             <Image
               {...props.image}
               className={getClassNames('placeholder-image')}
-              size={props.size}
+              size={size}
             >
               <Icon
                 name='file alternate outline'
@@ -137,7 +137,7 @@ const LazyDocument = (props: Props) => {
               />
             </Image>
           )}
-          {(props.download || props.src || props.children) && props.dimmable && (
+          {(props.download || src || props.children) && dimmable && (
             <Dimmer
               active={dimmer}
             >
@@ -147,7 +147,7 @@ const LazyDocument = (props: Props) => {
                 {props.download && (
                   <DownloadButton
                     primary
-                    url={props.download || props.src}
+                    url={props.download || src}
                   />
                 )}
                 {props.children}
@@ -158,15 +158,6 @@ const LazyDocument = (props: Props) => {
       </Transition>
     </>
   );
-};
-
-LazyDocument.defaultProps = {
-  dimmable: true,
-  duration: 1000,
-  pdf: false,
-  preview: undefined,
-  size: 'medium',
-  src: undefined
 };
 
 export default LazyDocument;

--- a/packages/semantic-ui/src/components/LazyImage.js
+++ b/packages/semantic-ui/src/components/LazyImage.js
@@ -31,7 +31,7 @@ type Props = {
   viewButtonLabel?: string
 };
 
-const LazyImage = (props: Props) => {
+const LazyImage = ({dimmable = true, duration = 1000, size = 'medium', ...props}: Props) => {
   const [dimmer, setDimmer] = useState(false);
   const [error, setError] = useState(false);
   const [loaded, setLoaded] = useState(!(props.src || props.preview));
@@ -71,7 +71,7 @@ const LazyImage = (props: Props) => {
         <Loader
           active
           inline='centered'
-          size={props.size}
+          size={size}
         />
       </Visibility>
     );
@@ -80,7 +80,7 @@ const LazyImage = (props: Props) => {
   return (
     <>
       <Transition
-        duration={props.duration}
+        duration={duration}
         visible
       >
         <Dimmer.Dimmable
@@ -94,7 +94,7 @@ const LazyImage = (props: Props) => {
           { !loaded && (
             <LazyLoader
               active
-              size={props.size}
+              size={size}
             />
           )}
           { !error && (props.preview || props.src) && (
@@ -109,7 +109,7 @@ const LazyImage = (props: Props) => {
                 setError(false);
                 setLoaded(true);
               }}
-              size={props.size}
+              size={size}
               src={props.preview || props.src}
             />
           )}
@@ -117,7 +117,7 @@ const LazyImage = (props: Props) => {
             <Image
               {...props.image}
               className={getClassNames('placeholder-image')}
-              size={props.size}
+              size={size}
             >
               <Icon
                 name='image'
@@ -125,7 +125,7 @@ const LazyImage = (props: Props) => {
               />
             </Image>
           )}
-          { (props.src || props.children) && props.dimmable && (
+          { (props.src || props.children) && dimmable && (
             <Dimmer
               active={dimmer}
             >
@@ -163,12 +163,6 @@ const LazyImage = (props: Props) => {
       )}
     </>
   );
-};
-
-LazyImage.defaultProps = {
-  dimmable: true,
-  duration: 1000,
-  size: 'medium'
 };
 
 export default LazyImage;

--- a/packages/semantic-ui/src/components/LazyLoader.js
+++ b/packages/semantic-ui/src/components/LazyLoader.js
@@ -9,20 +9,15 @@ type Props = {
   size: string
 };
 
-const LazyLoader = (props: Props) => (
+const LazyLoader = ({active = false, size = 'small', ...props}: Props) => (
   <Image
     className='lazy-loader'
-    size={props.size}
+    size={size}
   >
     <Loader
-      active={props.active}
+      active={active}
     />
   </Image>
 );
-
-LazyLoader.defaultProps = {
-  active: false,
-  size: 'small'
-};
 
 export default LazyLoader;

--- a/packages/semantic-ui/src/components/LazyMedia.js
+++ b/packages/semantic-ui/src/components/LazyMedia.js
@@ -48,7 +48,7 @@ const WebContentTypes = [
   'video/mp4'
 ];
 
-const LazyMedia: ComponentType<any> = (props: Props) => {
+const LazyMedia: ComponentType<any> = ({dimmable = true, size = 'medium', ...props}: Props) => {
   const [contentType, setContentType] = useState(props.contentType || '');
   const [name, setName] = useState(props.name);
   const [preview, setPreview] = useState(props.preview);
@@ -126,11 +126,11 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
     if (contentType.startsWith(ContentTypes.image)) {
       return (
         <LazyImage
-          dimmable={props.dimmable}
+          dimmable={dimmable}
           download={downloadUrl}
           preview={preview}
           src={source}
-          size={props.size}
+          size={size}
           viewButtonLabel={viewButtonLabel}
         >
           { renderChildren() }
@@ -141,12 +141,12 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
     if (contentType.startsWith(ContentTypes.video)) {
       return (
         <LazyVideo
-          dimmable={props.dimmable}
+          dimmable={dimmable}
           download={downloadUrl}
           playButtonLabel={viewButtonLabel}
           preview={preview}
           src={source}
-          size={props.size}
+          size={size}
           transcriptions={props.transcriptions}
         >
           { renderChildren() }
@@ -157,12 +157,12 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
     if (contentType.startsWith(ContentTypes.audio)) {
       return (
         <LazyAudio
-          dimmable={props.dimmable}
+          dimmable={dimmable}
           download={downloadUrl}
           playButtonLabel={viewButtonLabel}
           preview={preview}
           src={source}
-          size={props.size}
+          size={size}
         >
           { renderChildren() }
         </LazyAudio>
@@ -171,17 +171,17 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
 
     return (
       <LazyDocument
-        dimmable={props.dimmable}
+        dimmable={dimmable}
         download={downloadUrl}
         pdf={contentType === ContentTypes.pdf}
         preview={preview}
         src={source}
-        size={props.size}
+        size={size}
       >
         { renderChildren() }
       </LazyDocument>
     );
-  }, [contentType, preview, source, props.dimmable, downloadUrl, props.size]);
+  }, [contentType, preview, source, dimmable, downloadUrl, size]);
 
   /**
    * Renders the upload message.
@@ -244,11 +244,6 @@ const LazyMedia: ComponentType<any> = (props: Props) => {
       { renderMessage() }
     </div>
   );
-};
-
-LazyMedia.defaultProps = {
-  dimmable: true,
-  size: 'medium'
 };
 
 export default LazyMedia;

--- a/packages/semantic-ui/src/components/LazyVideo.js
+++ b/packages/semantic-ui/src/components/LazyVideo.js
@@ -39,7 +39,7 @@ type Props = {
   transcriptions?: Array<Transcription>
 };
 
-const LazyVideo = (props: Props) => {
+const LazyVideo = ({autoPlay = false, dimmable = true, duration = 1000, embedded = false, icon = 'right circle arrow', size = 'medium', ...props}: Props) => {
   const [dimmer, setDimmer] = useState(false);
   const [error, setError] = useState(false);
   const [loaded, setLoaded] = useState(!(props.preview || props.src));
@@ -75,7 +75,7 @@ const LazyVideo = (props: Props) => {
         <Loader
           active
           inline='centered'
-          size={props.size}
+          size={size}
         />
       </Visibility>
     );
@@ -84,7 +84,7 @@ const LazyVideo = (props: Props) => {
   return (
     <>
       <Transition
-        duration={props.duration}
+        duration={duration}
         visible
       >
         <Dimmer.Dimmable
@@ -98,7 +98,7 @@ const LazyVideo = (props: Props) => {
           { !loaded && (
             <LazyLoader
               active
-              size={props.size}
+              size={size}
             />
           )}
           { !error && props.preview && (
@@ -114,14 +114,14 @@ const LazyVideo = (props: Props) => {
                 setLoaded(true);
               }}
               src={props.preview}
-              size={props.size}
+              size={size}
             />
           )}
           { !error && !props.preview && props.src && (
             <Image
               {...props.image}
               className={getClassNames()}
-              size={props.size}
+              size={size}
             >
               <video
                 onError={() => {
@@ -140,7 +140,7 @@ const LazyVideo = (props: Props) => {
             <Image
               {...props.image}
               className={getClassNames('placeholder-image')}
-              size={props.size}
+              size={size}
             >
               <Icon
                 name='image'
@@ -148,7 +148,7 @@ const LazyVideo = (props: Props) => {
               />
             </Image>
           )}
-          { (props.src || props.children) && props.dimmable && (
+          { (props.src || props.children) && dimmable && (
             <Dimmer
               active={dimmer}
             >
@@ -178,9 +178,9 @@ const LazyVideo = (props: Props) => {
       </Transition>
       { props.src && (
         <VideoPlayer
-          autoPlay={props.autoPlay}
-          embedded={props.embedded}
-          icon={props.icon}
+          autoPlay={autoPlay}
+          embedded={embedded}
+          icon={icon}
           onClose={() => setModal(false)}
           open={modal}
           placeholder={props.preview}
@@ -191,15 +191,6 @@ const LazyVideo = (props: Props) => {
       )}
     </>
   );
-};
-
-LazyVideo.defaultProps = {
-  autoPlay: false,
-  dimmable: true,
-  duration: 1000,
-  embedded: false,
-  icon: 'right circle arrow',
-  size: 'medium'
 };
 
 export default LazyVideo;

--- a/packages/semantic-ui/src/components/ListTable.js
+++ b/packages/semantic-ui/src/components/ListTable.js
@@ -54,7 +54,10 @@ type Props = DataListProps & DataTableProps & {
  * back-end implementing the <code>resource-api</code>. See the
  * <a href="https://github.com/performant-software/resource-api">GitHub page</a> for more details.
  */
-const ListTable = useDataList((props: Props) => {
+const ListTable = useDataList(({configurable = true, tableProps = {
+    celled: true,
+    sortable: true
+  }, ...props}: Props) => {
   const prevColumns = Hooks.usePrevious(props.columns);
 
   /**
@@ -118,14 +121,6 @@ const ListTable = useDataList((props: Props) => {
     />
   );
 });
-
-ListTable.defaultProps = {
-  configurable: true,
-  tableProps: {
-    celled: true,
-    sortable: true
-  }
-};
 
 export default ListTable;
 

--- a/packages/semantic-ui/src/components/PhotoViewer.js
+++ b/packages/semantic-ui/src/components/PhotoViewer.js
@@ -14,7 +14,7 @@ type Props = {
   size?: string
 };
 
-const PhotoViewer = (props: Props) => {
+const PhotoViewer = ({size = 'small', ...props}: Props) => {
   const [error, setError] = useState(false);
 
   return (
@@ -27,7 +27,7 @@ const PhotoViewer = (props: Props) => {
           mountNode={mountNode}
           onClose={props.onClose.bind(this)}
           open={props.open}
-          size={props.size}
+          size={size}
         >
           <Modal.Content>
             { error && (
@@ -50,10 +50,6 @@ const PhotoViewer = (props: Props) => {
       )}
     </ModalContext.Consumer>
   );
-};
-
-PhotoViewer.defaultProps = {
-  size: 'small'
 };
 
 export default PhotoViewer;

--- a/packages/semantic-ui/src/components/PlayButton.js
+++ b/packages/semantic-ui/src/components/PlayButton.js
@@ -22,28 +22,22 @@ type Props = {
 /**
  * This component can be used as a toggle for playing media.
  */
-const PlayButton = (props: Props) => (
+const PlayButton = ({onClick = undefined, size = 'massive', style = undefined, ...props}: Props) => (
   <Button
     className='play-button'
     color='black'
     icon='play'
     onClick={(e) => {
-      if (props.onClick) {
+      if (onClick) {
         e.stopPropagation();
 
-        // $FlowFixMe - Not really an issue since we're checking for props.onClick above.
-        props.onClick();
+        // $FlowFixMe - Not really an issue since we're checking for onClick above.
+        onClick();
       }
     }}
-    size={props.size}
-    style={props.style}
+    size={size}
+    style={style}
   />
 );
-
-PlayButton.defaultProps = {
-  onClick: undefined,
-  size: 'massive',
-  style: undefined
-};
 
 export default PlayButton;

--- a/packages/semantic-ui/src/components/SearchPagination.js
+++ b/packages/semantic-ui/src/components/SearchPagination.js
@@ -16,7 +16,7 @@ type Props = PaginationProps & {
  * that can be selected by the user. If the `scrollToTop` prop is set to `true`, the window will scroll to the top
  * after applying a new value.
  */
-const SearchPagination = ({ usePagination, ...props }: Props) => {
+const SearchPagination = ({ usePagination, scrollToTop = false,  ...props }: Props) => {
   const { currentRefinement, nbPages: pages, refine } = usePagination(props);
   const onPageChange = useCallback((e, { activePage }) => refine(activePage - 1), [refine]);
 
@@ -43,10 +43,6 @@ const SearchPagination = ({ usePagination, ...props }: Props) => {
       totalPages={pages}
     />
   );
-};
-
-SearchPagination.defaultProps = {
-  scrollToTop: false
 };
 
 export default SearchPagination;

--- a/packages/semantic-ui/src/components/SearchResults.js
+++ b/packages/semantic-ui/src/components/SearchResults.js
@@ -55,7 +55,7 @@ type Props = HitsProps & {
  * This component is used with the `useHits` hook from Instant Search Hooks and renders a pass-through to the
  * `ItemCollection` component.
  */
-const SearchResults = ({ useHits, ...props }: Props) => {
+const SearchResults = ({ useHits, as = undefined, asProps = undefined, link = undefined, renderDescription = undefined, renderEmptyList = undefined, renderExtra = undefined, renderHeader = undefined, renderImage = undefined, renderMeta = undefined,  ...props }: Props) => {
   const { hits } = useHits(props);
 
   const {
@@ -85,18 +85,6 @@ const SearchResults = ({ useHits, ...props }: Props) => {
       renderMeta={renderMeta}
     />
   );
-};
-
-SearchResults.defaultProps = {
-  as: undefined,
-  asProps: undefined,
-  link: undefined,
-  renderDescription: undefined,
-  renderEmptyList: undefined,
-  renderExtra: undefined,
-  renderHeader: undefined,
-  renderImage: undefined,
-  renderMeta: undefined
 };
 
 export default SearchResults;

--- a/packages/semantic-ui/src/components/Section.js
+++ b/packages/semantic-ui/src/components/Section.js
@@ -10,8 +10,8 @@ type Props = {
   visible?: boolean
 }
 
-const Section = (props: Props) => {
-  if (!props.visible) {
+const Section = ({divided = true, header = undefined, visible = true, ...props}: Props) => {
+  if (!visible) {
     return null;
   }
 
@@ -19,23 +19,17 @@ const Section = (props: Props) => {
     <div
       className='section'
     >
-      { props.header && (
+      { header && (
         <Header
-          content={props.header}
+          content={header}
         />
       )}
       { props.children }
       <Divider
-        hidden={!props.divided}
+        hidden={!divided}
       />
     </div>
   );
-};
-
-Section.defaultProps = {
-  divided: true,
-  header: undefined,
-  visible: true
 };
 
 export default Section;

--- a/packages/semantic-ui/src/components/Selectize.js
+++ b/packages/semantic-ui/src/components/Selectize.js
@@ -196,17 +196,17 @@ const SelectizeGrid = useDataList(useList((props: GridProps) => {
   );
 }));
 
-const Selectize = (props: Props) => {
+const Selectize = ({centered = false, modal = undefined, multiple = true, searchable = true, selectedItems = [], ...props}: Props) => {
   const [error, setError] = useState(false);
   const [selectedItem, setSelectedItem] = useState();
-  const [selectedItems, setSelectedItems] = useState(props.selectedItems || []);
+  const [selectedItems, setSelectedItems] = useState(selectedItems || []);
 
   /**
    * Sets the allowMultiple prop to "true" if the multiple prop is a boolean or non-zero integer.
    *
    * @type {boolean}
    */
-  const allowMultiple = useMemo(() => !!props.multiple, [props.multiple]);
+  const allowMultiple = useMemo(() => !!multiple, [multiple]);
 
   /**
    * Sets the allowed number of items that can be selected. If the multiple prop is a boolean, this will be
@@ -215,8 +215,8 @@ const Selectize = (props: Props) => {
    * @type {boolean|number}
    */
   const allowedCount = useMemo(() => (
-    _.isNumber(props.multiple) ? props.multiple : Number.MAX_SAFE_INTEGER
-  ), [props.multiple]);
+    _.isNumber(multiple) ? multiple : Number.MAX_SAFE_INTEGER
+  ), [multiple]);
 
   /**
    * Returns true if the passed item is selected.
@@ -246,7 +246,7 @@ const Selectize = (props: Props) => {
         item
       ]);
     }
-  }, [isSelected, props.multiple]);
+  }, [isSelected, multiple]);
 
   /**
    * Selects or deselects the single passed item.
@@ -268,19 +268,19 @@ const Selectize = (props: Props) => {
    * @type {(function(*=): (*))|*}
    */
   const onSave = useCallback((item) => {
-    if (props.modal && props.modal.onSave) {
-      return props.modal.onSave(item).then((saved) => onSelect(saved));
+    if (modal && modal.onSave) {
+      return modal.onSave(item).then((saved) => onSelect(saved));
     }
 
     return Promise.resolve();
-  }, [onSelect, props.modal]);
+  }, [onSelect, modal]);
 
   return (
     <ModalContext.Consumer>
       { (mountNode) => (
         <Modal
           as={Form}
-          centered={props.centered}
+          centered={centered}
           className='selectize'
           mountNode={mountNode}
           noValidate
@@ -333,14 +333,6 @@ const Selectize = (props: Props) => {
       )}
     </ModalContext.Consumer>
   );
-};
-
-Selectize.defaultProps = {
-  centered: false,
-  modal: undefined,
-  multiple: true,
-  searchable: true,
-  selectedItems: []
 };
 
 export default Selectize;

--- a/packages/semantic-ui/src/components/SelectizeImageHeader.js
+++ b/packages/semantic-ui/src/components/SelectizeImageHeader.js
@@ -46,20 +46,20 @@ type CardProps = {
 
 const DEFAULT_PER_PAGE = 5;
 
-const SelectizeCard = (props: CardProps) => (
+const SelectizeCard = ({header = undefined, image = undefined, meta = undefined, renderExtra = undefined, ...props}: CardProps) => (
   <Card
     raised={props.selected}
     link
     onClick={props.onClick}
   >
-    { props.image && _.isString(props.image) && (
+    { image && _.isString(image) && (
       <Image
         size='small'
-        src={props.image}
+        src={image}
       />
     )}
-    { !!props.image && !_.isString(props.image) && props.image }
-    { !props.image && (
+    { !!image && !_.isString(image) && image }
+    { !image && (
       <Segment
         placeholder
       >
@@ -70,17 +70,17 @@ const SelectizeCard = (props: CardProps) => (
       </Segment>
     )}
     <Card.Content>
-      { props.header && (
+      { header && (
         <Card.Header>
           <Header
             as='h6'
-            content={props.header}
+            content={header}
           />
         </Card.Header>
       )}
-      { props.meta && (
+      { meta && (
         <Card.Meta
-          content={props.meta}
+          content={meta}
         />
       )}
       { props.description && (
@@ -112,14 +112,7 @@ const SelectizeCard = (props: CardProps) => (
   </Card>
 );
 
-SelectizeCard.defaultProps = {
-  header: undefined,
-  image: undefined,
-  meta: undefined,
-  renderExtra: undefined
-};
-
-const SelectizeImageHeader = (props: Props) => {
+const SelectizeImageHeader = ({collapsable = true, onItemClick = () => {}, perPage = DEFAULT_PER_PAGE, renderExtra = undefined, ...props}: Props) => {
   const [page, setPage] = useState(1);
   const [pages, setPages] = useState(0);
   const [collapsed, setCollapsed] = useState(false);
@@ -133,14 +126,14 @@ const SelectizeImageHeader = (props: Props) => {
     let records = null;
 
     if (page && props.selectedItems && props.selectedItems.length) {
-      const startIndex = (page - 1) * (props.perPage || DEFAULT_PER_PAGE);
-      const endIndex = startIndex + (props.perPage || DEFAULT_PER_PAGE);
+      const startIndex = (page - 1) * (perPage || DEFAULT_PER_PAGE);
+      const endIndex = startIndex + (perPage || DEFAULT_PER_PAGE);
 
       records = props.selectedItems.slice(startIndex, endIndex);
     }
 
     return records;
-  }, [page, props.perPage, props.selectedItems]);
+  }, [page, perPage, props.selectedItems]);
 
   /**
    * Sets the pagination label.
@@ -148,12 +141,12 @@ const SelectizeImageHeader = (props: Props) => {
    * @type {string}
    */
   const pagination = useMemo(() => {
-    const startIndex = (page - 1) * (props.perPage || DEFAULT_PER_PAGE);
-    const endIndex = startIndex + (props.perPage || DEFAULT_PER_PAGE);
+    const startIndex = (page - 1) * (perPage || DEFAULT_PER_PAGE);
+    const endIndex = startIndex + (perPage || DEFAULT_PER_PAGE);
     const total = props.selectedItems.length;
 
     return `${startIndex + 1} - ${Math.min(endIndex, total)} of ${total}`;
-  }, [page, props.perPage, props.selectedItems]);
+  }, [page, perPage, props.selectedItems]);
 
   /**
    * Changes the current page number. If the next page is invalid, we move to the first page or last page.
@@ -176,10 +169,10 @@ const SelectizeImageHeader = (props: Props) => {
    * Set the number of pages when the perPage or selectedItems props change.
    */
   useEffect(() => {
-    if (props.perPage && props.selectedItems) {
-      setPages(Math.ceil(props.selectedItems.length / props.perPage));
+    if (perPage && props.selectedItems) {
+      setPages(Math.ceil(props.selectedItems.length / perPage));
     }
-  }, [props.perPage, props.selectedItems]);
+  }, [perPage, props.selectedItems]);
 
   /**
    * If we're removing the last item on the page, decrement the page by 1.
@@ -213,22 +206,22 @@ const SelectizeImageHeader = (props: Props) => {
               onClick={onPageChange.bind(this, -1)}
             />
             <Card.Group
-              itemsPerRow={props.perPage}
+              itemsPerRow={perPage}
             >
               { _.map(items, (item) => (
                 <SelectizeCard
                   description={props.renderDescription && props.renderDescription(item)}
-                  extra={props.renderExtra && props.renderExtra(item)}
+                  extra={renderExtra && renderExtra(item)}
                   header={props.renderHeader && props.renderHeader(item)}
                   image={props.renderImage && props.renderImage(item)}
                   meta={props.renderMeta && props.renderMeta(item)}
                   key={item.id}
                   onClick={() => (
                     props.selectedItem === item
-                      ? props.onItemClick(null)
-                      : props.onItemClick(item)
+                      ? onItemClick(null)
+                      : onItemClick(item)
                   )}
-                  onDelete={() => props.onItemClick(item)}
+                  onDelete={() => onItemClick(item)}
                   selected={item === props.selectedItem}
                 />
               ))}
@@ -249,7 +242,7 @@ const SelectizeImageHeader = (props: Props) => {
         <div />
         <div>{ pagination }</div>
         <div>
-          { props.collapsable && (
+          { collapsable && (
             <Button
               as='a'
               basic
@@ -264,13 +257,6 @@ const SelectizeImageHeader = (props: Props) => {
       </div>
     </Segment>
   );
-};
-
-SelectizeImageHeader.defaultProps = {
-  collapsable: true,
-  onItemClick: () => {},
-  perPage: DEFAULT_PER_PAGE,
-  renderExtra: undefined
 };
 
 export default SelectizeImageHeader;

--- a/packages/semantic-ui/src/components/SimpleEditPage.js
+++ b/packages/semantic-ui/src/components/SimpleEditPage.js
@@ -72,7 +72,10 @@ type Props = EditContainerProps & {
  * This component can be used to render the layout for a form/page with edit capabilities. Use in conjunction with the
  * `withEditPage` higher-order component for a fully fledged record editing environment.
  */
-const SimpleEditPage: any = (props: Props) => {
+const SimpleEditPage: any = ({editable = true, menuProps = {
+    pointing: true,
+    secondary: true
+  }, ...props}: Props) => {
   const [currentTab, setCurrentTab] = useState();
   const [saved, setSaved] = useState(false);
 
@@ -119,7 +122,7 @@ const SimpleEditPage: any = (props: Props) => {
   const renderTabs = useCallback(() => {
     const menu = (
       <Menu
-        {...props.menuProps}
+        {...menuProps}
       >
         { tabs?.length > 1 && _.map(tabs, (item) => (
           <Menu.Item
@@ -136,7 +139,7 @@ const SimpleEditPage: any = (props: Props) => {
           <Menu.Item
             className='button-container'
           >
-            { props.editable && (
+            { editable && (
               <Button
                 content={i18n.t('Common.buttons.save')}
                 disabled={props.loading || props.saving}
@@ -235,14 +238,6 @@ const SimpleEditPage: any = (props: Props) => {
       </Grid.Row>
     </Grid>
   );
-};
-
-SimpleEditPage.defaultProps = {
-  editable: true,
-  menuProps: {
-    pointing: true,
-    secondary: true
-  }
 };
 
 const Tab = (props: any) => props.children;

--- a/packages/semantic-ui/src/components/Thumbnail.js
+++ b/packages/semantic-ui/src/components/Thumbnail.js
@@ -9,7 +9,7 @@ type Props = {
   style?: any
 };
 
-const Thumbnail = (props: Props) => {
+const Thumbnail = ({style = {}, ...props}: Props) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -28,7 +28,7 @@ const Thumbnail = (props: Props) => {
           {...props}
           onLoad={() => setLoading(false)}
           style={{
-            ...props.style,
+            ...style,
             visibility: loading ? 'hidden' : 'visible'
           }}
         />
@@ -38,10 +38,6 @@ const Thumbnail = (props: Props) => {
       )}
     </div>
   );
-};
-
-Thumbnail.defaultProps = {
-  style: {}
 };
 
 export default Thumbnail;

--- a/packages/semantic-ui/src/components/Toaster.js
+++ b/packages/semantic-ui/src/components/Toaster.js
@@ -37,16 +37,16 @@ const TRANSITION_DURATION = 700;
  * This is a simple messaging pane that drops from the top of
  * the page and displays that child elements
  */
-const Toaster = (props: Props) => {
+const Toaster = ({onDismiss = undefined, timeout = 3000, type = Toaster.MessageTypes.info, ...props}: Props) => {
   const [visible, setVisible] = useState(true);
 
   /*
    * If a timeout is provided, automatically hide the message after <code>timeout</code> milliseconds.
    */
-  if (props.timeout && props.timeout > 0) {
+  if (timeout && timeout > 0) {
     _.delay(() => {
       setVisible(false);
-    }, props.timeout);
+    }, timeout);
   }
 
   /*
@@ -54,8 +54,8 @@ const Toaster = (props: Props) => {
    * by <code>TRANSITION_DURATION</code> milliseconds in order for the transition to run.
    */
   useEffect(() => {
-    if (!visible && props.onDismiss) {
-      _.delay(props.onDismiss.bind(this), TRANSITION_DURATION);
+    if (!visible && onDismiss) {
+      _.delay(onDismiss.bind(this), TRANSITION_DURATION);
     }
   }, [visible]);
 
@@ -68,11 +68,11 @@ const Toaster = (props: Props) => {
     >
       <Message
         className='toaster'
-        info={props.type === Toaster.MessageTypes.info}
-        negative={props.type === Toaster.MessageTypes.negative}
+        info={type === Toaster.MessageTypes.info}
+        negative={type === Toaster.MessageTypes.negative}
         onDismiss={() => setVisible(false)}
-        positive={props.type === Toaster.MessageTypes.positive}
-        warning={props.type === Toaster.MessageTypes.warning}
+        positive={type === Toaster.MessageTypes.positive}
+        warning={type === Toaster.MessageTypes.warning}
       >
         { props.children }
       </Message>
@@ -85,12 +85,6 @@ Toaster.MessageTypes = {
   negative: 'negative',
   positive: 'positive',
   warning: 'warning'
-};
-
-Toaster.defaultProps = {
-  onDismiss: undefined,
-  timeout: 3000,
-  type: Toaster.MessageTypes.info
 };
 
 export default Toaster;

--- a/packages/semantic-ui/src/components/VideoFrameSelector.js
+++ b/packages/semantic-ui/src/components/VideoFrameSelector.js
@@ -26,9 +26,13 @@ const INTERVAL_STEP = 1;
 const MIN_INTERVAL = 1;
 const MAX_INTERVAL = 300;
 
-const VideoFrameSelector = (props: Props) => {
+const VideoFrameSelector = ({button = {
+    basic: true,
+    content: i18n.t('VideoFrameSelector.buttons.select'),
+    icon: 'image'
+  }, defaultInterval = 15, title = i18n.t('VideoFrameSelector.title'), ...props}: Props) => {
   const [duration, setDuration] = useState(0);
-  const [interval, setInterval] = useState(props.defaultInterval);
+  const [interval, setInterval] = useState(defaultInterval);
   const [time, setTime] = useState(0);
   const [modal, setModal] = useState(false);
 
@@ -43,7 +47,7 @@ const VideoFrameSelector = (props: Props) => {
   return (
     <>
       <Button
-        {...props.button}
+        {...button}
         onClick={() => setModal(true)}
       />
       <ModalContext.Consumer>
@@ -56,7 +60,7 @@ const VideoFrameSelector = (props: Props) => {
             size='small'
           >
             <Modal.Header
-              content={props.title}
+              content={title}
             />
             <Modal.Content>
               <Segment>
@@ -144,16 +148,6 @@ const VideoFrameSelector = (props: Props) => {
       </ModalContext.Consumer>
     </>
   );
-};
-
-VideoFrameSelector.defaultProps = {
-  button: {
-    basic: true,
-    content: i18n.t('VideoFrameSelector.buttons.select'),
-    icon: 'image'
-  },
-  defaultInterval: 15,
-  title: i18n.t('VideoFrameSelector.title')
 };
 
 export default withTranslation()(VideoFrameSelector);

--- a/packages/semantic-ui/src/components/VideoPlayer.js
+++ b/packages/semantic-ui/src/components/VideoPlayer.js
@@ -37,7 +37,7 @@ type Props = {
   video: string
 };
 
-const VideoPlayer = (props: Props) => {
+const VideoPlayer = ({autoPlay = false, embedded = false, icon = 'right circle arrow', size = 'small', ...props}: Props) => {
   const [error, setError] = useState(false);
 
   const embedRef = useRef();
@@ -65,7 +65,7 @@ const VideoPlayer = (props: Props) => {
           mountNode={mountNode}
           onClose={props.onClose.bind(this)}
           open={props.open}
-          size={props.size}
+          size={size}
         >
           <Modal.Content>
             { error && (
@@ -75,22 +75,22 @@ const VideoPlayer = (props: Props) => {
                 icon='exclamation circle'
               />
             )}
-            { props.embedded && (
+            { embedded && (
               <Ref
                 innerRef={embedRef}
               >
                 <Embed
-                  active={props.autoPlay}
-                  icon={props.icon}
-                  iframe={props.autoPlay ? { allow: 'autoplay' } : undefined}
+                  active={autoPlay}
+                  icon={icon}
+                  iframe={autoPlay ? { allow: 'autoplay' } : undefined}
                   placeholder={props.placeholder}
-                  url={`${props.video}${props.autoPlay ? '?autoplay=true' : ''}`}
+                  url={`${props.video}${autoPlay ? '?autoplay=true' : ''}`}
                 />
               </Ref>
             )}
-            { !props.embedded && (
+            { !embedded && (
               <video
-                autoPlay={props.autoPlay}
+                autoPlay={autoPlay}
                 controls
                 onError={() => setError(true)}
                 src={props.video}
@@ -112,13 +112,6 @@ const VideoPlayer = (props: Props) => {
       )}
     </ModalContext.Consumer>
   );
-};
-
-VideoPlayer.defaultProps = {
-  autoPlay: false,
-  embedded: false,
-  icon: 'right circle arrow',
-  size: 'small'
 };
 
 export default VideoPlayer;

--- a/packages/semantic-ui/src/components/ViewXML.js
+++ b/packages/semantic-ui/src/components/ViewXML.js
@@ -16,10 +16,17 @@ type Props = {
   xml: string
 };
 
-const ViewXML = (props: Props) => {
+const ViewXML = ({opener = {
+    component: Button,
+    props: {
+      content: i18n.t('ViewXML.buttons.view')
+    }
+  }, style = {
+    maxHeight: '70vh'
+  }, ...props}: Props) => {
   const [showModal, setShowModal] = useState(false);
-  const OpenerComponent = props.opener.component;
-  const openerProps = props.opener.props;
+  const OpenerComponent = opener.component;
+  const openerProps = opener.props;
 
   return (
     <ModalContext.Consumer>
@@ -61,18 +68,6 @@ const ViewXML = (props: Props) => {
       )}
     </ModalContext.Consumer>
   );
-};
-
-ViewXML.defaultProps = {
-  opener: {
-    component: Button,
-    props: {
-      content: i18n.t('ViewXML.buttons.view')
-    }
-  },
-  style: {
-    maxHeight: '70vh'
-  }
 };
 
 export default ViewXML;

--- a/packages/shared/src/components/InfiniteScroll.js
+++ b/packages/shared/src/components/InfiniteScroll.js
@@ -18,7 +18,7 @@ type Props = {
   onBottomReached: () => void
 };
 
-const InfiniteScroll = (props: Props) => {
+const InfiniteScroll = ({offset = 0, ...props}: Props) => {
   const [height, setHeight] = useState(0);
   const containerRef = useRef();
 
@@ -48,7 +48,7 @@ const InfiniteScroll = (props: Props) => {
     if (element) {
       const { scrollTop, clientHeight, scrollHeight } = element;
 
-      if ((scrollTop + clientHeight) >= (scrollHeight - props.offset)) {
+      if ((scrollTop + clientHeight) >= (scrollHeight - offset)) {
         props.onBottomReached();
       }
     }
@@ -117,10 +117,6 @@ const InfiniteScroll = (props: Props) => {
       { props.children }
     </Component>
   );
-};
-
-InfiniteScroll.defaultProps = {
-  offset: 0
 };
 
 export default InfiniteScroll;

--- a/packages/shared/src/components/Keyboard.js
+++ b/packages/shared/src/components/Keyboard.js
@@ -17,7 +17,7 @@ const KEY_SHIFT = '{shift}';
 const LAYOUT_DEFAULT = 'default';
 const LAYOUT_SHIFT = 'shift';
 
-const KeyboardSimple = (props: Props) => {
+const KeyboardSimple = ({keyboardClass = 'simple-keyboard', ...props}: Props) => {
   const keyboardRef = useRef();
 
   // Toggles the layout name for Shift and CapsLock keys.
@@ -34,7 +34,7 @@ const KeyboardSimple = (props: Props) => {
   // Sets up the keyboard reference and the initial value when the component is first rendered.
   useEffect(() => {
     const { layout, onChange } = props;
-    keyboardRef.current = new Keyboard(`.${props.keyboardClass}`, { ...layout, onChange, onKeyPress });
+    keyboardRef.current = new Keyboard(`.${keyboardClass}`, { ...layout, onChange, onKeyPress });
     keyboardRef.current.setInput(props.value);
   }, []);
 
@@ -45,11 +45,7 @@ const KeyboardSimple = (props: Props) => {
     }
   }, [props.value]);
 
-  return <div className={props.keyboardClass} />;
-};
-
-KeyboardSimple.defaultProps = {
-  keyboardClass: 'simple-keyboard'
+  return <div className={keyboardClass} />;
 };
 
 export default KeyboardSimple;

--- a/packages/shared/src/components/RichTextArea.js
+++ b/packages/shared/src/components/RichTextArea.js
@@ -17,28 +17,7 @@ const ReactQuill = lazy(() => import('react-quill'));
 const SEARCH_EMPTY = '<p><br></p>';
 const REPLACE_EMPTY = '';
 
-const RichTextArea = withSuspense((props: Props) => (
-  <ReactQuill
-    className='rich-text-area'
-    formats={props.formats}
-    modules={props.modules}
-    onChange={(value) => {
-      let newValue = value;
-
-      if (value === SEARCH_EMPTY) {
-        newValue = REPLACE_EMPTY;
-      }
-
-      props.onChange(newValue);
-    }}
-    placeholder={props.placeholder}
-    theme='snow'
-    value={props.value}
-  />
-));
-
-RichTextArea.defaultProps = {
-  formats: [
+const RichTextArea = withSuspense(({formats = [
     'header',
     'font',
     'size',
@@ -53,8 +32,7 @@ RichTextArea.defaultProps = {
     'link',
     'image',
     'video'
-  ],
-  modules: {
+  ], modules = {
     toolbar: [[{
       header: '1'
     }, {
@@ -86,9 +64,25 @@ RichTextArea.defaultProps = {
     clipboard: {
       matchVisual: false
     }
-  },
-  placeholder: undefined
-};
+  }, placeholder = undefined, ...props}: Props) => (
+  <ReactQuill
+    className='rich-text-area'
+    formats={formats}
+    modules={modules}
+    onChange={(value) => {
+      let newValue = value;
+
+      if (value === SEARCH_EMPTY) {
+        newValue = REPLACE_EMPTY;
+      }
+
+      props.onChange(newValue);
+    }}
+    placeholder={placeholder}
+    theme='snow'
+    value={props.value}
+  />
+));
 
 export default RichTextArea;
 export type { Props as RichTextAreaProps };

--- a/packages/user-defined-fields/src/components/UserDefinedFieldsEmbeddedList.js
+++ b/packages/user-defined-fields/src/components/UserDefinedFieldsEmbeddedList.js
@@ -23,7 +23,11 @@ const OMIT_PROPS = [
 
 const DEFAULT_ORDER = 0;
 
-const UserDefinedFieldsEmbeddedList = (props: Props) => {
+const UserDefinedFieldsEmbeddedList = ({actions = [{
+    name: 'edit'
+  }, {
+    name: 'delete'
+  }], ...props}: Props) => {
   /**
    * Returns true if the passed column should be hidden by default.
    *
@@ -73,14 +77,6 @@ const UserDefinedFieldsEmbeddedList = (props: Props) => {
       }}
     />
   );
-};
-
-UserDefinedFieldsEmbeddedList.defaultProps = {
-  actions: [{
-    name: 'edit'
-  }, {
-    name: 'delete'
-  }]
 };
 
 export default UserDefinedFieldsEmbeddedList;

--- a/packages/user-defined-fields/src/components/UserDefinedFieldsList.js
+++ b/packages/user-defined-fields/src/components/UserDefinedFieldsList.js
@@ -27,7 +27,11 @@ const OMIT_PROPS = [
 
 const DEFAULT_ORDER = 0;
 
-const UserDefinedFieldsList: ComponentType<any> = (props: Props) => {
+const UserDefinedFieldsList: ComponentType<any> = ({actions = [{
+    name: 'edit'
+  }, {
+    name: 'delete'
+  }], ...props}: Props) => {
   /**
    * Returns true if the passed column should be hidden by default.
    *
@@ -81,14 +85,6 @@ const UserDefinedFieldsList: ComponentType<any> = (props: Props) => {
       onSave={(udf) => UserDefinedFieldsService.save(udf)}
     />
   );
-};
-
-UserDefinedFieldsList.defaultProps = {
-  actions: [{
-    name: 'edit'
-  }, {
-    name: 'delete'
-  }]
 };
 
 export default UserDefinedFieldsList;

--- a/packages/visualize/src/components/TreeGraph.js
+++ b/packages/visualize/src/components/TreeGraph.js
@@ -66,11 +66,16 @@ const Orientation = {
   vertical: 'vertical'
 };
 
-const TreeGraph = (props: Props) => {
+const TreeGraph = ({layout = Layout.cartesian, linkColor = '#B2B09B', linkType = LinkType.line, linkWidth = 1, margin = {
+    top: 30,
+    left: 30,
+    right: 30,
+    bottom: 70
+  }, offset = 0, orientation = Orientation.horizontal, stepPercent = 0.5, ...props}: Props) => {
   const ref = useRef();
 
-  const innerWidth = props.parentWidth - props.margin.left - props.margin.right;
-  const innerHeight = props.parentHeight - props.margin.top - props.margin.bottom;
+  const innerWidth = props.parentWidth - margin.left - margin.right;
+  const innerHeight = props.parentHeight - margin.top - margin.bottom;
 
   /**
    * Sets the link component based on the layout, linkType, and orientation props.
@@ -80,38 +85,38 @@ const TreeGraph = (props: Props) => {
   const LinkComponent = useMemo(() => {
     let value;
 
-    if (props.layout === Layout.polar) {
-      if (props.linkType === LinkType.step) {
+    if (layout === Layout.polar) {
+      if (linkType === LinkType.step) {
         value = LinkRadialStep;
-      } else if (props.linkType === LinkType.curve) {
+      } else if (linkType === LinkType.curve) {
         value = LinkRadialCurve;
-      } else if (props.linkType === LinkType.line) {
+      } else if (linkType === LinkType.line) {
         value = LinkRadialLine;
       } else {
         value = LinkRadial;
       }
-    } else if (props.orientation === Orientation.vertical) {
-      if (props.linkType === LinkType.step) {
+    } else if (orientation === Orientation.vertical) {
+      if (linkType === LinkType.step) {
         value = LinkVerticalStep;
-      } else if (props.linkType === LinkType.curve) {
+      } else if (linkType === LinkType.curve) {
         value = LinkVerticalCurve;
-      } else if (props.linkType === LinkType.line) {
+      } else if (linkType === LinkType.line) {
         value = LinkVerticalLine;
       } else {
         value = LinkVertical;
       }
-    } else if (props.linkType === LinkType.step) {
+    } else if (linkType === LinkType.step) {
       value = LinkHorizontalStep;
-    } else if (props.linkType === LinkType.curve) {
+    } else if (linkType === LinkType.curve) {
       value = LinkHorizontalCurve;
-    } else if (props.linkType === LinkType.line) {
+    } else if (linkType === LinkType.line) {
       value = LinkHorizontalLine;
     } else {
       value = LinkHorizontal;
     }
 
     return value;
-  }, [props.layout, props.linkType, props.orientation]);
+  }, [layout, linkType, orientation]);
 
   /**
    * Returns the depth of the last expanded node.
@@ -137,11 +142,11 @@ const TreeGraph = (props: Props) => {
     let top;
     let left;
 
-    if (props.layout === Layout.polar) {
+    if (layout === Layout.polar) {
       const [radialX, radialY] = pointRadial(x, y);
       top = radialY;
       left = radialX;
-    } else if (props.orientation === Orientation.vertical) {
+    } else if (orientation === Orientation.vertical) {
       top = y;
       left = x;
     } else {
@@ -153,7 +158,7 @@ const TreeGraph = (props: Props) => {
       top,
       left
     };
-  }, [props.layout, props.orientation]);
+  }, [layout, orientation]);
 
   /**
    * Returns the position and size of the root node.
@@ -167,7 +172,7 @@ const TreeGraph = (props: Props) => {
 
     const depth = getMaxDepth(props.data, 1);
 
-    if (props.layout === Layout.polar) {
+    if (layout === Layout.polar) {
       origin = {
         x: innerWidth / 2,
         y: innerHeight / 2
@@ -176,7 +181,7 @@ const TreeGraph = (props: Props) => {
       sizeHeight = (Math.min(innerWidth, innerHeight) / 2) * (depth / 2);
     } else {
       origin = { x: 0, y: 0 };
-      if (props.orientation === Orientation.vertical) {
+      if (orientation === Orientation.vertical) {
         sizeWidth = innerWidth;
         sizeHeight = innerHeight;
       } else {
@@ -190,7 +195,7 @@ const TreeGraph = (props: Props) => {
       sizeHeight,
       origin
     };
-  }, [getMaxDepth, innerHeight, innerWidth, props.data, props.layout, props.orientation]);
+  }, [getMaxDepth, innerHeight, innerWidth, props.data, layout, orientation]);
 
   const renderNode = useCallback((node) => (
     <foreignObject>
@@ -217,7 +222,7 @@ const TreeGraph = (props: Props) => {
         { renderNode(node) }
       </Group>
     );
-  }, [renderNode, props.layout, props.orientation, props.linkType]);
+  }, [renderNode, layout, orientation, linkType]);
 
   /**
    * Resizes the "circle" and "rect" elements based on the text contained in the group. This effect will also
@@ -247,7 +252,7 @@ const TreeGraph = (props: Props) => {
         }
       });
     }
-  }, [props.data, props.layout, props.orientation, props.linkType]);
+  }, [props.data, layout, orientation, linkType]);
 
   return (
     <div
@@ -259,13 +264,13 @@ const TreeGraph = (props: Props) => {
     >
       <svg
         width={props.parentWidth}
-        height={props.parentHeight - props.offset}
+        height={props.parentHeight - offset}
         ref={props.zoom.containerRef}
       >
         { props.renderZoomContainer() }
         <Group
-          top={props.margin.top}
-          left={props.margin.left}
+          top={margin.top}
+          left={margin.left}
           transform={props.zoom.toString()}
         >
           <Tree
@@ -283,9 +288,9 @@ const TreeGraph = (props: Props) => {
                   <LinkComponent
                     key={i}
                     data={link}
-                    percent={props.stepPercent}
-                    stroke={props.linkColor}
-                    strokeWidth={props.linkWidth}
+                    percent={stepPercent}
+                    stroke={linkColor}
+                    strokeWidth={linkWidth}
                     fill='none'
                   />
                 ))}
@@ -297,22 +302,6 @@ const TreeGraph = (props: Props) => {
       </svg>
     </div>
   );
-};
-
-TreeGraph.defaultProps = {
-  layout: Layout.cartesian,
-  linkColor: '#B2B09B',
-  linkType: LinkType.line,
-  linkWidth: 1,
-  margin: {
-    top: 30,
-    left: 30,
-    right: 30,
-    bottom: 70
-  },
-  offset: 0,
-  orientation: Orientation.horizontal,
-  stepPercent: 0.5
 };
 
 const TreeGraphComponent: ComponentType<any> = withParentSize(withZoom(TreeGraph));


### PR DESCRIPTION
# Summary

Using `defaultProps` on a functional component results in a browser console warning that is actually categorized as an error: `Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.`. The error was getting in the way of actually useful `console.log` statements so I asked Claude Sonnet to clone the repo and replace `defaultProps` across the codebase. I'm leaving this as a draft until it gets more scrutiny.