### PR TITLE
Allow functional resolvers for icon/color in DataTable

### DIFF
--- a/packages/semantic-ui/src/components/DataTable.js
+++ b/packages/semantic-ui/src/components/DataTable.js
@@ -317,8 +317,8 @@ class DataTable extends Component<Props, State> {
         {...asProps(item)}
         basic
         compact
-        color={action.color}
-        icon={action.icon}
+        color={action.resolveColor ? action.resolveColor(item) : action.color}
+        icon={action.resolveIcon ? action.resolveIcon(item) : action.icon}
         key={`${action.name}-${index}`}
         onClick={action.onClick && action.onClick.bind(this, item, index)}
         title={action.title}

--- a/packages/semantic-ui/src/components/List.js
+++ b/packages/semantic-ui/src/components/List.js
@@ -31,6 +31,8 @@ type Action = {
     title: string
   },
   render?: (item: any, index: number) => Element<any>,
+  resolveColor?: (item: any) => ?string,
+  resolveIcon?: (item: any) => ?string,
   title?: string
 };
 


### PR DESCRIPTION
### In this PR

Per performant-software/archnet3#1738
- Allow `DataTable` to receive `resolveColor` and `resolveIcon` for dynamic colors and icons (such as ones that change based on state).
   - Lists and card actions already had this ability, but the data table could only receive static color and icon