### PR TITLE
i18n: turn off i18next debug logging

### DIFF
--- a/packages/core-data/src/i18n/i18n.js
+++ b/packages/core-data/src/i18n/i18n.js
@@ -14,7 +14,7 @@ const i18n = i18next.createInstance();
 
 i18n
   .init({
-    debug: true,
+    debug: false,
     fallbackLng: 'en',
     lng: 'en',
     interpolation: {

--- a/packages/shared/src/i18n/i18n.js
+++ b/packages/shared/src/i18n/i18n.js
@@ -12,7 +12,7 @@ const i18n = createInstance();
 
 i18n
   .init({
-    debug: true,
+    debug: false,
     fallbackLng: 'en',
     lng: 'en',
     interpolation: {

--- a/packages/storybook/src/i18n/i18n.js
+++ b/packages/storybook/src/i18n/i18n.js
@@ -12,7 +12,7 @@ const i18n = createInstance();
 
 i18n
   .init({
-    debug: true,
+    debug: false,
     fallbackLng: 'en',
     lng: 'en',
     interpolation: {

--- a/packages/visualize/src/i18n/i18n.js
+++ b/packages/visualize/src/i18n/i18n.js
@@ -12,7 +12,7 @@ const i18n = createInstance();
 
 i18n
   .init({
-    debug: true,
+    debug: false,
     fallbackLng: 'en',
     lng: 'en',
     interpolation: {


### PR DESCRIPTION
The four i18next instances in this repo initialize with `debug: true`, so every application that uses these packages prints i18next's full configuration object and language-change notices at startup — dozens of lines per instance, multiplied across packages. Noticed while cleaning up the FairData Sites local dev output, where these dumps are the largest single source of noise.

Debug now defaults to false in all four packages. Anyone debugging i18n in this repo can flip it locally.