### PR TITLE
Add `sideEffects` to `package.json` in `/shared`

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,6 +17,9 @@
     },
     "./style.css": "./dist/style.css"
   },
+  "sideEffects": [
+    "**/*.css"
+  ],
   "scripts": {
     "build": "vite build && flow-copy-source -v src types"
   },


### PR DESCRIPTION
### In this PR
Addresses Issue #595 by adding an explicit list of `sideEffects` to the `shared-components` package to allow more aggressive tree-shaking by consuming applications. This avoids the issue of bundling a component built on `react-ga4` (from the `Analytics` component of the package` that includes a gtag injector. Adding the `sideEffects` field in `package.json` allows the `Analytics` component to be shaken out of the bundle if unused.

### Notes and questions
- This has been tested locally with `npm link`; I built the `shared-components` bundle and then imported it into FDS and ran `netlify build`, and verified that a) the gtag script is not included in the output and b) the imports from the `shared-components` module still function in the built site (e.g. the fuzzy date utils, which seems to be the main thing FDS uses from this package).
- More testing should be done re: the behavior of the CSS, to make sure that it is in fact not getting shaken out of the bundle when it shouldn't be;
- Obviously this solution introduces a development constraint with this package going forward in terms of making sure that no new side effects are introduced in future updates (or are properly documented and added to the list when they are); this seems worth it to me, since I think especially with `shared-components` it's not uncommon for it to be imported into the site just to use the date utils or whatever and we don't want to introduce bloat into the built site, but still something to be aware of.
- Do we think this should also be implemented for other packages? The GA4 stuff seems to be the biggest offender in terms of bundling unnecessary code, but I could imagine we might want to add this to the other packages as well (with the same caveat as above about being very careful about future changes not breaking anything).
