### PR TITLE
Add `OverlayLayer` component to `core-data` exports

### DIFF
--- a/packages/core-data/src/components/OverlayLayer.js
+++ b/packages/core-data/src/components/OverlayLayer.js
@@ -1,0 +1,56 @@
+// @flow
+
+import React from 'react';
+import { MapStyles, WarpedImageLayerPeripleo as WarpedImageLayer } from '@performant-software/geospatial';
+import { GeoJSONLayer, RasterLayer } from '@peripleo/maplibre';
+import type { Layer } from '../types/RuntimeConfig.js';
+
+type OverlayLayerProps = {
+  /**
+   * The overlay layer to render.
+   */
+  overlay: Layer
+};
+
+/**
+ * This component renders a GeoJSONLayer or RasterLayer component depending on the `layer_type` of the passed `overlay`.
+ */
+const OverlayLayer = (props: OverlayLayerProps) => {
+  const { overlay } = props;
+
+  if (overlay.layer_type === 'geojson') {
+    return (
+      <GeoJSONLayer
+        id={overlay.name}
+        data={overlay.content || overlay.url}
+        fillStyle={MapStyles.fill}
+        pointStyle={MapStyles.point}
+        strokeStyle={MapStyles.stroke}
+      />
+    );
+  }
+
+  if (overlay.layer_type === 'raster') {
+    return (
+      <RasterLayer
+        id={overlay.name}
+        url={overlay.url}
+      />
+    );
+  }
+
+  if (overlay.layer_type === 'georeference') {
+    return (
+      <WarpedImageLayer
+        id={overlay.name}
+        manifest={overlay.content}
+        opacity={overlay.opacity}
+        url={overlay.url}
+      />
+    );
+  }
+
+  return null;
+};
+
+export default OverlayLayer;

--- a/packages/core-data/src/components/OverlayLayers.js
+++ b/packages/core-data/src/components/OverlayLayers.js
@@ -1,9 +1,8 @@
 // @flow
 
-import { MapStyles, WarpedImageLayerPeripleo as WarpedImageLayer } from '@performant-software/geospatial';
-import { GeoJSONLayer, RasterLayer } from '@peripleo/maplibre';
 import React from 'react';
 import _ from 'underscore';
+import OverlayLayer from './OverlayLayer';
 
 type Layer = {
   /**
@@ -30,54 +29,6 @@ type Layer = {
    * (Optional) URL that contains the layer. This can be a URL to GeoJSON data or a Raster tile set.
    */
   url?: string
-};
-
-type OverlayLayerProps = {
-  /**
-   * The overlay layer to render.
-   */
-  overlay: Layer
-};
-
-/**
- * This component renders a GeoJSONLayer or RasterLayer component depending on the `layer_type` of the passed `overlay`.
- */
-const OverlayLayer = (props: OverlayLayerProps) => {
-  const { overlay } = props;
-
-  if (overlay.layer_type === 'geojson') {
-    return (
-      <GeoJSONLayer
-        id={overlay.name}
-        data={overlay.content || overlay.url}
-        fillStyle={MapStyles.fill}
-        pointStyle={MapStyles.point}
-        strokeStyle={MapStyles.stroke}
-      />
-    );
-  }
-
-  if (overlay.layer_type === 'raster') {
-    return (
-      <RasterLayer
-        id={overlay.name}
-        url={overlay.url}
-      />
-    );
-  }
-
-  if (overlay.layer_type === 'georeference') {
-    return (
-      <WarpedImageLayer
-        id={overlay.name}
-        manifest={overlay.content}
-        opacity={overlay.opacity}
-        url={overlay.url}
-      />
-    );
-  }
-
-  return null;
 };
 
 type Props = {

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -16,6 +16,7 @@ export { default as HitsPerPage } from './components/HitsPerPage';
 export { default as LayerMenu } from './components/LayerMenu';
 export { default as MediaGallery } from './components/MediaGallery';
 export { default as Notification } from './components/Notification';
+export { default as OverlayLayer } from './components/OverlayLayer';
 export { default as OverlayLayers } from './components/OverlayLayers';
 export { default as PersistentSearchStateContextProvider } from './components/PersistentSearchStateContextProvider';
 export { default as PlaceLayersSelector } from './components/PlaceLayersSelector';


### PR DESCRIPTION
# Summary

Currently, the `core-data` package only exports `OverlayLayers`, which wraps around `OverlayLayer` to handle multiple layers. This PR pulls `OverlayLayer` into its own file and gives it an export so consuming applications can use it on its own when they only need to render one layer.