### PR TITLE
Bounding box prop for LocationMarkers

### DIFF
--- a/packages/geospatial/src/components/LocationMarkers.js
+++ b/packages/geospatial/src/components/LocationMarkers.js
@@ -13,6 +13,12 @@ type Props = {
   animate?: boolean,
 
   /**
+   * (Optional) bounding box to fit the map to.
+   * If not provided, the bounding box will be calculated from the data.
+   */
+  boundingBox?: any,
+
+  /**
    * (Optional) data to pass to the fitToBounds function.
    */
   boundingBoxData?: any,
@@ -114,13 +120,21 @@ const LocationMarkers = (props: Props) => {
    */
   useEffect(() => {
     if (map && data && props.fitBoundingBox) {
-      const bbox = MapUtils.getBoundingBox(data, props.buffer);
+      const bbox = props.boundingBox ?? MapUtils.getBoundingBox(data, props.buffer);
 
       if (bbox) {
         map.fitBounds(bbox, props.boundingBoxOptions, props.boundingBoxData);
       }
     }
-  }, [map, props.buffer, props.data, props.boundingBoxData, props.boundingBoxOptions, props.fitBoundingBox]);
+  }, [
+    map,
+    props.buffer,
+    props.data,
+    props.boundingBox,
+    props.boundingBoxData,
+    props.boundingBoxOptions,
+    props.fitBoundingBox
+  ]);
 
   if (!data) {
     return null;


### PR DESCRIPTION
# Summary

This PR adds a new `boundingBox` prop to `LocationMarkers`. If provided, the map will be zoomed into the specified bounding box. If this prop is undefined, the map defaults to its original behavior of calculating a bounding box covering all map geometry.

Note for reviewing: I recommend looking at https://github.com/performant-software/core-data-places/pull/696 for how it's used in a consuming application.