### PR TITLE
Add `toArcs` function to `geospatial`

### DIFF
--- a/packages/geospatial/src/utils/Map.js
+++ b/packages/geospatial/src/utils/Map.js
@@ -4,9 +4,15 @@ import { WarpedMapLayer } from '@allmaps/maplibre';
 import {
   bbox,
   bboxPolygon,
+  bearing,
+  bezierSpline,
   buffer,
+  destination,
+  distance,
   feature,
-  featureCollection
+  featureCollection,
+  lineString,
+  midpoint
 } from '@turf/turf';
 import _ from 'underscore';
 import circle from '@turf/circle';
@@ -202,11 +208,49 @@ const validateCoordinates = (coordinates) => {
   return valid;
 };
 
+/**
+ * Returns a GeoJSON FeatureCollection of LineStrings (arcs) for the passed coordinates.
+ *
+ * @param coordinates
+ * @param options
+ *
+ * @returns {FeatureCollection<LineString, GeoJsonProperties>}
+ */
+const toArcs = (coordinates, options = {}) => {
+  const { curvature = 0.2 } = options;
+  const features = [];
+
+  for (let i = 0; i < coordinates.length - 1; i += 1) {
+    const start = coordinates[i];
+    const end = coordinates[i + 1];
+
+    const d = distance(start, end);
+    const m = midpoint(start, end);
+    const b = bearing(start, end);
+
+    const offsetBearing = b + 90 > 180 ? b + 90 - 360 : b + 90;
+    const dest = destination(m, d * curvature, offsetBearing);
+
+    const line = lineString([start, dest.geometry.coordinates, end]);
+    const arc = bezierSpline(line);
+
+    arc.properties = {
+      ...arc.properties,
+      index: i
+    };
+
+    features.push(arc);
+  }
+
+  return featureCollection(features);
+};
+
 export default {
   addGeoreferenceLayer,
   toCertaintyCircle,
   getBoundingBox,
   removeLayer,
+  toArcs,
   toFeature,
   toFeatureCollection,
   validateBoundingBox,

--- a/packages/geospatial/src/utils/Map.js
+++ b/packages/geospatial/src/utils/Map.js
@@ -7,6 +7,7 @@ import {
   bearing,
   bezierSpline,
   buffer,
+  centroid,
   destination,
   distance,
   feature,
@@ -211,14 +212,17 @@ const validateCoordinates = (coordinates) => {
 /**
  * Returns a GeoJSON FeatureCollection of LineStrings (arcs) for the passed coordinates.
  *
- * @param coordinates
+ * @param features
  * @param options
  *
  * @returns {FeatureCollection<LineString, GeoJsonProperties>}
  */
-const toArcs = (coordinates, options = {}) => {
-  const { curvature = 0.2 } = options;
-  const features = [];
+const toArcs = (features, options = {}) => {
+  const { curvature = -0.2 } = options;
+
+  const coordinates = features.map(feature => centroid(feature).geometry.coordinates);
+
+  const arcFeatures = [];
 
   for (let i = 0; i < coordinates.length - 1; i += 1) {
     const start = coordinates[i];
@@ -239,10 +243,10 @@ const toArcs = (coordinates, options = {}) => {
       index: i
     };
 
-    features.push(arc);
+    arcFeatures.push(arc);
   }
 
-  return featureCollection(features);
+  return featureCollection(arcFeatures);
 };
 
 export default {

--- a/packages/geospatial/src/utils/MapStyles.js
+++ b/packages/geospatial/src/utils/MapStyles.js
@@ -13,10 +13,7 @@ const point = {
     'circle-stroke-width': 1,
     'circle-color': [
       'case',
-      ['any',
-        ['boolean', ['feature-state', 'hover'], false],
-        ['boolean', ['feature-state', 'selected'], false]
-      ],
+      ['boolean', ['feature-state', 'hover'], false],
       '#3b62ff',
       '#ff623b'
     ],

--- a/packages/geospatial/src/utils/MapStyles.js
+++ b/packages/geospatial/src/utils/MapStyles.js
@@ -13,7 +13,10 @@ const point = {
     'circle-stroke-width': 1,
     'circle-color': [
       'case',
-      ['boolean', ['feature-state', 'hover'], false],
+      ['any',
+        ['boolean', ['feature-state', 'hover'], false],
+        ['boolean', ['feature-state', 'selected'], false]
+      ],
       '#3b62ff',
       '#ff623b'
     ],


### PR DESCRIPTION
# Summary

This PR adds a new `toArcs` function that accepts an array of features and returns a `FeatureCollection` of curved paths between them.

## Screenshot

(the dotted path styling here is handled on the frontend)

<img width="639" height="473" alt="Screenshot 2026-06-16 at 3 15 19 PM" src="https://github.com/user-attachments/assets/b6ccd3a7-c0c4-4f2f-b6cf-7212044288f8" />
