### PR TITLE
Show correct date accuracy (archnet #1743)

### DIFF
--- a/packages/semantic-ui/src/components/FilterLabels.js
+++ b/packages/semantic-ui/src/components/FilterLabels.js
@@ -3,8 +3,9 @@
 import React, { useCallback } from 'react';
 import { Button, Label } from 'semantic-ui-react';
 import _ from 'underscore';
-import { Date as DateUtils } from '@performant-software/shared-components';
+import { Browser, Calendar } from '@performant-software/shared-components';
 import i18n from '../i18n/i18n';
+import { ACCURACY_YEAR } from './FuzzyDate';
 import { FilterOperatorOptions, type Filter } from './ListFilters';
 import './FilterLabels.css';
 
@@ -45,11 +46,19 @@ const FilterLabels = (props: Props) => {
       // format booleans as capitalized strings
       displayValue = filter.value ? 'True' : 'False';
     } else if (filter.type === 'date' && typeof filter.value === 'object' && filter.value !== null) {
-      // format FuzzyDate objects
-      const { startDate, endDate, range } = filter.value;
-      const formattedStart = startDate ? DateUtils.formatDate(startDate) : '';
+      // format FuzzyDate objects to selected accuracy
+      const { accuracy = ACCURACY_YEAR, startDate, endDate, range } = filter.value;
+
+      const calendar = new Calendar(
+        Browser.isBrowser() && navigator.language,
+        Calendar.Calendars.gregorian
+      );
+
+      const formatDate = (value) => calendar.format(value, accuracy);
+      const formattedStart = startDate ? formatDate(startDate) : '';
+
       if (range && endDate) {
-        displayValue = `${formattedStart} - ${DateUtils.formatDate(endDate)}`;
+        displayValue = `${formattedStart} - ${formatDate(endDate)}`;
       } else {
         displayValue = formattedStart;
       }

--- a/packages/semantic-ui/src/components/FuzzyDate.js
+++ b/packages/semantic-ui/src/components/FuzzyDate.js
@@ -589,3 +589,9 @@ FuzzyDate.defaultProps = {
 };
 
 export default FuzzyDate;
+
+export {
+  ACCURACY_DATE,
+  ACCURACY_MONTH,
+  ACCURACY_YEAR
+};


### PR DESCRIPTION
### In this PR

Per performant-software/archnet3#1743:
- Amend date conversion in "active filter" pills to show the correct accuracy / range for a fuzzy date
